### PR TITLE
feat(card): update heading and description spacing

### DIFF
--- a/packages/components/src/components/card/card.scss
+++ b/packages/components/src/components/card/card.scss
@@ -117,13 +117,15 @@
     text-n1-wrap
     m-0
     font-medium;
+  line-height: var(--calcite-font-line-height-relative-snug);
 }
 
 @include includes.slotted("description", "*") {
   @apply text-color-2
     text-n2-wrap
-    m-0 mt-0.5
+    m-0
     font-normal;
+  line-height: var(--calcite-font-line-height-relative-snug);
 }
 
 @include includes.slotted("thumbnail", "img") {


### PR DESCRIPTION
**Related Issue:** [#12304](https://github.com/Esri/calcite-design-system/issues/12304)

## Summary

Remove `margin-top` from `description` slot.
Update `heading` and `description` line heights to `--calcite-font-line-height-relative-snug`.
