### PR TITLE
feat(block): update heading styling for system consistency

### DIFF
--- a/packages/components/src/components/block/block.scss
+++ b/packages/components/src/components/block/block.scss
@@ -200,8 +200,8 @@ calcite-sort-handle {
     ease-in-out
     p-0;
 
-  color: var(--calcite-block-heading-text-color, var(--calcite-color-text-2));
-  font-weight: var(--calcite-font-weight-medium);
+  color: var(--calcite-block-heading-text-color, var(--calcite-color-text-1));
+  font-weight: var(--calcite-font-weight-normal);
   line-height: var(--calcite-font-line-height-relative-snug);
 }
 

--- a/packages/components/src/components/block/block.scss
+++ b/packages/components/src/components/block/block.scss
@@ -196,8 +196,6 @@ calcite-sort-handle {
 
 .header .title .heading {
   @apply word-break
-    transition-color
-    ease-in-out
     p-0;
 
   color: var(--calcite-block-heading-text-color, var(--calcite-color-text-1));
@@ -288,6 +286,7 @@ calcite-action-menu {
       --calcite-block-heading-text-color,
       var(--calcite-block-heading-text-color-press, var(--calcite-color-text-1))
     );
+    font-weight: var(--calcite-font-weight-medium);
   }
 
   .description {


### PR DESCRIPTION
**Related Issue:** [#12305](https://github.com/Esri/calcite-design-system/issues/12305)

## Summary

Update heading style when collapsed to:

- font-weight: --calcite-font-weight-normal
- color: --calcite-color-text-1