### PR TITLE
chore: refine demo page setup

### DIFF
--- a/packages/components/index.html
+++ b/packages/components/index.html
@@ -12,7 +12,7 @@
     </style>
   </head>
 
-  <body>
+  <body class="calcite-mode-auto">
     <demo-dom-swapper>
       <!-- use this page for quickly setting up your page for a bug fix/repro cases or feature enhancement -->
     </demo-dom-swapper>

--- a/packages/components/src/demos/_assets/head.ts
+++ b/packages/components/src/demos/_assets/head.ts
@@ -38,13 +38,4 @@
 
   CSS.forEach(loadCss);
   SCRIPTS.forEach(loadScript);
-
-  document.addEventListener("DOMContentLoaded", () => {
-    const darkThemeMq = window.matchMedia("(prefers-color-scheme: dark)");
-    if (darkThemeMq.matches) {
-      document.body.classList.add("calcite-mode-dark");
-    } else {
-      document.body.classList.remove("calcite-mode-dark");
-    }
-  });
 })();

--- a/packages/components/src/demos/_assets/head.ts
+++ b/packages/components/src/demos/_assets/head.ts
@@ -1,8 +1,6 @@
 ((): void => {
   const ASSETS_PATH = "/src/demos/_assets";
   const CSS = [`${ASSETS_PATH}/demos.css`];
-  const urlParams = new URLSearchParams(window.location.search);
-  const DISABLE_HEADER_URL_PARAM = "header-disabled";
 
   interface Script {
     src: string;
@@ -18,32 +16,6 @@
       type: "module",
     },
   ];
-
-  const parseTemplate = (text: string): HTMLTemplateElement | null => {
-    const parser = new DOMParser();
-    const doc = parser.parseFromString(text, "text/html");
-    return doc.head.querySelector("template");
-  };
-
-  const loadHeader = async (): Promise<void> => {
-    const response = await window.fetch(`${ROOT}${ASSETS_PATH}/demo-template.html`);
-    const text = await response.text();
-    const template = parseTemplate(text);
-    if (template) {
-      const firstChild = document.body.firstChild;
-      if (firstChild) {
-        document.body.insertBefore(template.content, firstChild);
-      }
-    }
-  };
-
-  if (window.location.pathname.includes("/src/demos/") && !urlParams.has(DISABLE_HEADER_URL_PARAM)) {
-    if (document.readyState === "loading") {
-      document.addEventListener("DOMContentLoaded", loadHeader);
-    } else {
-      loadHeader();
-    }
-  }
 
   const ROOT = "";
 
@@ -66,4 +38,13 @@
 
   CSS.forEach(loadCss);
   SCRIPTS.forEach(loadScript);
+
+  document.addEventListener("DOMContentLoaded", () => {
+    const darkThemeMq = window.matchMedia("(prefers-color-scheme: dark)");
+    if (darkThemeMq.matches) {
+      document.body.classList.add("calcite-mode-dark");
+    } else {
+      document.body.classList.remove("calcite-mode-dark");
+    }
+  });
 })();


### PR DESCRIPTION
**Related Issue:** #13269 

## Summary

This follow-up PR adds `prefers-color-scheme` support to the demo index.html file and cleans up some unused code that was loading the demo header, which we're no longer using.