### PR TITLE
chore(linting): disable `jsdoc/require-param` in favor of types

### DIFF
--- a/packages/eslint-config/core.js
+++ b/packages/eslint-config/core.js
@@ -54,6 +54,7 @@ export default tseslint.config(
 
       "jsdoc/check-param-names": "off",
       "jsdoc/require-jsdoc": "off",
+      "jsdoc/require-param": "off",
       "jsdoc/require-param-description": "off",
       "jsdoc/require-param-type": "off",
       "jsdoc/require-property-type": "off",


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Disables `jsdoc/require-param`, which creates churn without providing additional value since we rely on TypeScript types. Methinks this should have been removed in https://github.com/Esri/calcite-design-system/pull/11165. 🤔