### PR TITLE
refactor!: drop deprecated component custom CSS props

### DIFF
--- a/packages/components/src/components/accordion-item/accordion-item.scss
+++ b/packages/components/src/components/accordion-item/accordion-item.scss
@@ -21,7 +21,6 @@
  * @prop --calcite-accordion-item-start-icon-color: Specifies the component's `iconStart` color. Falls back to `--calcite-accordion-item-icon-color` or current color.
  * @prop --calcite-accordion-item-text-color: [Deprecated] Use `--calcite-accordion-text-color`. Specifies the component's text color.
  * @prop --calcite-accordion-item-text-color-hover: [Deprecated] Use `--calcite-accordion-text-color-hover`. Specifies the component's text color on hover.
- * @prop --calcite-accordion-item-text-color-press: [Deprecated] Use `--calcite-accordion-text-color-press`. Specifies the component's text color on press.
  */
 
 // AUTO-GENERATED — do not modify. Changes will be overwritten.

--- a/packages/components/src/components/action-group/action-group.scss
+++ b/packages/components/src/components/action-group/action-group.scss
@@ -7,8 +7,6 @@
  * @prop --calcite-action-group-border-color: Specifies the component's border color when used in a `calcite-action-bar` or `calcite-action-menu`.
  * @prop --calcite-action-group-columns: When `layout` is `"grid"`, specifies the component's grid-template-columns.
  * @prop --calcite-action-group-gap: When `layout` is `"grid"`, specifies the component's gap.
- * @prop --calcite-action-group-padding: [Deprecated] Use `--calcite-action-group-gap`. Specifies the component's padding.
- *
  */
 
 // AUTO-GENERATED — do not modify. Changes will be overwritten.

--- a/packages/components/src/components/button/button.scss
+++ b/packages/components/src/components/button/button.scss
@@ -8,7 +8,6 @@
  * @prop --calcite-button-corner-radius: Specifies the component's corner radius.
  * @prop --calcite-button-icon-color: Specifies the component's `iconStart` and `iconEnd` color.
  * @prop --calcite-button-loader-color: Specifies the component's loader color.
- * @prop --calcite-button-shadow-color: [Deprecated] Use `--calcite-button-shadow`. Specifies the component's box-shadow color.
  * @prop --calcite-button-text-color: Specifies the component's text color.
  * @prop --calcite-button-shadow: Specifies the component's shadow.
  */

--- a/packages/components/src/components/card/card.scss
+++ b/packages/components/src/components/card/card.scss
@@ -7,16 +7,13 @@
  * @prop --calcite-card-background-color: Specifies the component's background color.
  * @prop --calcite-card-border-color: Specifies the component's border color.
  * @prop --calcite-card-corner-radius: Specifies the component's corner radius.
- * @prop --calcite-card-selection-background-color-active: [Deprecated] Use `--calcite-card-selection-background-color-press`. Specifies the component's selection element background color when active.
  * @prop --calcite-card-selection-background-color-hover: Specifies the component's selection element background color when hovered.
  * @prop --calcite-card-selection-background-color-press: Specifies the component's selection element background color when active.
- * @prop --calcite-card-selection-background-color-selected: [Deprecated] Use `--calcite-card-background-color`. Specifies the component's selection element icon color when `selected`.
  * @prop --calcite-card-selection-background-color: [Deprecated] Use `--calcite-card-background-color`. Specifies the component's selection element background color.
  * @prop --calcite-card-selection-color-hover: Specifies the component's selection element color when hovered or focused.
  * @prop --calcite-card-selection-color: Specifies the component's selection element color.
  * @prop --calcite-card-selection-icon-color-hover: [Deprecated] Use `--calcite-card-selection-color-hover`. Specifies the component's selection element icon color when hovered.
  * @prop --calcite-card-selection-icon-color-selected: [Deprecated] Use `--calcite-card-accent-color-selected`. Specifies the component's selection element icon color when `selected`.
- * @prop --calcite-card-selection-icon-color: [Deprecated] Use `--calcite-card-selection-color`. Specifies the component's selection element icon color.
  * @prop --calcite-card-shadow: Specifies the component's shadow.
  *
  */

--- a/packages/components/src/components/inline-editable/inline-editable.e2e.ts
+++ b/packages/components/src/components/inline-editable/inline-editable.e2e.ts
@@ -435,20 +435,6 @@ describe("calcite-inline-editable", () => {
           shadowSelector: `.${CSS.confirmChangesButton}`,
           targetProp: "--calcite-button-loader-color",
         },
-        "--calcite-inline-editable-button-shadow-color": [
-          {
-            shadowSelector: `.${CSS.enableEditingButton}`,
-            targetProp: "--calcite-button-shadow-color",
-          },
-          {
-            shadowSelector: `.${CSS.cancelEditingButton}`,
-            targetProp: "--calcite-button-shadow-color",
-          },
-          {
-            shadowSelector: `.${CSS.confirmChangesButton}`,
-            targetProp: "--calcite-button-shadow-color",
-          },
-        ],
         "--calcite-inline-editable-button-text-color": [
           {
             shadowSelector: `.${CSS.enableEditingButton}`,

--- a/packages/components/src/components/inline-editable/inline-editable.scss
+++ b/packages/components/src/components/inline-editable/inline-editable.scss
@@ -8,7 +8,6 @@
  * @prop --calcite-inline-editable-button-background-color: Specifies the button element's background color when appearance="solid" or appearance="outline-fill".
  * @prop --calcite-inline-editable-button-corner-radius: Specifies the button element's corner radius.
  * @prop --calcite-inline-editable-button-loader-color: Specifies the button element's loader color.
- * @prop --calcite-inline-editable-button-shadow-color: Specifies the button element's box-shadow color.
  * @prop --calcite-inline-editable-button-text-color: Specifies the button element's text color.
  */
 
@@ -96,7 +95,6 @@ calcite-button {
   --calcite-button-background-color: var(--calcite-inline-editable-button-background-color);
   --calcite-button-corner-radius: var(--calcite-inline-editable-button-corner-radius);
   --calcite-button-loader-color: var(--calcite-inline-editable-button-loader-color);
-  --calcite-button-shadow-color: var(--calcite-inline-editable-button-shadow-color);
   --calcite-button-text-color: var(--calcite-inline-editable-button-text-color);
 }
 

--- a/packages/components/src/components/input-date-picker/input-date-picker.scss
+++ b/packages/components/src/components/input-date-picker/input-date-picker.scss
@@ -34,7 +34,6 @@
  * @prop --calcite-input-date-picker-corner-radius: Specifies the component's input corner radius.
  * @prop --calcite-input-date-picker-divider-color: Specifies the component's divider color between two inputs when in range mode.
  * @prop --calcite-input-date-picker-icon-color: Specifies the component's in-field input icon color.
- * @prop --calcite-input-date-picker-icon-color-hover: [Deprecated] Specifies the component's in-field input icon color on hover.
  * @prop --calcite-input-date-picker-placeholder-text-color: Specifies the component's input placeholder text color.
  * @prop --calcite-input-date-picker-shadow: Specifies the component's input shadow.
  * @prop --calcite-input-date-picker-text-color: Specifies the component's input text color.

--- a/packages/components/src/components/notice/notice.scss
+++ b/packages/components/src/components/notice/notice.scss
@@ -11,8 +11,6 @@
  * @prop --calcite-notice-title-text-color: Specifies the component's title text color.
  * @prop --calcite-notice-content-text-color: Specifies the component's content text color.
  * @prop --calcite-notice-width: [Deprecated] Specifies the component's width.
- * @prop --calcite-notice-close-text-color-hover: [Deprecated] Use `--calcite-notice-close-icon-color-hover`. Specifies the background color of the component's close button when hovered.
- * @prop --calcite-notice-close-text-color: [Deprecated] Use `--calcite-notice-close-icon-color`. Specifies the text color of the component's close button.
  */
 
 @use "sass:list";

--- a/packages/components/src/components/popover/popover.scss
+++ b/packages/components/src/components/popover/popover.scss
@@ -8,7 +8,6 @@
  * @prop --calcite-popover-corner-radius: Specifies the component's corner radius.
  * @prop --calcite-popover-max-size-x: Specifies the component's maximum width.
  * @prop --calcite-popover-text-color: Specifies the component's text color.
- * @prop --calcite-popover-z-index: [Deprecated] No longer necessary. Specifies the component's z-index value.
  */
 
 @use "../../styles/includes";

--- a/packages/components/src/components/radio-button/radio-button.e2e.ts
+++ b/packages/components/src/components/radio-button/radio-button.e2e.ts
@@ -666,19 +666,5 @@ describe("calcite-radio-button", () => {
         ],
       });
     });
-    describe("deprecated", () => {
-      themed(html`<calcite-radio-button></calcite-radio-button>`, {
-        "--calcite-radio-size": [
-          {
-            targetProp: "blockSize",
-            shadowSelector: `.${CSS.radio}`,
-          },
-          {
-            targetProp: "inlineSize",
-            shadowSelector: `.${CSS.radio}`,
-          },
-        ],
-      });
-    });
   });
 });

--- a/packages/components/src/components/radio-button/radio-button.scss
+++ b/packages/components/src/components/radio-button/radio-button.scss
@@ -7,8 +7,6 @@
  * @prop --calcite-radio-button-border-color: Specifies the component's border color.
  * @prop --calcite-radio-button-corner-radius: Specifies the component's corner radius.
  * @prop --calcite-radio-button-size: Specifies the component's size.
- * @prop --calcite-radio-size: [Deprecated] Use `--calcite-radio-button-size`. Specifies the component's size.
- *
  */
 
 // AUTO-GENERATED — do not modify. Changes will be overwritten.
@@ -73,22 +71,13 @@
 }
 
 :host([scale="s"]) {
-  --calcite-internal-radio-size: var(
-    --calcite-radio-button-size,
-    var(--calcite-radio-size, var(--calcite-size-fixed-md))
-  );
+  --calcite-internal-radio-size: var(--calcite-radio-button-size, var(--calcite-size-fixed-md));
 }
 :host([scale="m"]) {
-  --calcite-internal-radio-size: var(
-    --calcite-radio-button-size,
-    var(--calcite-radio-size, var(--calcite-size-fixed-md-plus))
-  );
+  --calcite-internal-radio-size: var(--calcite-radio-button-size, var(--calcite-size-fixed-md-plus));
 }
 :host([scale="l"]) {
-  --calcite-internal-radio-size: var(
-    --calcite-radio-button-size,
-    var(--calcite-radio-size, var(--calcite-size-fixed-lg))
-  );
+  --calcite-internal-radio-size: var(--calcite-radio-button-size, var(--calcite-size-fixed-lg));
 }
 
 .radio {

--- a/packages/components/src/components/rating/rating.scss
+++ b/packages/components/src/components/rating/rating.scss
@@ -3,7 +3,6 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-rating-spacing-unit: [Deprecated] Use `--calcite-rating-spacing`. Specifies the amount of left and right margin spacing between each item.
  * @prop --calcite-rating-spacing: Specifies the amount of left and right margin spacing between each item.
  * @prop --calcite-rating-color-hover: Specifies the component's item color when hovered.
  * @prop --calcite-rating-color-press: Specifies the component's item color when active.

--- a/packages/components/src/components/tooltip/tooltip.scss
+++ b/packages/components/src/components/tooltip/tooltip.scss
@@ -8,7 +8,6 @@
  * @prop --calcite-tooltip-corner-radius: Specifies the component's corner radius.
  * @prop --calcite-tooltip-max-size-x: Specifies the component's maximum width.
  * @prop --calcite-tooltip-text-color: Specifies the component's text color.
- * @prop --calcite-tooltip-z-index: [Deprecated] No longer necessary. Specifies the z-index value for the component.
  */
 
 @use "../../styles/includes";


### PR DESCRIPTION
**Related Issue:** #13291

## Summary

Removes deprecated custom CSS props that were no longer referenced in styling or that were planned for 5.0 removal. The remaining ones will be removed at v6.

BREAKING CHANGE: removes the following deprecated custom CSS props:

* `--calcite-accordion-item-text-color-press`† – use `--calcite-accordion-text-color-press`
* `--calcite-action-group-padding`† – use `--calcite-action-group-gap`
* `--calcite-button-shadow-color`† – use `--calcite-button-shadow`
* `--calcite-card-selection-background-color-active`† – use `--calcite-card-selection-background-color-press`
* `--calcite-card-selection-background-color-selected`† – use `--calcite-card-background-color`
* `--calcite-card-selection-icon-color`† – use `--calcite-card-selection-color`
* `--calcite-inline-editable-button-shadow-color`‡
* `--calcite-input-date-picker-icon-color-hover`†
* `--calcite-notice-close-text-color-hover`† – use `--calcite-notice-close-icon-color-hover`
* `--calcite-radio-size` – use `--calcite-radio-button-size`
* `--calcite-notice-close-text-color`† – use `--calcite-notice-close-icon-color`
* `--calcite-popover-z-index`§
* `--calcite-tooltip-z-index`§
* `--calcite-rating-spacing-unit`† – use `--calcite-rating-spacing`

† not referenced in styles, so there should be no impact from removal
‡ not deprecated previously, but used to set unreferenced custom prop (see above)
§ no longer needed after #12904

