### PR TITLE
chore: fix call to `gh-pages` package to deploy preview storybook

### DIFF
--- a/.github/scripts/publishPrerelease.sh
+++ b/.github/scripts/publishPrerelease.sh
@@ -40,7 +40,7 @@ elif [ "$BRANCH" = "dev" ]; then
 
       # try deploying storybook, but still release next if it fails with "|| true"
       { npm run --workspace=@esri/calcite-components build-storybook &&
-          npm run --workspace=@esri/calcite-components gh-pages --dist docs --branch gh-pages --message "chore: deploy storybook" --no-history;
+          npx --workspace=@esri/calcite-components gh-pages --dist docs --branch gh-pages --message "chore: deploy storybook" --no-history;
       } || true
 
       # remove the built docs after storybook deploys to gh-pages


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Corrects the `gh-pages` call from https://github.com/Esri/calcite-design-system/pull/13144, which was mistakenly invoked as a script. It’s now properly executed as a package via `npx`.