### PR TITLE
chore: bump `@types/node` to match volta major version

### DIFF
--- a/examples/components/vite/package.json
+++ b/examples/components/vite/package.json
@@ -18,7 +18,7 @@
     "@esri/calcite-components": "3.3.3"
   },
   "devDependencies": {
-    "@types/node": "^22.1.0",
+    "@types/node": "24.10.0",
     "typescript": "^5.5.4",
     "vite": "^5.3.5",
     "vite-plugin-static-copy": "^1.0.6"

--- a/examples/components/vue/package.json
+++ b/examples/components/vue/package.json
@@ -20,7 +20,7 @@
     "vue": "^3.4.36"
   },
   "devDependencies": {
-    "@types/node": "^22.1.0",
+    "@types/node": "24.10.0",
     "@vitejs/plugin-vue": "^5.1.2",
     "ncp": "^2.0.0",
     "typescript": "^4.5.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "@types/estree": "1.0.8",
         "@types/github-script": "github:actions/github-script",
         "@types/jest-axe": "3.5.9",
-        "@types/node": "^20.12.7",
+        "@types/node": "24.10.0",
         "@types/react": "18.3.12",
         "@types/react-dom": "18.3.1",
         "@types/semver": "7.7.1",
@@ -6572,23 +6572,6 @@
         "node": ">=24"
       }
     },
-    "node_modules/@types/github-script/node_modules/@types/node": {
-      "version": "24.8.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.8.1.tgz",
-      "integrity": "sha512-alv65KGRadQVfVcG69MuB4IzdYVpRwMG/mq8KWOaoOdyY617P5ivaDiMCGOFDWD2sAn5Q0mR3mRtUOgm99hL9Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~7.14.0"
-      }
-    },
-    "node_modules/@types/github-script/node_modules/undici-types": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.14.0.tgz",
-      "integrity": "sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -6707,13 +6690,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.22",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.22.tgz",
-      "integrity": "sha512-hRnu+5qggKDSyWHlnmThnUqg62l29Aj/6vcYgUaSFL9oc7DVjeWEQN3PRgdSc6F8d9QRMWkf36CLMch1Do/+RQ==",
+      "version": "24.10.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.0.tgz",
+      "integrity": "sha512-qzQZRBqkFsYyaSWXuEHc2WR9c0a0CXwiE5FWUvn7ZM+vdy1uZLfCunD38UzhuB7YN/J11ndbDBcTmOdxJo9Q7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -15318,6 +15301,23 @@
       "engines": {
         "node": ">=20.0.0"
       }
+    },
+    "node_modules/happy-dom/node_modules/@types/node": {
+      "version": "20.19.24",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.24.tgz",
+      "integrity": "sha512-FE5u0ezmi6y9OZEzlJfg37mqqf6ZDSF2V/NLjUyGrR9uTZ7Sb9F7bLNZ03S4XVUNRWGA7Ck4c1kK+YnuWjl+DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/hard-rejection": {
       "version": "2.1.0",
@@ -30886,9 +30886,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@types/estree": "1.0.8",
     "@types/github-script": "github:actions/github-script",
     "@types/jest-axe": "3.5.9",
-    "@types/node": "^20.12.7",
+    "@types/node": "24.10.0",
     "@types/react": "18.3.12",
     "@types/react-dom": "18.3.1",
     "@types/semver": "7.7.1",


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Bumps types version missed in https://github.com/Esri/calcite-design-system/pull/13281.

**Note**: 24.11.0 (exact Volta version) is [not available yet](https://www.npmjs.com/package/@types/node?activeTab=versions)