### PR TITLE
ci(actions): correctly handle input booleans being passed as strings

### DIFF
--- a/.github/scripts/monday/syncActionChanges.js
+++ b/.github/scripts/monday/syncActionChanges.js
@@ -6,8 +6,8 @@ const { assertRequired } = require("../support/utils");
  * @typedef {object} SyncActionChangesInputs
  * Incoming inputs from the "SyncActionChanges" event dispatch
  * @property {number} issue_number - The target issue number for syncing changes.
- * @property {boolean} [milestone_updated] - Indicates if the milestone was updated.
- * @property {boolean} [assignee_updated] - Indicates if the assignees were updated.
+ * @property {"true" | "false"} milestone_updated - Indicates if the milestone was updated.
+ * @property {"true" | "false"} assignee_updated - Indicates if the assignees were updated.
  * @property {"open" | "closed"} [state_updated] - Indicates if the state (open/closed) was updated.
  * @property {string} [label_name] - The label name added or removed from the issue.
  * @property {"added" | "removed"} [label_action] - The action taken on the label.
@@ -39,10 +39,10 @@ module.exports = async ({ github, context, core }) => {
 
   const monday = Monday(issue, core);
 
-  if (milestone_updated) {
+  if (milestone_updated === "true") {
     monday.handleMilestone();
   }
-  if (assignee_updated) {
+  if (assignee_updated === "true") {
     monday.handleAssignees();
   }
   if (state_updated) {


### PR DESCRIPTION
**Related Issue:** n/a

## Summary
Properly handles workflow input boolean values as strings (`"true" | "false"`), ensuring the correct actions are run in `syncActionChanges.js`. Before this, the milestone and assignee calls always run as the boolean `"false"` input is always provided by default.
