### PR TITLE
ci(actions): remove syncing of `5 - verified` and replace with `Adding to Kit` only for design issues

### DIFF
--- a/.github/scripts/monday/updateLabels.js
+++ b/.github/scripts/monday/updateLabels.js
@@ -1,12 +1,6 @@
 // @ts-check
 const Monday = require("../support/monday");
-const {
-  labels: {
-    issueWorkflow,
-    issueType: { design },
-  },
-} = require("../support/resources");
-const { assertRequired, includesLabel } = require("../support/utils");
+const { assertRequired } = require("../support/utils");
 
 /** @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments */
 module.exports = async ({ context, core }) => {
@@ -14,22 +8,13 @@ module.exports = async ({ context, core }) => {
     /** @type {import('@octokit/webhooks-types').IssuesLabeledEvent} */ (
       context.payload
     );
-  const [labelName] = assertRequired([label?.name], core, "No label found in payload.");
+  const [labelName] = assertRequired(
+    [label?.name],
+    core,
+    "No label found in payload.",
+  );
 
   const monday = Monday(issue, core);
-
-  const isVerified = labelName === issueWorkflow.verified;
-  if (
-    isVerified &&
-    issue.state === "closed" &&
-    !includesLabel(issue.labels, design)
-  ) {
-    monday.setColumnValue(monday.mondayColumns.status, "Done", {
-      title: "Issue Verified and Closed",
-    });
-  } else {
-    monday.addLabel(labelName);
-  }
-
+  monday.addLabel(labelName);
   await monday.commit();
 };

--- a/.github/scripts/support/monday.js
+++ b/.github/scripts/support/monday.js
@@ -159,13 +159,6 @@ module.exports = function Monday(issue, core) {
       },
     ],
     [
-      issueWorkflow.verified,
-      {
-        column: mondayColumns.status,
-        value: "Verified",
-      },
-    ],
-    [
       issueType.design,
       {
         column: mondayColumns.designIssue,
@@ -906,17 +899,22 @@ module.exports = function Monday(issue, core) {
   function handleState(action = "open") {
     const CLOSED = "Closed";
     const DONE = "Done";
+    const ADDING_TO_KIT = "Adding to Kit";
     const logParams = { title: "Handle State" };
+
     if (!issue.state) {
       core.warning("No Issue state provided.", logParams);
       return;
     }
+
     setColumnValue(mondayColumns.open, stateMap[issue.state], logParams);
 
     if (action === "closed") {
       if (issue.state_reason !== "completed") {
         setColumnValue(mondayColumns.status, CLOSED, logParams);
-      } else if (!includesLabel(issue.labels, issueType.design)) {
+      } else if (includesLabel(issue.labels, issueType.design)) {
+        setColumnValue(mondayColumns.status, ADDING_TO_KIT, logParams);
+      } else {
         setColumnValue(mondayColumns.status, DONE, logParams);
       }
     }


### PR DESCRIPTION
**Related Issue:** #13236

## Summary
Stops all syncing of the `5 - verified` label as it is not needed in Monday and causes more edge-cases. To satisfy the designers' requirements, closing `design` issues now sets the Monday status to `Adding to Kit`.

This change cleans up label/state logic and removes a manual step for Designers.
