### PR TITLE
fix(dialog, input-date-picker, popover, sheet): skip restoring focus when closing a focus-trap with no previously focused related element

### DIFF
--- a/packages/components/src/controllers/useFocusTrap.browser.e2e.tsx
+++ b/packages/components/src/controllers/useFocusTrap.browser.e2e.tsx
@@ -1,0 +1,51 @@
+import { JsxNode, LitElement, property } from "@arcgis/lumina";
+import { describe, expect, it } from "vitest";
+import { mount } from "@arcgis/lumina-compiler/testing";
+import { PropertyValues } from "lit";
+import { html } from "../../support/formatting";
+import { waitForNextTick } from "../tests/utils/timing";
+import { useFocusTrap } from "./useFocusTrap";
+
+describe("useFocusTrap", () => {
+  class Test extends LitElement {
+    @property() open? = false;
+
+    focusTrap = useFocusTrap<this>({
+      triggerProp: "open",
+    })(this);
+
+    private onClick() {
+      this.open = false;
+    }
+
+    override updated(changes: PropertyValues<this>): void {
+      if (changes.has("open")) {
+        if (this.open) {
+          this.focusTrap.activate();
+        } else {
+          this.focusTrap.deactivate();
+        }
+      }
+    }
+
+    override render(): JsxNode {
+      return <div>{this.open ? <button onClick={this.onClick}>close me!</button> : null}</div>;
+    }
+  }
+
+  it("does not try to restore focus to the document when there was no previously focused element", async () => {
+    document.body.innerHTML = html`<a href="/">should not focus here</a>`;
+
+    const { el, component } = await mount(Test);
+    el.open = true;
+    await component.updateComplete;
+    await waitForNextTick(); // allow focus to shift
+
+    expect(document.activeElement?.tagName).toBe(el.tagName);
+
+    el.open = false;
+    await component.updateComplete;
+    await waitForNextTick(); // allow focus to shift
+    expect(document.activeElement?.tagName).toBe("BODY");
+  });
+});

--- a/packages/components/src/utils/focusTrapComponent.ts
+++ b/packages/components/src/utils/focusTrapComponent.ts
@@ -71,7 +71,9 @@ const outsideClickDeactivated = new WeakSet<HTMLElement | SVGElement>();
  * @param el
  */
 function defaultSetReturnFocus(hostEl: HTMLElement, el: HTMLElement | SVGElement): false {
-  if (!outsideClickDeactivated.has(hostEl)) {
+  const noPreviousRelatedFocusedEl = !el || el === document.body || el === document.documentElement; // see https://developer.mozilla.org/en-US/docs/Web/API/Document/activeElement#value
+
+  if (!outsideClickDeactivated.has(hostEl) && noPreviousRelatedFocusedEl) {
     focusElement(el as FocusableElement);
   }
 

--- a/packages/components/src/utils/focusTrapComponent.ts
+++ b/packages/components/src/utils/focusTrapComponent.ts
@@ -67,13 +67,12 @@ const outsideClickDeactivated = new WeakSet<HTMLElement | SVGElement>();
 /**
  * Default behavior for returning focus when the FocusTrap is deactivated.
  *
- * @param hostEl
- * @param el
+ * @see https://github.com/focus-trap/focus-trap#setreturnfocus
  */
 function defaultSetReturnFocus(hostEl: HTMLElement, el: HTMLElement | SVGElement): false {
-  const noPreviousRelatedFocusedEl = !el || el === document.body || el === document.documentElement; // see https://developer.mozilla.org/en-US/docs/Web/API/Document/activeElement#value
+  const hasPreviousRelatedFocusedEl = el && el !== document.body && el !== document.documentElement; // see https://developer.mozilla.org/en-US/docs/Web/API/Document/activeElement#value
 
-  if (!outsideClickDeactivated.has(hostEl) && noPreviousRelatedFocusedEl) {
+  if (!outsideClickDeactivated.has(hostEl) && hasPreviousRelatedFocusedEl) {
     focusElement(el as FocusableElement);
   }
 


### PR DESCRIPTION
**Related Issue:** #13149

## Summary

Closed focus traps opened without a previously focused element now keep focus on the last element until removal instead of moving it to the first focusable element on the page.