### PR TITLE
refactor(stepper)!: remove calciteStepperItemChange deprecated event

### DIFF
--- a/packages/components/src/components/stepper/stepper.e2e.ts
+++ b/packages/components/src/components/stepper/stepper.e2e.ts
@@ -572,12 +572,11 @@ describe("calcite-stepper", () => {
     });
   });
 
-  describe("should emit calciteStepperChange/calciteStepperItemChange on user interaction", () => {
+  describe("should emit calciteStepperChange on user interaction", () => {
     let layout: Stepper["el"]["layout"];
 
     async function assertEmitting(page: E2EPage, hasContent: boolean): Promise<void> {
       const element = await page.find("calcite-stepper");
-      const itemChangeSpy = await element.spyOnEvent("calciteStepperItemChange");
       const changeSpy = await element.spyOnEvent("calciteStepperChange");
       const firstItem = await page.find("#step-1");
 
@@ -592,12 +591,10 @@ describe("calcite-stepper", () => {
       // non user interaction
       firstItem.setProperty("selected", true);
       await page.waitForChanges();
-      expect(itemChangeSpy).toHaveReceivedEventTimes(expectedEvents);
-      expect(changeSpy).toHaveReceivedEventTimes(expectedEvents);
+      expect(changeSpy.events.length).toBe(expectedEvents);
 
       await page.$eval("#step-2", itemClicker);
-      expect(itemChangeSpy).toHaveReceivedEventTimes(++expectedEvents);
-      expect(changeSpy).toHaveReceivedEventTimes(expectedEvents);
+      expect(changeSpy.events.length).toBe(++expectedEvents);
       expect(await getSelectedItemId()).toBe("step-2");
 
       if (hasContent) {
@@ -606,39 +603,32 @@ describe("calcite-stepper", () => {
         );
 
         if (layout === "vertical") {
-          expect(itemChangeSpy).toHaveReceivedEventTimes(++expectedEvents);
-          expect(changeSpy).toHaveReceivedEventTimes(expectedEvents);
+          expect(changeSpy.events.length).toBe(++expectedEvents);
           expect(await getSelectedItemId()).toBe("step-1");
         } else {
           // no events since horizontal layout moves content outside of item selection hit area
-          expect(itemChangeSpy).toHaveReceivedEventTimes(expectedEvents);
-          expect(changeSpy).toHaveReceivedEventTimes(expectedEvents);
+          expect(changeSpy.events.length).toBe(expectedEvents);
         }
       }
 
       // disabled item
       await page.$eval("#step-3", itemClicker);
-      expect(itemChangeSpy).toHaveReceivedEventTimes(expectedEvents);
-      expect(changeSpy).toHaveReceivedEventTimes(expectedEvents);
+      expect(changeSpy.events.length).toBe(expectedEvents);
 
       await page.$eval("#step-4", itemClicker);
-      expect(itemChangeSpy).toHaveReceivedEventTimes(++expectedEvents);
-      expect(changeSpy).toHaveReceivedEventTimes(expectedEvents);
+      expect(changeSpy.events.length).toBe(++expectedEvents);
       expect(await getSelectedItemId()).toBe("step-4");
 
       await page.$eval("#step-5", itemClicker);
-      expect(itemChangeSpy).toHaveReceivedEventTimes(expectedEvents);
-      expect(changeSpy).toHaveReceivedEventTimes(expectedEvents);
+      expect(changeSpy.events.length).toBe(expectedEvents);
 
       await element.callMethod("prevStep");
       await page.waitForChanges();
-      expect(itemChangeSpy).toHaveReceivedEventTimes(expectedEvents);
-      expect(changeSpy).toHaveReceivedEventTimes(expectedEvents);
+      expect(changeSpy.events.length).toBe(expectedEvents);
 
       await element.callMethod("nextStep");
       await page.waitForChanges();
-      expect(itemChangeSpy).toHaveReceivedEventTimes(expectedEvents);
-      expect(changeSpy).toHaveReceivedEventTimes(expectedEvents);
+      expect(changeSpy.events.length).toBe(expectedEvents);
     }
 
     describe("horizontal layout", () => {
@@ -914,7 +904,7 @@ describe("calcite-stepper", () => {
       expect(await isElementFocused(page, `#${actionStartId}`, { shadowed: true })).toBe(true);
     });
 
-    it("should emit calciteStepperItemChange on user interaction", async () => {
+    it("should emit calciteStepperChange on user interaction", async () => {
       const page = await newE2EPage();
       await page.setContent(
         html`<calcite-stepper layout="horizontal-single">
@@ -936,25 +926,20 @@ describe("calcite-stepper", () => {
       const stepper = await page.find("calcite-stepper");
       const [actionStart, actionEnd] = await findAll(page, "calcite-stepper >>> calcite-action");
       const changeSpy = await stepper.spyOnEvent("calciteStepperChange");
-      const itemChangeSpy = await stepper.spyOnEvent("calciteStepperItemChange");
-      expect(changeSpy).toHaveReceivedEventTimes(0);
-      expect(itemChangeSpy).toHaveReceivedEventTimes(0);
+      let expectedEvents = 0;
+      expect(changeSpy.events.length).toBe(expectedEvents);
 
       await actionEnd.click();
-      expect(changeSpy).toHaveReceivedEventTimes(1);
-      expect(itemChangeSpy).toHaveReceivedEventTimes(1);
+      expect(changeSpy.events.length).toBe(++expectedEvents);
 
       await actionEnd.click();
-      expect(changeSpy).toHaveReceivedEventTimes(1);
-      expect(itemChangeSpy).toHaveReceivedEventTimes(1);
+      expect(changeSpy.events.length).toBe(expectedEvents);
 
       await actionStart.click();
-      expect(changeSpy).toHaveReceivedEventTimes(2);
-      expect(itemChangeSpy).toHaveReceivedEventTimes(2);
+      expect(changeSpy.events.length).toBe(++expectedEvents);
 
       await actionStart.click();
-      expect(changeSpy).toHaveReceivedEventTimes(2);
-      expect(itemChangeSpy).toHaveReceivedEventTimes(2);
+      expect(changeSpy.events.length).toBe(expectedEvents);
     });
 
     it(`switching to layout="horizontal-single" dynamically from another option should display a single item (#8931)`, async () => {

--- a/packages/components/src/components/stepper/stepper.tsx
+++ b/packages/components/src/components/stepper/stepper.tsx
@@ -176,13 +176,6 @@ export class Stepper extends LitElement {
   /** Fires when the active `calcite-stepper-item` changes. */
   calciteStepperChange = createEvent({ cancelable: false });
 
-  /**
-   * Fires when the active `calcite-stepper-item` changes.
-   *
-   * @deprecated in v2.8.4, removal target v6.0.0 -  Use `calciteStepperChange` or `calciteStepperItemChange` on items instead.
-   */
-  calciteStepperItemChange = createEvent({ cancelable: false });
-
   //#endregion
 
   //#region Lifecycle
@@ -298,7 +291,6 @@ export class Stepper extends LitElement {
   }
 
   private emitItemSelect(): void {
-    this.calciteStepperItemChange.emit();
     this.calciteStepperChange.emit();
   }
 


### PR DESCRIPTION
**Related Issue:** [#13080](https://github.com/Esri/calcite-design-system/issues/13080)

## Summary

Remove `calciteStepperItemChange` deprecated event.

BREAKING CHANGE: Deprecated event has been removed, use the following event instead:

`calciteStepperChange`