### PR TITLE
refactor: port `hidden` common test helper to browser mode

### DIFF
--- a/packages/components/src/components/accordion-item/accordion-item.browser.e2e.tsx
+++ b/packages/components/src/components/accordion-item/accordion-item.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults, reflects } from "../../tests/commonTests/browser";
+import { defaults, reflects, hidden } from "../../tests/commonTests/browser";
 
 describe("calcite-accordion-item", () => {
   describe("defaults", () => {
@@ -33,5 +33,9 @@ describe("calcite-accordion-item", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-accordion-item"));
   });
 });

--- a/packages/components/src/components/accordion-item/accordion-item.e2e.ts
+++ b/packages/components/src/components/accordion-item/accordion-item.e2e.ts
@@ -1,16 +1,12 @@
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
-import { accessible, renders, slots, hidden, themed, focusable, t9n } from "../../tests/commonTests";
+import { accessible, renders, slots, themed, focusable, t9n } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 import { CSS, IDS, SLOTS } from "./resources";
 
 describe("calcite-accordion-item", () => {
   describe("renders", () => {
     renders("calcite-accordion-item", { display: "flex" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-accordion-item");
   });
 
   describe("accessible", () => {

--- a/packages/components/src/components/accordion/accordion.browser.e2e.tsx
+++ b/packages/components/src/components/accordion/accordion.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults, reflects } from "../../tests/commonTests/browser";
+import { defaults, reflects, hidden } from "../../tests/commonTests/browser";
 
 describe("calcite-accordion", () => {
   describe("defaults", () => {
@@ -57,5 +57,9 @@ describe("calcite-accordion", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-accordion"));
   });
 });

--- a/packages/components/src/components/accordion/accordion.e2e.ts
+++ b/packages/components/src/components/accordion/accordion.e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
-import { accessible, hidden, renders, themed } from "../../tests/commonTests";
+import { accessible, renders, themed } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 import { CSS as ACCORDION_ITEM_CSS } from "../accordion-item/resources";
 import { findAll } from "../../tests/utils/puppeteer";
@@ -29,10 +29,6 @@ describe("calcite-accordion", () => {
 
   describe("renders", () => {
     renders("calcite-accordion", { display: "block" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-accordion");
   });
 
   describe("accessible", () => {

--- a/packages/components/src/components/action-bar/action-bar.browser.e2e.tsx
+++ b/packages/components/src/components/action-bar/action-bar.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { mount } from "@arcgis/lumina-compiler/testing";
 import { describe } from "vitest";
-import { cancelable, defaults, reflects } from "../../tests/commonTests/browser";
+import { cancelable, defaults, reflects, hidden } from "../../tests/commonTests/browser";
 import { mockConsole } from "../../tests/utils/logging";
 
 describe("calcite-action-bar", () => {
@@ -72,5 +72,9 @@ describe("calcite-action-bar", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-action-bar"));
   });
 });

--- a/packages/components/src/components/action-bar/action-bar.e2e.ts
+++ b/packages/components/src/components/action-bar/action-bar.e2e.ts
@@ -6,7 +6,6 @@ import {
   accessible,
   delegatesToFloatingUiOwningComponent,
   focusable,
-  hidden,
   renders,
   slots,
   t9n,
@@ -24,10 +23,6 @@ describe("calcite-action-bar", () => {
 
   describe("renders", () => {
     renders("calcite-action-bar", { display: "inline-flex" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-action-bar");
   });
 
   describe("delegates to floating-ui-owner component", () => {

--- a/packages/components/src/components/action-group/action-group.browser.e2e.tsx
+++ b/packages/components/src/components/action-group/action-group.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults, reflects } from "../../tests/commonTests/browser";
+import { defaults, reflects, hidden } from "../../tests/commonTests/browser";
 import { mockConsole } from "../../tests/utils/logging";
 
 describe("calcite-action-group", () => {
@@ -44,5 +44,9 @@ describe("calcite-action-group", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-action-group"));
   });
 });

--- a/packages/components/src/components/action-group/action-group.e2e.ts
+++ b/packages/components/src/components/action-group/action-group.e2e.ts
@@ -4,7 +4,6 @@ import {
   accessible,
   focusable,
   handlesActionMenuPlacements,
-  hidden,
   renders,
   slots,
   t9n,
@@ -28,10 +27,6 @@ describe("calcite-action-group", () => {
 
   describe("focusable", () => {
     focusable(actionGroupHTML, { shadowFocusTargetSelector: "calcite-action" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-action-group");
   });
 
   describe("accessible", () => {

--- a/packages/components/src/components/action-menu/action-menu.browser.e2e.tsx
+++ b/packages/components/src/components/action-menu/action-menu.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults, reflects } from "../../tests/commonTests/browser";
+import { defaults, reflects, hidden } from "../../tests/commonTests/browser";
 import { mockConsole } from "../../tests/utils/logging";
 
 describe("calcite-action-menu", () => {
@@ -60,5 +60,9 @@ describe("calcite-action-menu", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-action-menu"));
   });
 });

--- a/packages/components/src/components/action-menu/action-menu.e2e.ts
+++ b/packages/components/src/components/action-menu/action-menu.e2e.ts
@@ -6,7 +6,6 @@ import {
   accessible,
   delegatesToFloatingUiOwningComponent,
   focusable,
-  hidden,
   renders,
   slots,
   themed,
@@ -22,10 +21,6 @@ describe("calcite-action-menu", () => {
 
   describe("renders", () => {
     renders("calcite-action-menu", { display: "flex" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-action-menu");
   });
 
   describe("accessible", () => {

--- a/packages/components/src/components/action-pad/action-pad.browser.e2e.tsx
+++ b/packages/components/src/components/action-pad/action-pad.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults, reflects } from "../../tests/commonTests/browser";
+import { defaults, reflects, hidden } from "../../tests/commonTests/browser";
 import { mockConsole } from "../../tests/utils/logging";
 
 describe("calcite-action-pad", () => {
@@ -64,5 +64,9 @@ describe("calcite-action-pad", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-action-pad"));
   });
 });

--- a/packages/components/src/components/action-pad/action-pad.e2e.ts
+++ b/packages/components/src/components/action-pad/action-pad.e2e.ts
@@ -4,7 +4,6 @@ import {
   accessible,
   delegatesToFloatingUiOwningComponent,
   focusable,
-  hidden,
   renders,
   slots,
   t9n,
@@ -20,10 +19,6 @@ describe("calcite-action-pad", () => {
 
   describe("renders", () => {
     renders("calcite-action-pad", { display: "block" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-action-pad");
   });
 
   describe("delegates to floating-ui-owner component", () => {

--- a/packages/components/src/components/action/action.browser.e2e.tsx
+++ b/packages/components/src/components/action/action.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults, reflects } from "../../tests/commonTests/browser";
+import { defaults, reflects, hidden } from "../../tests/commonTests/browser";
 
 describe("calcite-action", () => {
   describe("defaults", () => {
@@ -121,5 +121,9 @@ describe("calcite-action", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-action"));
   });
 });

--- a/packages/components/src/components/action/action.e2e.ts
+++ b/packages/components/src/components/action/action.e2e.ts
@@ -1,7 +1,7 @@
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import { GlobalTestProps } from "../../tests/utils/puppeteer";
-import { accessible, disabled, hidden, renders, t9n, themed, focusable } from "../../tests/commonTests";
+import { accessible, disabled, renders, t9n, themed, focusable } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 import { CSS } from "./resources";
 
@@ -73,10 +73,6 @@ describe("calcite-action", () => {
 
   describe("renders", () => {
     renders("calcite-action", { display: "flex" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-action");
   });
 
   describe("disabled", () => {

--- a/packages/components/src/components/alert/alert.browser.e2e.tsx
+++ b/packages/components/src/components/alert/alert.browser.e2e.tsx
@@ -1,6 +1,7 @@
+import { h } from "@arcgis/lumina";
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults, reflects } from "../../tests/commonTests/browser";
+import { defaults, reflects, hidden } from "../../tests/commonTests/browser";
 
 describe("calcite-alert", () => {
   describe("defaults", () => {
@@ -33,5 +34,9 @@ describe("calcite-alert", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount(<calcite-alert open />));
   });
 });

--- a/packages/components/src/components/alert/alert.e2e.ts
+++ b/packages/components/src/components/alert/alert.e2e.ts
@@ -2,7 +2,7 @@
 import { newE2EPage, E2EPage, E2EElement } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it, beforeEach } from "vitest";
 import { html } from "../../../support/formatting";
-import { accessible, hidden, HYDRATED_ATTR, renders, t9n } from "../../tests/commonTests";
+import { accessible, HYDRATED_ATTR, renders, t9n } from "../../tests/commonTests";
 import { getElementXY, skipAnimations } from "../../tests/utils/puppeteer";
 import { openClose, themed } from "../../tests/commonTests";
 import { CSS, DURATIONS } from "./resources";
@@ -18,10 +18,6 @@ describe("calcite-alert", () => {
 
   describe("renders", () => {
     renders("calcite-alert", { visible: false, display: "block" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("<calcite-alert open></calcite-alert>");
   });
 
   describe("accessible", () => {

--- a/packages/components/src/components/autocomplete-item-group/autocomplete-item-group.browser.e2e.tsx
+++ b/packages/components/src/components/autocomplete-item-group/autocomplete-item-group.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults } from "../../tests/commonTests/browser";
+import { defaults, hidden } from "../../tests/commonTests/browser";
 
 describe("calcite-autocomplete-item-group", () => {
   describe("defaults", () => {
@@ -13,5 +13,9 @@ describe("calcite-autocomplete-item-group", () => {
         { propertyName: "scale", defaultValue: "m" },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-autocomplete-item-group"));
   });
 });

--- a/packages/components/src/components/autocomplete-item-group/autocomplete-item-group.e2e.ts
+++ b/packages/components/src/components/autocomplete-item-group/autocomplete-item-group.e2e.ts
@@ -1,15 +1,11 @@
 import { describe } from "vitest";
 import { html } from "../../../support/formatting";
-import { hidden, renders, themed } from "../../tests/commonTests";
+import { renders, themed } from "../../tests/commonTests";
 import { CSS } from "./resources";
 
 describe("calcite-autocomplete-item-group", () => {
   describe("renders", () => {
     renders("calcite-autocomplete-item-group", { display: "flex" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-autocomplete-item-group");
   });
 
   describe("theme", () => {

--- a/packages/components/src/components/autocomplete-item/autocomplete-item.browser.e2e.tsx
+++ b/packages/components/src/components/autocomplete-item/autocomplete-item.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults, reflects } from "../../tests/commonTests/browser";
+import { defaults, reflects, hidden } from "../../tests/commonTests/browser";
 
 describe("calcite-autocomplete-item", () => {
   describe("defaults", () => {
@@ -31,5 +31,9 @@ describe("calcite-autocomplete-item", () => {
         { propertyName: "iconStart", value: "banana" },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-autocomplete-item"));
   });
 });

--- a/packages/components/src/components/autocomplete-item/autocomplete-item.e2e.ts
+++ b/packages/components/src/components/autocomplete-item/autocomplete-item.e2e.ts
@@ -1,14 +1,10 @@
 import { describe } from "vitest";
-import { disabled, hidden, renders, slots, themed } from "../../tests/commonTests";
+import { disabled, renders, slots, themed } from "../../tests/commonTests";
 import { CSS, SLOTS } from "./resources";
 
 describe("calcite-autocomplete-item", () => {
   describe("renders", () => {
     renders("calcite-autocomplete-item", { display: "flex" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-autocomplete-item");
   });
 
   describe("slots", () => {

--- a/packages/components/src/components/autocomplete/autocomplete.browser.e2e.tsx
+++ b/packages/components/src/components/autocomplete/autocomplete.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { cancelable, defaults, reflects } from "../../tests/commonTests/browser";
+import { cancelable, defaults, reflects, hidden } from "../../tests/commonTests/browser";
 import { defaultMenuPlacement } from "../../utils/floating-ui";
 
 describe("calcite-autocomplete", () => {
@@ -215,5 +215,9 @@ describe("calcite-autocomplete", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-autocomplete"));
   });
 });

--- a/packages/components/src/components/autocomplete/autocomplete.e2e.ts
+++ b/packages/components/src/components/autocomplete/autocomplete.e2e.ts
@@ -6,7 +6,6 @@ import {
   floatingUIOwner,
   focusable,
   formAssociated,
-  hidden,
   internalLabel,
   labelable,
   openClose,
@@ -128,10 +127,6 @@ describe("calcite-autocomplete", () => {
 
   describe("translation support", () => {
     t9n("calcite-autocomplete");
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-autocomplete");
   });
 
   describe("slots", () => {

--- a/packages/components/src/components/avatar/avatar.browser.e2e.tsx
+++ b/packages/components/src/components/avatar/avatar.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults } from "../../tests/commonTests/browser";
+import { defaults, hidden } from "../../tests/commonTests/browser";
 
 describe("calcite-avatar", () => {
   describe("defaults", () => {
@@ -13,5 +13,9 @@ describe("calcite-avatar", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-avatar"));
   });
 });

--- a/packages/components/src/components/avatar/avatar.e2e.ts
+++ b/packages/components/src/components/avatar/avatar.e2e.ts
@@ -1,7 +1,7 @@
 // @ts-strict-ignore
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
-import { accessible, hidden, renders, themed } from "../../tests/commonTests";
+import { accessible, renders, themed } from "../../tests/commonTests";
 import { placeholderImage } from "../../../.storybook/placeholder-image";
 import { html } from "../../../support/formatting";
 import { CSS } from "./resources";
@@ -14,10 +14,6 @@ const placeholderUrl = placeholderImage({
 describe("calcite-avatar", () => {
   describe("renders", () => {
     renders("calcite-avatar", { display: "inline-block" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-avatar");
   });
 
   describe("accessible", () => {

--- a/packages/components/src/components/block-group/block-group.browser.e2e.tsx
+++ b/packages/components/src/components/block-group/block-group.browser.e2e.tsx
@@ -1,7 +1,7 @@
 import { mount } from "@arcgis/lumina-compiler/testing";
 import { describe } from "vitest";
 import { mockConsole } from "../../tests/utils/logging";
-import { cancelable, defaults, reflects } from "../../tests/commonTests/browser";
+import { cancelable, defaults, reflects, hidden } from "../../tests/commonTests/browser";
 
 describe("calcite-block-group", () => {
   mockConsole();
@@ -76,5 +76,9 @@ describe("calcite-block-group", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-block-group"));
   });
 });

--- a/packages/components/src/components/block-group/block-group.e2e.ts
+++ b/packages/components/src/components/block-group/block-group.e2e.ts
@@ -1,7 +1,7 @@
 // @ts-strict-ignore
 import { newE2EPage, E2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
-import { accessible, hidden, renders, focusable, disabled } from "../../tests/commonTests";
+import { accessible, renders, focusable, disabled } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 import { GlobalTestProps, dragAndDrop, findAll } from "../../tests/utils/puppeteer";
 import { DEBOUNCE } from "../../utils/resources";
@@ -27,10 +27,6 @@ describe("calcite-block-group", () => {
     focusable(html`<calcite-block-group> ${blockHTML} </calcite-block-group>`, {
       focusTargetSelector: "calcite-block",
     });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-block-group");
   });
 
   describe("accessible", () => {

--- a/packages/components/src/components/block-section/block-section.browser.e2e.tsx
+++ b/packages/components/src/components/block-section/block-section.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults, reflects } from "../../tests/commonTests/browser";
+import { defaults, reflects, hidden } from "../../tests/commonTests/browser";
 
 describe("calcite-block-section", () => {
   describe("defaults", () => {
@@ -45,5 +45,9 @@ describe("calcite-block-section", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-block-section"));
   });
 });

--- a/packages/components/src/components/block-section/block-section.e2e.ts
+++ b/packages/components/src/components/block-section/block-section.e2e.ts
@@ -1,17 +1,13 @@
 // @ts-strict-ignore
 import { newE2EPage, E2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
-import { accessible, focusable, hidden, renders, themed, t9n } from "../../tests/commonTests";
+import { accessible, focusable, renders, themed, t9n } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 import { CSS } from "./resources";
 
 describe("calcite-block-section", () => {
   describe("renders", () => {
     renders("calcite-block-section", { display: "block" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-block-section");
   });
 
   describe("translation support", () => {

--- a/packages/components/src/components/block/block.browser.e2e.tsx
+++ b/packages/components/src/components/block/block.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults, reflects } from "../../tests/commonTests/browser";
+import { defaults, reflects, hidden } from "../../tests/commonTests/browser";
 import { defaultEndMenuPlacement } from "../../utils/floating-ui";
 import { mockConsole } from "../../tests/utils/logging";
 
@@ -101,5 +101,9 @@ describe("calcite-block", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-block"));
   });
 });

--- a/packages/components/src/components/block/block.e2e.ts
+++ b/packages/components/src/components/block/block.e2e.ts
@@ -7,7 +7,6 @@ import {
   disabled,
   focusable,
   handlesActionMenuPlacements,
-  hidden,
   renders,
   slots,
   t9n,
@@ -24,10 +23,6 @@ describe("calcite-block", () => {
 
   describe("renders", () => {
     renders("calcite-block", { display: "flex" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-block");
   });
 
   describe("openClose", () => {

--- a/packages/components/src/components/button/button.browser.e2e.tsx
+++ b/packages/components/src/components/button/button.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { mount } from "@arcgis/lumina-compiler/testing";
 import { describe } from "vitest";
-import { defaults } from "../../tests/commonTests/browser";
+import { defaults, hidden } from "../../tests/commonTests/browser";
 
 describe("calcite-button", () => {
   describe("defaults", () => {
@@ -89,5 +89,9 @@ describe("calcite-button", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-button"));
   });
 });

--- a/packages/components/src/components/button/button.e2e.ts
+++ b/packages/components/src/components/button/button.e2e.ts
@@ -1,25 +1,12 @@
 // @ts-strict-ignore
 import { newE2EPage, E2EElement } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
-import {
-  accessible,
-  disabled,
-  focusable,
-  hidden,
-  HYDRATED_ATTR,
-  labelable,
-  t9n,
-  themed,
-} from "../../tests/commonTests";
+import { accessible, disabled, focusable, HYDRATED_ATTR, labelable, t9n, themed } from "../../tests/commonTests";
 import { GlobalTestProps } from "../../tests/utils/puppeteer";
 import { html } from "../../../support/formatting";
 import { CSS } from "./resources";
 
 describe("calcite-button", () => {
-  describe("honors hidden attribute", () => {
-    hidden("calcite-button");
-  });
-
   it("renders child element as disabled", async () => {
     const page = await newE2EPage();
     await page.setContent(`<calcite-button disabled>Continue</calcite-button>`);

--- a/packages/components/src/components/card-group/card-group.browser.e2e.tsx
+++ b/packages/components/src/components/card-group/card-group.browser.e2e.tsx
@@ -1,0 +1,9 @@
+import { describe } from "vitest";
+import { mount } from "@arcgis/lumina-compiler/testing";
+import { hidden } from "../../tests/commonTests/browser";
+
+describe("calcite-card-group", () => {
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-card-group"));
+  });
+});

--- a/packages/components/src/components/card-group/card-group.e2e.ts
+++ b/packages/components/src/components/card-group/card-group.e2e.ts
@@ -2,7 +2,7 @@
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import { html } from "../../../support/formatting";
-import { accessible, renders, hidden, disabled, themed, focusable } from "../../tests/commonTests";
+import { accessible, renders, disabled, themed, focusable } from "../../tests/commonTests";
 import { createSelectedItemsAsserter } from "../../tests/utils/puppeteer";
 import { CSS } from "./resources";
 
@@ -11,10 +11,6 @@ describe("calcite-card-group", () => {
     renders("<calcite-card-group label='test-label'><calcite-card></calcite-card></calcite-card-group>", {
       display: "block",
     });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-card-group");
   });
 
   describe("disabled", () => {

--- a/packages/components/src/components/card/card.browser.e2e.tsx
+++ b/packages/components/src/components/card/card.browser.e2e.tsx
@@ -1,0 +1,9 @@
+import { describe } from "vitest";
+import { mount } from "@arcgis/lumina-compiler/testing";
+import { hidden } from "../../tests/commonTests/browser";
+
+describe("calcite-card", () => {
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-card"));
+  });
+});

--- a/packages/components/src/components/card/card.e2e.ts
+++ b/packages/components/src/components/card/card.e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
-import { accessible, renders, slots, hidden, t9n, themed, focusable } from "../../tests/commonTests";
+import { accessible, renders, slots, t9n, themed, focusable } from "../../tests/commonTests";
 import { placeholderImage } from "../../../.storybook/placeholder-image";
 import { html } from "../../../support/formatting";
 import { CSS, SLOTS } from "./resources";
@@ -13,10 +13,6 @@ const placeholder = placeholderImage({
 describe("calcite-card", () => {
   describe("renders", () => {
     renders("calcite-card", { display: "block" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-card");
   });
 
   describe("focusable", () => {

--- a/packages/components/src/components/carousel-item/carousel-item.browser.e2e.tsx
+++ b/packages/components/src/components/carousel-item/carousel-item.browser.e2e.tsx
@@ -1,0 +1,9 @@
+import { describe } from "vitest";
+import { mount } from "@arcgis/lumina-compiler/testing";
+import { hidden } from "../../tests/commonTests/browser";
+
+describe("calcite-carousel-item", () => {
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-carousel-item"));
+  });
+});

--- a/packages/components/src/components/carousel-item/carousel-item.e2e.ts
+++ b/packages/components/src/components/carousel-item/carousel-item.e2e.ts
@@ -1,15 +1,11 @@
 import { describe } from "vitest";
-import { accessible, hidden, renders } from "../../tests/commonTests";
+import { accessible, renders } from "../../tests/commonTests";
 
 describe("calcite-carousel-item", () => {
   describe("renders", () => {
     renders("<calcite-carousel-item selected></calcite-carousel-item>", {
       display: "flex",
     });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-carousel-item");
   });
 
   describe("accessible", () => {

--- a/packages/components/src/components/carousel/carousel.browser.e2e.tsx
+++ b/packages/components/src/components/carousel/carousel.browser.e2e.tsx
@@ -1,0 +1,21 @@
+import { h } from "@arcgis/lumina";
+import { describe } from "vitest";
+import { mount } from "@arcgis/lumina-compiler/testing";
+import { hidden } from "../../tests/commonTests/browser";
+
+describe("calcite-carousel", () => {
+  describe("honors hidden attribute", () => {
+    hidden(() =>
+      mount(
+        <calcite-carousel hidden label="Carousel example">
+          <calcite-carousel-item label="Carousel Item 1">
+            <p>carousel item content</p>
+          </calcite-carousel-item>
+          <calcite-carousel-item label="Carousel Item 2">
+            <p>carousel item content</p>
+          </calcite-carousel-item>
+        </calcite-carousel>,
+      ),
+    );
+  });
+});

--- a/packages/components/src/components/carousel/carousel.e2e.ts
+++ b/packages/components/src/components/carousel/carousel.e2e.ts
@@ -1,7 +1,7 @@
 // @ts-strict-ignore
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
-import { accessible, focusable, hidden, renders, t9n, themed } from "../../tests/commonTests";
+import { accessible, focusable, renders, t9n, themed } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 import { breakpoints } from "../../utils/responsive";
 import { findAll } from "../../tests/utils/puppeteer";
@@ -21,17 +21,6 @@ describe("calcite-carousel", () => {
       {
         display: "flex",
       },
-    );
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden(
-      html`<calcite-carousel hidden label="Carousel example"
-        ><calcite-carousel-item label="Carousel Item 1"><p>carousel item content</p></calcite-carousel-item
-        ><calcite-carousel-item label="Carousel Item 2"
-          ><p>carousel item content</p></calcite-carousel-item
-        ></calcite-carousel
-      >`,
     );
   });
 

--- a/packages/components/src/components/checkbox/checkbox.browser.e2e.tsx
+++ b/packages/components/src/components/checkbox/checkbox.browser.e2e.tsx
@@ -1,0 +1,9 @@
+import { describe } from "vitest";
+import { mount } from "@arcgis/lumina-compiler/testing";
+import { hidden } from "../../tests/commonTests/browser";
+
+describe("calcite-checkbox", () => {
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-checkbox"));
+  });
+});

--- a/packages/components/src/components/checkbox/checkbox.e2e.ts
+++ b/packages/components/src/components/checkbox/checkbox.e2e.ts
@@ -6,7 +6,6 @@ import {
   disabled,
   focusable,
   formAssociated,
-  hidden,
   internalLabel,
   HYDRATED_ATTR,
   labelable,
@@ -20,10 +19,6 @@ import { findAll } from "../../tests/utils/puppeteer";
 import { CSS } from "./resources";
 
 describe("calcite-checkbox", () => {
-  describe("honors hidden attribute", () => {
-    hidden("calcite-checkbox");
-  });
-
   describe("accessible", () => {
     accessible(
       `<calcite-label><calcite-checkbox id="example" name="example" value="one"></calcite-checkbox> label</calcite-label>`,

--- a/packages/components/src/components/chip-group/chip-group.browser.e2e.tsx
+++ b/packages/components/src/components/chip-group/chip-group.browser.e2e.tsx
@@ -1,0 +1,9 @@
+import { describe } from "vitest";
+import { mount } from "@arcgis/lumina-compiler/testing";
+import { hidden } from "../../tests/commonTests/browser";
+
+describe("calcite-chip-group", () => {
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-chip-group"));
+  });
+});

--- a/packages/components/src/components/chip-group/chip-group.e2e.ts
+++ b/packages/components/src/components/chip-group/chip-group.e2e.ts
@@ -2,7 +2,7 @@
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import { html } from "../../../support/formatting";
-import { accessible, renders, hidden, disabled, focusable } from "../../tests/commonTests";
+import { accessible, renders, disabled, focusable } from "../../tests/commonTests";
 import { CSS as CHIP_CSS } from "../chip/resources";
 import { createSelectedItemsAsserter } from "../../tests/utils/puppeteer";
 
@@ -11,10 +11,6 @@ describe("calcite-chip-group", () => {
     renders("<calcite-chip-group><calcite-chip></calcite-chip></calcite-chip-group>", {
       display: "flex",
     });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-chip-group");
   });
 
   describe("disabled", () => {

--- a/packages/components/src/components/chip/chip.browser.e2e.tsx
+++ b/packages/components/src/components/chip/chip.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults, reflects } from "../../tests/commonTests/browser";
+import { defaults, reflects, hidden } from "../../tests/commonTests/browser";
 
 describe("calcite-chip", () => {
   describe("defaults", () => {
@@ -40,5 +40,9 @@ describe("calcite-chip", () => {
         { propertyName: "selected", value: true },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-chip"));
   });
 });

--- a/packages/components/src/components/chip/chip.e2e.ts
+++ b/packages/components/src/components/chip/chip.e2e.ts
@@ -1,17 +1,13 @@
 // @ts-strict-ignore
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
-import { accessible, disabled, focusable, hidden, renders, slots, t9n, themed } from "../../tests/commonTests";
+import { accessible, disabled, focusable, renders, slots, t9n, themed } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 import { CSS, SLOTS } from "./resources";
 
 describe("calcite-chip", () => {
   describe("renders", () => {
     renders("<calcite-chip>doritos</calcite-chip>", { display: "inline-flex" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-chip");
   });
 
   describe("accessible with icon only", () => {

--- a/packages/components/src/components/color-picker-hex-input/color-picker-hex-input.browser.e2e.tsx
+++ b/packages/components/src/components/color-picker-hex-input/color-picker-hex-input.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults, reflects } from "../../tests/commonTests/browser";
+import { defaults, reflects, hidden } from "../../tests/commonTests/browser";
 
 describe("calcite-color-picker-hex-input", () => {
   describe("defaults", () => {
@@ -33,5 +33,9 @@ describe("calcite-color-picker-hex-input", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-color-picker-hex-input"));
   });
 });

--- a/packages/components/src/components/color-picker-hex-input/color-picker-hex-input.e2e.ts
+++ b/packages/components/src/components/color-picker-hex-input/color-picker-hex-input.e2e.ts
@@ -1,7 +1,7 @@
 // @ts-strict-ignore
 import { newE2EPage, E2EPage, E2EElement } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it, beforeEach } from "vitest";
-import { accessible, focusable, hidden, renders } from "../../tests/commonTests";
+import { accessible, focusable, renders } from "../../tests/commonTests";
 import { selectText } from "../../tests/utils/puppeteer";
 import { canConvertToHexa, isValidHex, normalizeHex } from "../color-picker/utils";
 import { CSS } from "./resources";
@@ -9,10 +9,6 @@ import { CSS } from "./resources";
 describe("calcite-color-picker-hex-input", () => {
   describe("renders", () => {
     renders("calcite-color-picker-hex-input", { display: "block" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-color-picker-hex-input");
   });
 
   describe("accessible", () => {

--- a/packages/components/src/components/color-picker-swatch/color-picker-swatch.browser.e2e.tsx
+++ b/packages/components/src/components/color-picker-swatch/color-picker-swatch.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults, reflects } from "../../tests/commonTests/browser";
+import { defaults, reflects, hidden } from "../../tests/commonTests/browser";
 
 describe("calcite-color-picker-swatch", () => {
   describe("defaults", () => {
@@ -25,5 +25,9 @@ describe("calcite-color-picker-swatch", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-color-picker-swatch"));
   });
 });

--- a/packages/components/src/components/color-picker-swatch/color-picker-swatch.e2e.ts
+++ b/packages/components/src/components/color-picker-swatch/color-picker-swatch.e2e.ts
@@ -1,15 +1,11 @@
 import { newE2EPage, E2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it, beforeEach } from "vitest";
-import { accessible, renders, hidden } from "../../tests/commonTests";
+import { accessible, renders } from "../../tests/commonTests";
 import { CSS } from "./resources";
 
 describe("calcite-color-picker-swatch", () => {
   describe("renders", () => {
     renders("calcite-color-picker-swatch", { display: "inline-flex" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-color-picker-swatch");
   });
 
   describe("accessible", () => {

--- a/packages/components/src/components/color-picker/color-picker.browser.e2e.tsx
+++ b/packages/components/src/components/color-picker/color-picker.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { cancelable, defaults, reflects } from "../../tests/commonTests/browser";
+import { cancelable, defaults, reflects, hidden } from "../../tests/commonTests/browser";
 import { mockConsole } from "../../tests/utils/logging";
 
 describe("calcite-color-picker", () => {
@@ -68,5 +68,9 @@ describe("calcite-color-picker", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-color-picker"));
   });
 });

--- a/packages/components/src/components/color-picker/color-picker.e2e.ts
+++ b/packages/components/src/components/color-picker/color-picker.e2e.ts
@@ -1,7 +1,7 @@
 // @ts-strict-ignore
 import { E2EElement, E2EPage, EventSpy, newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { accessible, disabled, focusable, hidden, renders, t9n, themed } from "../../tests/commonTests";
+import { accessible, disabled, focusable, renders, t9n, themed } from "../../tests/commonTests";
 import {
   findAll,
   getElementRect,
@@ -50,10 +50,6 @@ describe("calcite-color-picker", () => {
   describe("accessible", () => {
     accessible("calcite-color-picker");
     accessible("<calcite-color-picker clearable value=''></calcite-color-picker>");
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-color-picker");
   });
 
   describe("renders", () => {

--- a/packages/components/src/components/combobox-item/combobox-item.browser.e2e.tsx
+++ b/packages/components/src/components/combobox-item/combobox-item.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults, reflects } from "../../tests/commonTests/browser";
+import { defaults, reflects, hidden } from "../../tests/commonTests/browser";
 
 describe("calcite-combobox-item", () => {
   describe("defaults", () => {
@@ -35,5 +35,9 @@ describe("calcite-combobox-item", () => {
         { propertyName: "selected", value: true },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-combobox-item"));
   });
 });

--- a/packages/components/src/components/combobox-item/combobox-item.e2e.ts
+++ b/packages/components/src/components/combobox-item/combobox-item.e2e.ts
@@ -1,5 +1,5 @@
 import { describe } from "vitest";
-import { disabled, hidden, renders, slots, themed } from "../../tests/commonTests";
+import { disabled, renders, slots, themed } from "../../tests/commonTests";
 import { ComponentTestTokens } from "../../tests/commonTests/themed";
 import { html } from "../../../support/formatting";
 import { SLOTS } from "./resources";
@@ -8,10 +8,6 @@ import { CSS } from "./resources";
 describe("calcite-combobox-item", () => {
   describe("renders", () => {
     renders("calcite-combobox-item", { display: "flex" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-combobox-item");
   });
 
   describe("slots", () => {

--- a/packages/components/src/components/combobox/combobox.browser.e2e.tsx
+++ b/packages/components/src/components/combobox/combobox.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { cancelable, defaults, reflects } from "../../tests/commonTests/browser";
+import { cancelable, defaults, reflects, hidden } from "../../tests/commonTests/browser";
 import { mockConsole } from "../../tests/utils/logging";
 
 describe("calcite-combobox", () => {
@@ -113,5 +113,9 @@ describe("calcite-combobox", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-combobox"));
   });
 });

--- a/packages/components/src/components/combobox/combobox.e2e.ts
+++ b/packages/components/src/components/combobox/combobox.e2e.ts
@@ -7,7 +7,6 @@ import {
   floatingUIOwner,
   focusable,
   formAssociated,
-  hidden,
   internalLabel,
   labelable,
   openClose,
@@ -52,10 +51,6 @@ describe("calcite-combobox", () => {
 
   describe("InternalLabel", () => {
     internalLabel(`calcite-combobox`);
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-combobox");
   });
 
   describe("accessible", () => {

--- a/packages/components/src/components/date-picker/date-picker.browser.e2e.tsx
+++ b/packages/components/src/components/date-picker/date-picker.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults } from "../../tests/commonTests/browser";
+import { defaults, hidden } from "../../tests/commonTests/browser";
 
 describe("calcite-date-picker", () => {
   describe("defaults", () => {
@@ -21,5 +21,9 @@ describe("calcite-date-picker", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-date-picker"));
   });
 });

--- a/packages/components/src/components/date-picker/date-picker.e2e.ts
+++ b/packages/components/src/components/date-picker/date-picker.e2e.ts
@@ -3,7 +3,7 @@ import { E2EElement, E2EPage, newE2EPage } from "@arcgis/lumina-compiler/puppete
 import { describe, expect, it } from "vitest";
 import { ConditionalPick } from "type-fest";
 import { html } from "../../../support/formatting";
-import { focusable, hidden, renders, t9n } from "../../tests/commonTests";
+import { focusable, renders, t9n } from "../../tests/commonTests";
 import { findAll, skipAnimations } from "../../tests/utils/puppeteer";
 import { Position } from "../interfaces";
 import { CSS as MONTH_CSS } from "../date-picker-month/resources";
@@ -14,10 +14,6 @@ import type { DatePicker } from "./date-picker";
 describe("calcite-date-picker", () => {
   describe("renders", () => {
     renders("calcite-date-picker", { display: "inline-block" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-date-picker");
   });
 
   describe("focusable", () => {

--- a/packages/components/src/components/dialog/dialog.browser.e2e.tsx
+++ b/packages/components/src/components/dialog/dialog.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults, reflects } from "../../tests/commonTests/browser";
+import { defaults, reflects, hidden } from "../../tests/commonTests/browser";
 import { mockConsole } from "../../tests/utils/logging";
 
 describe("calcite-dialog", () => {
@@ -176,5 +176,9 @@ describe("calcite-dialog", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-dialog"));
   });
 });

--- a/packages/components/src/components/dialog/dialog.e2e.ts
+++ b/packages/components/src/components/dialog/dialog.e2e.ts
@@ -1,7 +1,7 @@
 // @ts-strict-ignore
 import { newE2EPage, E2EPage, E2EElement } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { accessible, focusable, hidden, openClose, renders, slots, t9n, themed } from "../../tests/commonTests";
+import { accessible, focusable, openClose, renders, slots, t9n, themed } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 import { GlobalTestProps, isElementFocused, newProgrammaticE2EPage, skipAnimations } from "../../tests/utils/puppeteer";
 import { IDS as PanelIDS } from "../panel/resources";
@@ -41,10 +41,6 @@ describe("calcite-dialog", () => {
 
   describe("renders", () => {
     renders("calcite-dialog", { display: "flex", visible: true });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-dialog");
   });
 
   describe("openClose", () => {

--- a/packages/components/src/components/dropdown-group/dropdown-group.browser.e2e.tsx
+++ b/packages/components/src/components/dropdown-group/dropdown-group.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults, reflects } from "../../tests/commonTests/browser";
+import { defaults, reflects, hidden } from "../../tests/commonTests/browser";
 
 describe("calcite-dropdown-group", () => {
   describe("defaults", () => {
@@ -25,5 +25,9 @@ describe("calcite-dropdown-group", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-dropdown-group"));
   });
 });

--- a/packages/components/src/components/dropdown-group/dropdown-group.e2e.ts
+++ b/packages/components/src/components/dropdown-group/dropdown-group.e2e.ts
@@ -1,7 +1,7 @@
 // @ts-strict-ignore
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
-import { hidden, renders } from "../../tests/commonTests";
+import { renders } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 import { findAll } from "../../tests/utils/puppeteer";
 import { ComponentTestTokens, themed } from "../../tests/commonTests/themed";
@@ -10,10 +10,6 @@ import { CSS } from "./resources";
 describe("calcite-dropdown-group", () => {
   describe("renders", () => {
     renders("calcite-dropdown-group", { display: "block" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-dropdown-group");
   });
 
   it("sets selectionMode on slotted dropdown item children", async () => {

--- a/packages/components/src/components/dropdown-item/dropdown-item.browser.e2e.tsx
+++ b/packages/components/src/components/dropdown-item/dropdown-item.browser.e2e.tsx
@@ -1,0 +1,9 @@
+import { describe } from "vitest";
+import { mount } from "@arcgis/lumina-compiler/testing";
+import { hidden } from "../../tests/commonTests/browser";
+
+describe("calcite-dropdown-item", () => {
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-dropdown-item"));
+  });
+});

--- a/packages/components/src/components/dropdown-item/dropdown-item.e2e.ts
+++ b/packages/components/src/components/dropdown-item/dropdown-item.e2e.ts
@@ -1,16 +1,12 @@
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
-import { focusable, renders, hidden, disabled, themed } from "../../tests/commonTests";
+import { focusable, renders, disabled, themed } from "../../tests/commonTests";
 import { ComponentTestTokens } from "../../tests/commonTests/themed";
 import { CSS } from "./resources";
 
 describe("calcite-dropdown-item", () => {
   describe("renders", () => {
     renders("calcite-dropdown-item", { display: "flex" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-dropdown-item");
   });
 
   describe("can be focused", () => {

--- a/packages/components/src/components/dropdown/dropdown.browser.e2e.tsx
+++ b/packages/components/src/components/dropdown/dropdown.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { mount } from "@arcgis/lumina-compiler/testing";
 import { describe } from "vitest";
-import { defaults, reflects } from "../../tests/commonTests/browser";
+import { defaults, reflects, hidden } from "../../tests/commonTests/browser";
 
 describe("calcite-dropdown", () => {
   describe("defaults", () => {
@@ -42,5 +42,9 @@ describe("calcite-dropdown", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-dropdown"));
   });
 });

--- a/packages/components/src/components/dropdown/dropdown.e2e.ts
+++ b/packages/components/src/components/dropdown/dropdown.e2e.ts
@@ -2,7 +2,7 @@
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import { html } from "../../../support/formatting";
-import { accessible, disabled, floatingUIOwner, focusable, hidden, openClose, renders } from "../../tests/commonTests";
+import { accessible, disabled, floatingUIOwner, focusable, openClose, renders } from "../../tests/commonTests";
 import {
   createSelectedItemsAsserter,
   findAll,
@@ -36,10 +36,6 @@ describe("calcite-dropdown", () => {
 
   describe("renders", () => {
     renders(simpleDropdownHTML, { display: "inline-block" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-dropdown");
   });
 
   describe("disabled", () => {

--- a/packages/components/src/components/fab/fab.browser.e2e.tsx
+++ b/packages/components/src/components/fab/fab.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults } from "../../tests/commonTests/browser";
+import { defaults, hidden } from "../../tests/commonTests/browser";
 
 describe("calcite-fab", () => {
   describe("defaults", () => {
@@ -17,5 +17,9 @@ describe("calcite-fab", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-fab"));
   });
 });

--- a/packages/components/src/components/fab/fab.e2e.ts
+++ b/packages/components/src/components/fab/fab.e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
-import { accessible, disabled, focusable, hidden, renders, themed } from "../../tests/commonTests";
+import { accessible, disabled, focusable, renders, themed } from "../../tests/commonTests";
 import { findAll } from "../../tests/utils/puppeteer";
 import { html } from "../../../support/formatting";
 import { CSS } from "./resources";
@@ -8,10 +8,6 @@ import { CSS } from "./resources";
 describe("calcite-fab", () => {
   describe("renders", () => {
     renders("calcite-fab", { display: "flex" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-fab");
   });
 
   describe("disabled", () => {

--- a/packages/components/src/components/filter/filter.browser.e2e.tsx
+++ b/packages/components/src/components/filter/filter.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { cancelable, defaults, reflects } from "../../tests/commonTests/browser";
+import { cancelable, defaults, reflects, hidden } from "../../tests/commonTests/browser";
 import { mockConsole } from "../../tests/utils/logging";
 
 describe("calcite-filter", () => {
@@ -45,5 +45,9 @@ describe("calcite-filter", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-filter"));
   });
 });

--- a/packages/components/src/components/filter/filter.e2e.ts
+++ b/packages/components/src/components/filter/filter.e2e.ts
@@ -1,7 +1,7 @@
 // @ts-strict-ignore
 import { newE2EPage, E2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it, beforeEach } from "vitest";
-import { accessible, disabled, focusable, hidden, renders, t9n, themed } from "../../tests/commonTests";
+import { accessible, disabled, focusable, renders, t9n, themed } from "../../tests/commonTests";
 import { CSS as INPUT_CSS } from "../input/resources";
 import { DEBOUNCE } from "../../utils/resources";
 import { html } from "../../../support/formatting";
@@ -14,10 +14,6 @@ describe("calcite-filter", () => {
 
   describe("renders", () => {
     renders("calcite-filter", { display: "flex" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-filter");
   });
 
   describe("accessible", () => {

--- a/packages/components/src/components/flow-item/flow-item.browser.e2e.tsx
+++ b/packages/components/src/components/flow-item/flow-item.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults, reflects } from "../../tests/commonTests/browser";
+import { defaults, reflects, hidden } from "../../tests/commonTests/browser";
 import { mockConsole } from "../../tests/utils/logging";
 
 describe("calcite-flow-item", () => {
@@ -120,5 +120,9 @@ describe("calcite-flow-item", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-flow-item"));
   });
 });

--- a/packages/components/src/components/flow-item/flow-item.e2e.ts
+++ b/packages/components/src/components/flow-item/flow-item.e2e.ts
@@ -6,7 +6,6 @@ import {
   delegatesToFloatingUiOwningComponent,
   disabled,
   focusable,
-  hidden,
   renders,
   slots,
   t9n,
@@ -30,10 +29,6 @@ describe("calcite-flow-item", () => {
 
   describe("renders", () => {
     renders("<calcite-flow-item selected></calcite-flow-item>", { display: "flex" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-flow-item");
   });
 
   describe("slots", () => {

--- a/packages/components/src/components/flow/flow.browser.e2e.tsx
+++ b/packages/components/src/components/flow/flow.browser.e2e.tsx
@@ -1,0 +1,9 @@
+import { describe } from "vitest";
+import { mount } from "@arcgis/lumina-compiler/testing";
+import { hidden } from "../../tests/commonTests/browser";
+
+describe("calcite-flow", () => {
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-flow"));
+  });
+});

--- a/packages/components/src/components/flow/flow.e2e.ts
+++ b/packages/components/src/components/flow/flow.e2e.ts
@@ -2,7 +2,7 @@
 import { E2EPage, newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it, vi } from "vitest";
 import { html } from "../../../support/formatting";
-import { accessible, focusable, hidden, renders, themed } from "../../tests/commonTests";
+import { accessible, focusable, renders, themed } from "../../tests/commonTests";
 import { CSS as ITEM_CSS } from "../flow-item/resources";
 import { findAll, isElementFocused } from "../../tests/utils/puppeteer";
 import type { Action } from "../action/action";
@@ -23,10 +23,6 @@ describe("calcite-flow", () => {
 
   describe("renders", () => {
     renders("calcite-flow", { display: "flex" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-flow");
   });
 
   describe("is focusable", () => {

--- a/packages/components/src/components/graph/graph.browser.e2e.tsx
+++ b/packages/components/src/components/graph/graph.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults } from "../../tests/commonTests/browser";
+import { defaults, hidden } from "../../tests/commonTests/browser";
 
 describe("calcite-graph", () => {
   describe("defaults", () => {
@@ -13,5 +13,9 @@ describe("calcite-graph", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-graph"));
   });
 });

--- a/packages/components/src/components/graph/graph.e2e.ts
+++ b/packages/components/src/components/graph/graph.e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage, E2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, beforeEach } from "vitest";
-import { accessible, hidden, renders, themed } from "../../tests/commonTests";
+import { accessible, renders, themed } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 import type { Graph } from "./graph";
 import { CSS } from "./resources";
@@ -30,10 +30,6 @@ async function createGraphWithData(): Promise<E2EPage> {
 describe("calcite-graph", () => {
   describe("renders", () => {
     renders(`calcite-graph`, { display: "block" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-graph");
   });
 
   describe("accessible", () => {

--- a/packages/components/src/components/handle/handle.browser.e2e.tsx
+++ b/packages/components/src/components/handle/handle.browser.e2e.tsx
@@ -1,0 +1,9 @@
+import { describe } from "vitest";
+import { mount } from "@arcgis/lumina-compiler/testing";
+import { hidden } from "../../tests/commonTests/browser";
+
+describe("calcite-handle", () => {
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-handle"));
+  });
+});

--- a/packages/components/src/components/handle/handle.e2e.ts
+++ b/packages/components/src/components/handle/handle.e2e.ts
@@ -1,7 +1,7 @@
 // @ts-strict-ignore
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
-import { accessible, disabled, hidden, renders, themed, t9n, focusable } from "../../tests/commonTests";
+import { accessible, disabled, renders, themed, t9n, focusable } from "../../tests/commonTests";
 import { CSS, SUBSTITUTIONS } from "./resources";
 import type { HandleNudge } from "./interfaces";
 import type { Handle } from "./handle";
@@ -9,10 +9,6 @@ import type { Handle } from "./handle";
 describe("calcite-handle", () => {
   describe("renders", () => {
     renders("calcite-handle", { display: "flex" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-handle");
   });
 
   describe("disabled", () => {

--- a/packages/components/src/components/icon/icon.browser.e2e.tsx
+++ b/packages/components/src/components/icon/icon.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults, reflects } from "../../tests/commonTests/browser";
+import { defaults, reflects, hidden } from "../../tests/commonTests/browser";
 
 describe("calcite-icon", () => {
   describe("defaults", () => {
@@ -23,5 +23,9 @@ describe("calcite-icon", () => {
         { propertyName: "scale", value: "m" },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-icon"));
   });
 });

--- a/packages/components/src/components/icon/icon.e2e.ts
+++ b/packages/components/src/components/icon/icon.e2e.ts
@@ -1,15 +1,11 @@
 // @ts-strict-ignore
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
-import { accessible, hidden, renders, themed } from "../../tests/commonTests";
+import { accessible, renders, themed } from "../../tests/commonTests";
 import { CSS } from "./resources";
 import { scaleToPx } from "./utils";
 
 describe("calcite-icon", () => {
-  describe("honors hidden attribute", () => {
-    hidden("calcite-icon");
-  });
-
   describe("accessible", () => {
     accessible(`<calcite-icon icon="a-z" text-label="sort options"></calcite-icon>`);
   });

--- a/packages/components/src/components/inline-editable/inline-editable.browser.e2e.tsx
+++ b/packages/components/src/components/inline-editable/inline-editable.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults } from "../../tests/commonTests/browser";
+import { defaults, hidden } from "../../tests/commonTests/browser";
 
 describe("calcite-inline-editable", () => {
   describe("defaults", () => {
@@ -13,5 +13,9 @@ describe("calcite-inline-editable", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-inline-editable"));
   });
 });

--- a/packages/components/src/components/inline-editable/inline-editable.e2e.ts
+++ b/packages/components/src/components/inline-editable/inline-editable.e2e.ts
@@ -1,7 +1,7 @@
 // @ts-strict-ignore
 import { E2EPage, newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { beforeEach, describe, expect, it } from "vitest";
-import { accessible, focusable, disabled, hidden, labelable, renders, t9n, themed } from "../../tests/commonTests";
+import { accessible, focusable, disabled, labelable, renders, t9n, themed } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 import type { Input } from "../input/input";
 import { findAll, getElementRect, toElementHandle } from "../../tests/utils/puppeteer";
@@ -19,10 +19,6 @@ describe("calcite-inline-editable", () => {
       `,
       { display: "block" },
     );
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-inline-editable");
   });
 
   describe("disabled", () => {

--- a/packages/components/src/components/input-date-picker/input-date-picker.browser.e2e.tsx
+++ b/packages/components/src/components/input-date-picker/input-date-picker.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults } from "../../tests/commonTests/browser";
+import { defaults, hidden } from "../../tests/commonTests/browser";
 
 describe("calcite-input-date-picker", () => {
   describe("defaults", () => {
@@ -33,5 +33,9 @@ describe("calcite-input-date-picker", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-input-date-picker"));
   });
 });

--- a/packages/components/src/components/input-date-picker/input-date-picker.e2e.ts
+++ b/packages/components/src/components/input-date-picker/input-date-picker.e2e.ts
@@ -7,7 +7,6 @@ import {
   floatingUIOwner,
   focusable,
   formAssociated,
-  hidden,
   internalLabel,
   labelable,
   openClose,
@@ -33,10 +32,6 @@ describe("calcite-input-date-picker", () => {
 
   describe("renders", () => {
     renders("calcite-input-date-picker", { display: "inline-block" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-input-date-picker");
   });
 
   describe("labelable", () => {

--- a/packages/components/src/components/input-message/input-message.browser.e2e.tsx
+++ b/packages/components/src/components/input-message/input-message.browser.e2e.tsx
@@ -1,0 +1,10 @@
+import { h } from "@arcgis/lumina";
+import { describe } from "vitest";
+import { mount } from "@arcgis/lumina-compiler/testing";
+import { hidden } from "../../tests/commonTests/browser";
+
+describe("calcite-input-message", () => {
+  describe("honors hidden attribute", () => {
+    hidden(() => mount(<calcite-input-message>Text</calcite-input-message>));
+  });
+});

--- a/packages/components/src/components/input-message/input-message.e2e.ts
+++ b/packages/components/src/components/input-message/input-message.e2e.ts
@@ -1,7 +1,7 @@
 // @ts-strict-ignore
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it, beforeEach } from "vitest";
-import { accessible, hidden, renders, themed } from "../../tests/commonTests";
+import { accessible, renders, themed } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 import { StatusIconDefaults } from "./interfaces";
 import { CSS } from "./resources";
@@ -10,10 +10,6 @@ describe("calcite-input-message", () => {
   describe("renders", () => {
     renders(`<calcite-input-message hidden></calcite-input-message>`, { display: "none", visible: false });
     renders(`<calcite-input-message></calcite-input-message>`, { display: "flex", visible: true });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden(`<calcite-input-message>Text</calcite-input-message>`);
   });
 
   describe("accessible", () => {

--- a/packages/components/src/components/input-number/input-number.browser.e2e.tsx
+++ b/packages/components/src/components/input-number/input-number.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults, reflects } from "../../tests/commonTests/browser";
+import { defaults, reflects, hidden } from "../../tests/commonTests/browser";
 
 describe("calcite-input-number", () => {
   describe("defaults", () => {
@@ -65,5 +65,9 @@ describe("calcite-input-number", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-input-number"));
   });
 });

--- a/packages/components/src/components/input-number/input-number.e2e.ts
+++ b/packages/components/src/components/input-number/input-number.e2e.ts
@@ -7,7 +7,6 @@ import {
   disabled,
   focusable,
   formAssociated,
-  hidden,
   internalLabel,
   labelable,
   renders,
@@ -53,10 +52,6 @@ describe("calcite-input-number", () => {
 
   describe("renders", () => {
     renders("calcite-input-number", { display: "block" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-input-number");
   });
 
   describe("disabled", () => {

--- a/packages/components/src/components/input-text/input-text.browser.e2e.tsx
+++ b/packages/components/src/components/input-text/input-text.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults, reflects } from "../../tests/commonTests/browser";
+import { defaults, reflects, hidden } from "../../tests/commonTests/browser";
 
 describe("calcite-input-text", () => {
   describe("defaults", () => {
@@ -57,5 +57,9 @@ describe("calcite-input-text", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-input-text"));
   });
 });

--- a/packages/components/src/components/input-text/input-text.e2e.ts
+++ b/packages/components/src/components/input-text/input-text.e2e.ts
@@ -6,7 +6,6 @@ import {
   disabled,
   focusable,
   formAssociated,
-  hidden,
   internalLabel,
   labelable,
   renders,
@@ -31,10 +30,6 @@ describe("calcite-input-text", () => {
 
   describe("renders", () => {
     renders("calcite-input-text", { display: "block" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-input-text");
   });
 
   describe("disabled", () => {

--- a/packages/components/src/components/input-time-picker/input-time-picker.browser.e2e.tsx
+++ b/packages/components/src/components/input-time-picker/input-time-picker.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults, reflects } from "../../tests/commonTests/browser";
+import { defaults, reflects, hidden } from "../../tests/commonTests/browser";
 import { mockConsole } from "../../tests/utils/logging";
 
 describe("calcite-input-time-picker", () => {
@@ -31,5 +31,9 @@ describe("calcite-input-time-picker", () => {
         { propertyName: "validationIcon", value: true },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-input-time-picker"));
   });
 });

--- a/packages/components/src/components/input-time-picker/input-time-picker.e2e.ts
+++ b/packages/components/src/components/input-time-picker/input-time-picker.e2e.ts
@@ -9,7 +9,6 @@ import {
   disabled,
   focusable,
   formAssociated,
-  hidden,
   internalLabel,
   labelable,
   renders,
@@ -55,10 +54,6 @@ describe("calcite-input-time-picker", () => {
     describe("renders with base lang when region code is unsupported", () => {
       renders(`<calcite-input-time-picker lang="nl-nl"></calcite-input-time-picker>`, { display: "inline-block" });
     });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-input-time-picker");
   });
 
   describe("accessible", () => {

--- a/packages/components/src/components/input-time-zone/input-time-zone.browser.e2e.tsx
+++ b/packages/components/src/components/input-time-zone/input-time-zone.browser.e2e.tsx
@@ -1,8 +1,11 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import { hidden } from "../../tests/commonTests/browser";
+import { mockConsole } from "../../tests/utils/logging";
 
 describe("calcite-input-time-zone", () => {
+  mockConsole();
+
   // describe("defaults", () => {
   //   defaults(() => mount(simpleTestProvider), [
   //     { propertyName: "disabled", defaultValue: false },

--- a/packages/components/src/components/input-time-zone/input-time-zone.browser.e2e.tsx
+++ b/packages/components/src/components/input-time-zone/input-time-zone.browser.e2e.tsx
@@ -1,4 +1,6 @@
 import { describe } from "vitest";
+import { mount } from "@arcgis/lumina-compiler/testing";
+import { hidden } from "../../tests/commonTests/browser";
 
 describe("calcite-input-time-zone", () => {
   // describe("defaults", () => {
@@ -27,4 +29,8 @@ describe("calcite-input-time-zone", () => {
   //     { propertyName: "validationIcon", value: true },
   //   ]);
   // });
+
+  describe("hidden", () => {
+    hidden(() => mount("calcite-input-time-zone"));
+  });
 });

--- a/packages/components/src/components/input-time-zone/input-time-zone.e2e.ts
+++ b/packages/components/src/components/input-time-zone/input-time-zone.e2e.ts
@@ -6,7 +6,6 @@ import {
   disabled,
   focusable,
   formAssociated,
-  hidden,
   labelable,
   openClose,
   renders,
@@ -75,10 +74,6 @@ describe("calcite-input-time-zone", () => {
         clearable: false,
       },
     );
-  });
-
-  describe("hidden", () => {
-    hidden(simpleTestProvider);
   });
 
   describe("renders", () => {

--- a/packages/components/src/components/input/input.browser.e2e.tsx
+++ b/packages/components/src/components/input/input.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults, reflects } from "../../tests/commonTests/browser";
+import { defaults, reflects, hidden } from "../../tests/commonTests/browser";
 
 describe("calcite-input", () => {
   describe("defaults", () => {
@@ -73,5 +73,9 @@ describe("calcite-input", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-input"));
   });
 });

--- a/packages/components/src/components/input/input.e2e.ts
+++ b/packages/components/src/components/input/input.e2e.ts
@@ -6,7 +6,6 @@ import {
   disabled,
   focusable,
   formAssociated,
-  hidden,
   internalLabel,
   labelable,
   renders,
@@ -50,10 +49,6 @@ describe("calcite-input", () => {
 
   describe("renders", () => {
     renders("calcite-input", { display: "block" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-input");
   });
 
   describe("disabled", () => {

--- a/packages/components/src/components/label/label.browser.e2e.tsx
+++ b/packages/components/src/components/label/label.browser.e2e.tsx
@@ -1,0 +1,9 @@
+import { describe } from "vitest";
+import { mount } from "@arcgis/lumina-compiler/testing";
+import { hidden } from "../../tests/commonTests/browser";
+
+describe("calcite-label", () => {
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-label"));
+  });
+});

--- a/packages/components/src/components/label/label.e2e.ts
+++ b/packages/components/src/components/label/label.e2e.ts
@@ -1,7 +1,7 @@
 // @ts-strict-ignore
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
-import { renders, hidden, themed } from "../../tests/commonTests";
+import { renders, themed } from "../../tests/commonTests";
 import { isElementFocused } from "../../tests/utils/puppeteer";
 import { html } from "../../../support/formatting";
 import { CSS } from "./resources";
@@ -35,10 +35,6 @@ describe("calcite-label", () => {
 
     const element = await page.find("calcite-label");
     expect(element).toEqualAttribute("layout", "inline-space-between");
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-label");
   });
 
   describe("alignment prop", () => {

--- a/packages/components/src/components/link/link.browser.e2e.tsx
+++ b/packages/components/src/components/link/link.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults } from "../../tests/commonTests/browser";
+import { defaults, hidden } from "../../tests/commonTests/browser";
 
 describe("calcite-link", () => {
   describe("defaults", () => {
@@ -13,5 +13,9 @@ describe("calcite-link", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-link"));
   });
 });

--- a/packages/components/src/components/link/link.e2e.ts
+++ b/packages/components/src/components/link/link.e2e.ts
@@ -1,17 +1,13 @@
 // @ts-strict-ignore
 import { newE2EPage, E2EPage, E2EElement } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it, beforeEach } from "vitest";
-import { accessible, disabled, focusable, hidden, renders, themed } from "../../tests/commonTests";
+import { accessible, disabled, focusable, renders, themed } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 import { CSS } from "./resources";
 
 describe("calcite-link", () => {
   describe("renders", () => {
     renders("<calcite-link href='/'>link</calcite-link>", { display: "inline" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-link");
   });
 
   describe("accessible", () => {

--- a/packages/components/src/components/list-item-group/list-item-group.browser.e2e.tsx
+++ b/packages/components/src/components/list-item-group/list-item-group.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults } from "../../tests/commonTests/browser";
+import { defaults, hidden } from "../../tests/commonTests/browser";
 
 describe("calcite-list-item-group", () => {
   describe("defaults", () => {
@@ -25,5 +25,9 @@ describe("calcite-list-item-group", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-list-item-group"));
   });
 });

--- a/packages/components/src/components/list-item-group/list-item-group.e2e.ts
+++ b/packages/components/src/components/list-item-group/list-item-group.e2e.ts
@@ -1,15 +1,11 @@
 import { describe } from "vitest";
-import { hidden, renders, disabled, themed } from "../../tests/commonTests";
+import { renders, disabled, themed } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 import { CSS } from "./resources";
 
 describe("calcite-list-item-group", () => {
   describe("renders", () => {
     renders("calcite-list-item-group", { display: "flex" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-list-item-group");
   });
 
   describe("disabled", () => {

--- a/packages/components/src/components/list-item/list-item.browser.e2e.tsx
+++ b/packages/components/src/components/list-item/list-item.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults, reflects } from "../../tests/commonTests/browser";
+import { defaults, reflects, hidden } from "../../tests/commonTests/browser";
 
 describe("calcite-list-item", () => {
   describe("defaults", () => {
@@ -113,5 +113,9 @@ describe("calcite-list-item", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-list-item"));
   });
 });

--- a/packages/components/src/components/list-item/list-item.e2e.ts
+++ b/packages/components/src/components/list-item/list-item.e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
-import { disabled, focusable, hidden, renders, slots, themed } from "../../tests/commonTests";
+import { disabled, focusable, renders, slots, themed } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 import { CSS, SLOTS } from "./resources";
 
@@ -13,10 +13,6 @@ describe("calcite-list-item", () => {
     focusable("<calcite-list-item active></calcite-list-item>", {
       shadowFocusTargetSelector: `.${CSS.container}`,
     });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-list-item");
   });
 
   describe("slots", () => {

--- a/packages/components/src/components/list/list.browser.e2e.tsx
+++ b/packages/components/src/components/list/list.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { cancelable, defaults, reflects } from "../../tests/commonTests/browser";
+import { cancelable, defaults, reflects, hidden } from "../../tests/commonTests/browser";
 
 describe("calcite-list", () => {
   describe("cancelable", () => {
@@ -97,5 +97,9 @@ describe("calcite-list", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-list"));
   });
 });

--- a/packages/components/src/components/list/list.e2e.ts
+++ b/packages/components/src/components/list/list.e2e.ts
@@ -1,7 +1,7 @@
 // @ts-strict-ignore
 import { E2EPage, newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
-import { accessible, disabled, focusable, hidden, renders, t9n, themed } from "../../tests/commonTests";
+import { accessible, disabled, focusable, renders, t9n, themed } from "../../tests/commonTests";
 import { placeholderImage } from "../../../.storybook/placeholder-image";
 import { html } from "../../../support/formatting";
 import { activeCellTestAttribute, CSS as ListItemCSS } from "../list-item/resources";
@@ -41,10 +41,6 @@ describe("calcite-list", () => {
         focusTargetSelector: "calcite-list-item",
       },
     );
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-list");
   });
 
   describe("translation support", () => {

--- a/packages/components/src/components/loader/loader.browser.e2e.tsx
+++ b/packages/components/src/components/loader/loader.browser.e2e.tsx
@@ -1,0 +1,9 @@
+import { describe } from "vitest";
+import { mount } from "@arcgis/lumina-compiler/testing";
+import { hidden } from "../../tests/commonTests/browser";
+
+describe("calcite-loader", () => {
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-loader"));
+  });
+});

--- a/packages/components/src/components/loader/loader.e2e.ts
+++ b/packages/components/src/components/loader/loader.e2e.ts
@@ -1,7 +1,7 @@
 // @ts-strict-ignore
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
-import { hidden, renders, themed } from "../../tests/commonTests";
+import { renders, themed } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 import { CSS } from "./resources";
 
@@ -9,10 +9,6 @@ describe("calcite-loader", () => {
   describe("renders", () => {
     renders(`<calcite-loader></calcite-loader>`, { display: "flex", visible: true });
     renders(`<calcite-loader inline></calcite-loader>`, { display: "flex", visible: true });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-loader");
   });
 
   it("displays label from text prop", async () => {

--- a/packages/components/src/components/menu-item/menu-item.browser.e2e.tsx
+++ b/packages/components/src/components/menu-item/menu-item.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { reflects } from "../../tests/commonTests/browser";
+import { reflects, hidden } from "../../tests/commonTests/browser";
 
 describe("calcite-menu-item", () => {
   describe("reflects", () => {
@@ -17,5 +17,9 @@ describe("calcite-menu-item", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-menu-item"));
   });
 });

--- a/packages/components/src/components/menu-item/menu-item.e2e.ts
+++ b/packages/components/src/components/menu-item/menu-item.e2e.ts
@@ -1,7 +1,7 @@
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import { html } from "../../../support/formatting";
-import { accessible, focusable, hidden, renders, t9n, themed } from "../../tests/commonTests";
+import { accessible, focusable, renders, t9n, themed } from "../../tests/commonTests";
 import { getFocusedElementProp } from "../../tests/utils/puppeteer";
 import { ComponentTestTokens } from "../../tests/commonTests/themed";
 import { CSS, SLOTS } from "../../../src/components/menu-item/resources";
@@ -10,10 +10,6 @@ import { Layout } from "./interfaces";
 describe("calcite-menu-item", () => {
   describe("renders", () => {
     renders("calcite-menu-item", { display: "flex" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-menu-item");
   });
 
   describe("accessible", () => {

--- a/packages/components/src/components/menu/menu.browser.e2e.tsx
+++ b/packages/components/src/components/menu/menu.browser.e2e.tsx
@@ -1,0 +1,16 @@
+import { h } from "@arcgis/lumina";
+import { describe } from "vitest";
+import { mount } from "@arcgis/lumina-compiler/testing";
+import { hidden } from "../../tests/commonTests/browser";
+
+describe("calcite-menu", () => {
+  describe("honors hidden attribute", () => {
+    hidden(() =>
+      mount(
+        <calcite-menu>
+          <calcite-menu-item text="calcite" />
+        </calcite-menu>,
+      ),
+    );
+  });
+});

--- a/packages/components/src/components/menu/menu.e2e.ts
+++ b/packages/components/src/components/menu/menu.e2e.ts
@@ -2,7 +2,7 @@
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import { html } from "../../../support/formatting";
-import { accessible, focusable, hidden, renders, t9n } from "../../tests/commonTests";
+import { accessible, focusable, renders, t9n } from "../../tests/commonTests";
 import { getFocusedElementProp } from "../../tests/utils/puppeteer";
 
 describe("calcite-menu", () => {
@@ -10,10 +10,6 @@ describe("calcite-menu", () => {
     renders(html`<calcite-menu><calcite-menu-item text="calcite"></calcite-menu-item></calcite-menu>`, {
       display: "flex",
     });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden(html`<calcite-menu><calcite-menu-item text="calcite"></calcite-menu-item></calcite-menu>`);
   });
 
   describe("accessible", () => {

--- a/packages/components/src/components/meter/meter.browser.e2e.tsx
+++ b/packages/components/src/components/meter/meter.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults, reflects } from "../../tests/commonTests/browser";
+import { defaults, hidden, reflects } from "../../tests/commonTests/browser";
 
 describe("calcite-meter", () => {
   describe("defaults", () => {
@@ -53,6 +53,10 @@ describe("calcite-meter", () => {
         },
       ],
     );
+  });
+
+  describe("hidden", () => {
+    hidden(() => mount("calcite-meter"));
   });
 
   describe("reflects", () => {

--- a/packages/components/src/components/meter/meter.e2e.ts
+++ b/packages/components/src/components/meter/meter.e2e.ts
@@ -1,16 +1,12 @@
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import { html } from "../../../support/formatting";
-import { accessible, renders, hidden, themed } from "../../tests/commonTests";
+import { accessible, renders, themed } from "../../tests/commonTests";
 import { CSS } from "./resources";
 
 describe("calcite-meter", () => {
   describe("renders", () => {
     renders("calcite-meter", { display: "flex" });
-  });
-
-  describe("hidden", () => {
-    hidden("calcite-meter");
   });
 
   describe("accessible", () => {

--- a/packages/components/src/components/navigation-logo/navigation-logo.browser.e2e.tsx
+++ b/packages/components/src/components/navigation-logo/navigation-logo.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults, reflects } from "../../tests/commonTests/browser";
+import { defaults, reflects, hidden } from "../../tests/commonTests/browser";
 
 describe("calcite-navigation-logo", () => {
   describe("defaults", () => {
@@ -57,5 +57,9 @@ describe("calcite-navigation-logo", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-navigation-logo"));
   });
 });

--- a/packages/components/src/components/navigation-logo/navigation-logo.e2e.ts
+++ b/packages/components/src/components/navigation-logo/navigation-logo.e2e.ts
@@ -1,16 +1,12 @@
 import { describe } from "vitest";
 import { html } from "../../../support/formatting";
-import { accessible, focusable, hidden, renders } from "../../tests/commonTests";
+import { accessible, focusable, renders } from "../../tests/commonTests";
 import { ComponentTestTokens, themed } from "../../tests/commonTests/themed";
 import { CSS } from "./resources";
 
 describe("calcite-navigation-logo", () => {
   describe("renders", () => {
     renders("calcite-navigation-logo", { display: "inline-flex" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-navigation-logo");
   });
 
   describe("accessible", () => {

--- a/packages/components/src/components/navigation-user/navigation-user.browser.e2e.tsx
+++ b/packages/components/src/components/navigation-user/navigation-user.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults, reflects } from "../../tests/commonTests/browser";
+import { defaults, reflects, hidden } from "../../tests/commonTests/browser";
 
 describe("calcite-navigation-user", () => {
   describe("defaults", () => {
@@ -29,5 +29,9 @@ describe("calcite-navigation-user", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-navigation-user"));
   });
 });

--- a/packages/components/src/components/navigation-user/navigation-user.e2e.ts
+++ b/packages/components/src/components/navigation-user/navigation-user.e2e.ts
@@ -1,17 +1,13 @@
 import { describe } from "vitest";
 import { boolean } from "../../../.storybook/utils";
 import { html } from "../../../support/formatting";
-import { accessible, focusable, hidden, renders } from "../../tests/commonTests";
+import { accessible, focusable, renders } from "../../tests/commonTests";
 import { ComponentTestTokens, themed } from "../../tests/commonTests/themed";
 import { CSS } from "./resources";
 
 describe("calcite-navigation-user", () => {
   describe("renders", () => {
     renders("calcite-navigation-user", { display: "inline-flex" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-navigation-user");
   });
 
   describe("accessible", () => {

--- a/packages/components/src/components/navigation/navigation.browser.e2e.tsx
+++ b/packages/components/src/components/navigation/navigation.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults, reflects } from "../../tests/commonTests/browser";
+import { defaults, reflects, hidden } from "../../tests/commonTests/browser";
 
 describe("calcite-navigation", () => {
   describe("defaults", () => {
@@ -25,5 +25,9 @@ describe("calcite-navigation", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-navigation"));
   });
 });

--- a/packages/components/src/components/navigation/navigation.e2e.ts
+++ b/packages/components/src/components/navigation/navigation.e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
-import { accessible, focusable, hidden, renders } from "../../tests/commonTests";
+import { accessible, focusable, renders } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 import { ComponentTestTokens, themed } from "../../tests/commonTests/themed";
 import { CSS } from "./resources";
@@ -8,10 +8,6 @@ import { CSS } from "./resources";
 describe("calcite-navigation", () => {
   describe("renders", () => {
     renders("calcite-navigation", { display: "block" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-navigation");
   });
 
   describe("is focusable", () => {

--- a/packages/components/src/components/notice/notice.browser.e2e.tsx
+++ b/packages/components/src/components/notice/notice.browser.e2e.tsx
@@ -1,0 +1,9 @@
+import { describe } from "vitest";
+import { mount } from "@arcgis/lumina-compiler/testing";
+import { hidden } from "../../tests/commonTests/browser";
+
+describe("calcite-notice", () => {
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-notice"));
+  });
+});

--- a/packages/components/src/components/notice/notice.e2e.ts
+++ b/packages/components/src/components/notice/notice.e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
-import { accessible, focusable, renders, slots, hidden, themed, t9n } from "../../tests/commonTests";
+import { accessible, focusable, renders, slots, themed, t9n } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 import { openClose } from "../../tests/commonTests";
 import { CSS, SLOTS } from "./resources";
@@ -14,10 +14,6 @@ describe("calcite-notice", () => {
 
   describe("renders", () => {
     renders(`<calcite-notice open>${noticeContent}</calcite-notice>`, { display: "flex" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-notice");
   });
 
   describe("accessible", () => {

--- a/packages/components/src/components/option-group/option-group.browser.e2e.tsx
+++ b/packages/components/src/components/option-group/option-group.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults, reflects } from "../../tests/commonTests/browser";
+import { defaults, reflects, hidden } from "../../tests/commonTests/browser";
 
 describe("calcite-option-group", () => {
   describe("defaults", () => {
@@ -25,5 +25,9 @@ describe("calcite-option-group", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-option-group"));
   });
 });

--- a/packages/components/src/components/option-group/option-group.e2e.ts
+++ b/packages/components/src/components/option-group/option-group.e2e.ts
@@ -1,15 +1,11 @@
 // @ts-strict-ignore
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
-import { accessible, renders, hidden } from "../../tests/commonTests";
+import { accessible, renders } from "../../tests/commonTests";
 
 describe("calcite-option-group", () => {
   describe("renders", () => {
     renders("calcite-option-group", { display: "block" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-option-group");
   });
 
   describe("accessible", () => {

--- a/packages/components/src/components/option/option.browser.e2e.tsx
+++ b/packages/components/src/components/option/option.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults, reflects } from "../../tests/commonTests/browser";
+import { defaults, reflects, hidden } from "../../tests/commonTests/browser";
 
 describe("calcite-option", () => {
   describe("defaults", () => {
@@ -29,5 +29,9 @@ describe("calcite-option", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-option"));
   });
 });

--- a/packages/components/src/components/option/option.e2e.ts
+++ b/packages/components/src/components/option/option.e2e.ts
@@ -1,7 +1,7 @@
 // @ts-strict-ignore
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
-import { accessible, renders, hidden } from "../../tests/commonTests";
+import { accessible, renders } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 import { findAll } from "../../tests/utils/puppeteer";
 import type { Option } from "./option";
@@ -9,10 +9,6 @@ import type { Option } from "./option";
 describe("calcite-option", () => {
   describe("renders", () => {
     renders("calcite-option", { display: "inline" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-option");
   });
 
   describe("accessible", () => {

--- a/packages/components/src/components/pagination/pagination.browser.e2e.tsx
+++ b/packages/components/src/components/pagination/pagination.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults } from "../../tests/commonTests/browser";
+import { defaults, hidden } from "../../tests/commonTests/browser";
 
 describe("calcite-pagination", () => {
   describe("defaults", () => {
@@ -17,5 +17,9 @@ describe("calcite-pagination", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-pagination"));
   });
 });

--- a/packages/components/src/components/pagination/pagination.e2e.ts
+++ b/packages/components/src/components/pagination/pagination.e2e.ts
@@ -2,7 +2,7 @@
 import { E2EElement, E2EPage, newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { beforeEach, describe, expect, it } from "vitest";
 import { html } from "../../../support/formatting";
-import { accessible, focusable, hidden, renders, t9n, themed } from "../../tests/commonTests";
+import { accessible, focusable, renders, t9n, themed } from "../../tests/commonTests";
 import { findAll } from "../../tests/utils/puppeteer";
 import { CSS } from "./resources";
 
@@ -21,10 +21,6 @@ describe("calcite-pagination", () => {
     focusable('<calcite-pagination page-size="1" start-item="1" total-items="10"></calcite-pagination>', {
       shadowFocusTargetSelector: `.${CSS.page}`,
     });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-pagination");
   });
 
   describe("accessible", () => {

--- a/packages/components/src/components/panel/panel.browser.e2e.tsx
+++ b/packages/components/src/components/panel/panel.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults, reflects } from "../../tests/commonTests/browser";
+import { defaults, reflects, hidden } from "../../tests/commonTests/browser";
 import { defaultEndMenuPlacement } from "../../utils/floating-ui";
 import { mockConsole } from "../../tests/utils/logging";
 
@@ -93,5 +93,9 @@ describe("calcite-panel", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-panel"));
   });
 });

--- a/packages/components/src/components/panel/panel.e2e.ts
+++ b/packages/components/src/components/panel/panel.e2e.ts
@@ -7,7 +7,6 @@ import {
   delegatesToFloatingUiOwningComponent,
   disabled,
   focusable,
-  hidden,
   renders,
   slots,
   t9n,
@@ -93,10 +92,6 @@ describe("calcite-panel", () => {
 
   describe("renders", () => {
     renders("calcite-panel", { display: "flex" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-panel");
   });
 
   describe("handles action-menu placement and flipPlacements", () => {

--- a/packages/components/src/components/popover/popover.browser.e2e.tsx
+++ b/packages/components/src/components/popover/popover.browser.e2e.tsx
@@ -1,6 +1,7 @@
+import { h } from "@arcgis/lumina";
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults } from "../../tests/commonTests/browser";
+import { defaults, hidden } from "../../tests/commonTests/browser";
 import { mockConsole } from "../../tests/utils/logging";
 
 describe("calcite-popover", () => {
@@ -48,5 +49,9 @@ describe("calcite-popover", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount(<calcite-popover open />));
   });
 });

--- a/packages/components/src/components/popover/popover.e2e.ts
+++ b/packages/components/src/components/popover/popover.e2e.ts
@@ -2,16 +2,7 @@
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import { html } from "../../../support/formatting";
-import {
-  accessible,
-  floatingUIOwner,
-  focusable,
-  hidden,
-  openClose,
-  renders,
-  t9n,
-  themed,
-} from "../../tests/commonTests";
+import { accessible, floatingUIOwner, focusable, openClose, renders, t9n, themed } from "../../tests/commonTests";
 import { skipAnimations } from "../../tests/utils/puppeteer";
 import { FloatingCSS } from "../../utils/floating-ui";
 import { mockConsole } from "../../tests/utils/logging";
@@ -47,10 +38,6 @@ describe("calcite-popover", () => {
     accessible(
       `<calcite-popover label="test" open closable reference-element="ref"></calcite-popover><div id="ref">😄</div>`,
     );
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden(`<calcite-popover open></calcite-popover>`);
   });
 
   describe("openClose", () => {

--- a/packages/components/src/components/progress/progress.browser.e2e.tsx
+++ b/packages/components/src/components/progress/progress.browser.e2e.tsx
@@ -1,0 +1,9 @@
+import { describe } from "vitest";
+import { mount } from "@arcgis/lumina-compiler/testing";
+import { hidden } from "../../tests/commonTests/browser";
+
+describe("calcite-progress", () => {
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-progress"));
+  });
+});

--- a/packages/components/src/components/progress/progress.e2e.ts
+++ b/packages/components/src/components/progress/progress.e2e.ts
@@ -1,15 +1,11 @@
 import { describe } from "vitest";
 import { html } from "../../../support/formatting";
-import { accessible, hidden, renders, themed } from "../../tests/commonTests";
+import { accessible, renders, themed } from "../../tests/commonTests";
 import { CSS } from "./resources";
 
 describe("calcite-progress", () => {
   describe("renders", () => {
     renders("calcite-progress", { display: "block" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-progress");
   });
 
   describe("accessible", () => {

--- a/packages/components/src/components/radio-button-group/radio-button-group.browser.e2e.tsx
+++ b/packages/components/src/components/radio-button-group/radio-button-group.browser.e2e.tsx
@@ -1,6 +1,10 @@
-import { describe } from "vitest";
+import { Fragment, h } from "@arcgis/lumina";
+import { describe, expect, it } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults, reflects } from "../../tests/commonTests/browser";
+import { userEvent } from "@vitest/browser/context";
+import { defaults, reflects, hidden } from "../../tests/commonTests/browser";
+import { RadioButton } from "../radio-button/radio-button";
+import { RadioButtonGroup } from "./radio-button-group";
 
 describe("calcite-radio-button-group", () => {
   describe("defaults", () => {
@@ -30,5 +34,68 @@ describe("calcite-radio-button-group", () => {
         { propertyName: "validationIcon", value: true },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-radio-button-group"));
+
+    it("honors hidden attribute when navigating", async () => {
+      const { container } = await mount<RadioButtonGroup>(
+        <Fragment>
+          <calcite-radio-button-group name="first">
+            <calcite-label>
+              1-1
+              <calcite-radio-button value="first" />
+            </calcite-label>
+            <calcite-label>
+              1-2
+              <calcite-radio-button value="second" />
+            </calcite-label>
+            <calcite-label>
+              1-3
+              <calcite-radio-button value="third" />
+            </calcite-label>
+          </calcite-radio-button-group>
+          <calcite-radio-button-group hidden name="second">
+            <calcite-label>
+              2-1
+              <calcite-radio-button value="first" />
+            </calcite-label>
+            <calcite-label>
+              2-2
+              <calcite-radio-button value="second" />
+            </calcite-label>
+            <calcite-label>
+              2-3
+              <calcite-radio-button value="third" />
+            </calcite-label>
+          </calcite-radio-button-group>
+          <calcite-radio-button-group name="third">
+            <calcite-label>
+              3-1
+              <calcite-radio-button value="first" />
+            </calcite-label>
+            <calcite-label>
+              3-2
+              <calcite-radio-button value="second" />
+            </calcite-label>
+            <calcite-label>
+              3-3
+              <calcite-radio-button value="third" />
+            </calcite-label>
+          </calcite-radio-button-group>
+        </Fragment>,
+      );
+
+      const firstElement = container.querySelector("calcite-radio-button")!;
+      await userEvent.click(firstElement);
+      await userEvent.tab();
+
+      const selected = container.querySelector<RadioButton["el"]>("calcite-radio-button[focused]")!;
+      const { name, value } = selected;
+
+      expect(name).toBe("third");
+      expect(value).toBe("first");
+    });
   });
 });

--- a/packages/components/src/components/radio-button-group/radio-button-group.e2e.ts
+++ b/packages/components/src/components/radio-button-group/radio-button-group.e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
-import { accessible, focusable, hidden, internalLabel, renders, themed, t9n } from "../../tests/commonTests";
+import { accessible, focusable, internalLabel, renders, themed, t9n } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 import { findAll, getFocusedElementProp } from "../../tests/utils/puppeteer";
 import type { RadioButton } from "../radio-button/radio-button";
@@ -35,69 +35,6 @@ describe("calcite-radio-button-group", () => {
 
   describe("InternalLabel", () => {
     internalLabel(`calcite-radio-button-group`);
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-radio-button");
-
-    it("honors hidden attribute when navigating", async () => {
-      const page = await newE2EPage();
-      await page.setContent(html`
-        <calcite-radio-button-group name="first">
-          <calcite-label>
-            1-1
-            <calcite-radio-button value="first"></calcite-radio-button>
-          </calcite-label>
-          <calcite-label>
-            1-2
-            <calcite-radio-button value="second"></calcite-radio-button>
-          </calcite-label>
-          <calcite-label>
-            1-3
-            <calcite-radio-button value="third"></calcite-radio-button>
-          </calcite-label>
-        </calcite-radio-button-group>
-        <calcite-radio-button-group name="second" hidden>
-          <calcite-label>
-            2-1
-            <calcite-radio-button value="first"></calcite-radio-button>
-          </calcite-label>
-          <calcite-label>
-            2-2
-            <calcite-radio-button value="second"></calcite-radio-button>
-          </calcite-label>
-          <calcite-label>
-            2-3
-            <calcite-radio-button value="third"></calcite-radio-button>
-          </calcite-label>
-        </calcite-radio-button-group>
-        <calcite-radio-button-group name="third">
-          <calcite-label>
-            3-1
-            <calcite-radio-button value="first"></calcite-radio-button>
-          </calcite-label>
-          <calcite-label>
-            3-2
-            <calcite-radio-button value="second"></calcite-radio-button>
-          </calcite-label>
-          <calcite-label>
-            3-3
-            <calcite-radio-button value="third"></calcite-radio-button>
-          </calcite-label>
-        </calcite-radio-button-group>
-      `);
-
-      const firstElement = await page.find("calcite-radio-button");
-      await firstElement.click();
-      await firstElement.press("Tab");
-      await page.waitForChanges();
-
-      const selected = await page.find("calcite-radio-button[focused]");
-      const name = await selected.getProperty("name");
-      const value = await selected.getProperty("value");
-      expect(name).toBe("third");
-      expect(value).toBe("first");
-    });
   });
 
   it("has a radio input for form compatibility", async () => {

--- a/packages/components/src/components/radio-button/radio-button.browser.e2e.tsx
+++ b/packages/components/src/components/radio-button/radio-button.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults, reflects } from "../../tests/commonTests/browser";
+import { defaults, reflects, hidden } from "../../tests/commonTests/browser";
 
 describe("calcite-radio-button", () => {
   describe("defaults", () => {
@@ -20,5 +20,9 @@ describe("calcite-radio-button", () => {
         { propertyName: "scale", value: "m" },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-radio-button"));
   });
 });

--- a/packages/components/src/components/radio-button/radio-button.e2e.ts
+++ b/packages/components/src/components/radio-button/radio-button.e2e.ts
@@ -6,7 +6,6 @@ import {
   disabled,
   focusable,
   formAssociated,
-  hidden,
   internalLabel,
   labelable,
   renders,
@@ -31,10 +30,6 @@ describe("calcite-radio-button", () => {
 
   describe("accessible without calcite-label", () => {
     accessible(`<calcite-radio-button label="label" id="example" name="example" value="one"></calcite-radio-button>`);
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-radio-button");
   });
 
   describe("labelable", () => {

--- a/packages/components/src/components/rating/rating.browser.e2e.tsx
+++ b/packages/components/src/components/rating/rating.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults, reflects } from "../../tests/commonTests/browser";
+import { defaults, reflects, hidden } from "../../tests/commonTests/browser";
 
 describe("calcite-rating", () => {
   describe("defaults", () => {
@@ -33,5 +33,9 @@ describe("calcite-rating", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-rating"));
   });
 });

--- a/packages/components/src/components/rating/rating.e2e.ts
+++ b/packages/components/src/components/rating/rating.e2e.ts
@@ -5,7 +5,6 @@ import {
   disabled,
   focusable,
   formAssociated,
-  hidden,
   internalLabel,
   labelable,
   renders,
@@ -20,10 +19,6 @@ describe("calcite-rating", () => {
   describe("common tests", () => {
     describe("renders", () => {
       renders("<calcite-rating></calcite-rating>", { display: "flex" });
-    });
-
-    describe("honors hidden attribute", () => {
-      hidden("calcite-rating");
     });
 
     describe("accessible", () => {

--- a/packages/components/src/components/scrim/scrim.browser.e2e.tsx
+++ b/packages/components/src/components/scrim/scrim.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults } from "../../tests/commonTests/browser";
+import { defaults, hidden } from "../../tests/commonTests/browser";
 import { mockConsole } from "../../tests/utils/logging";
 
 describe("calcite-scrim", () => {
@@ -16,5 +16,9 @@ describe("calcite-scrim", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-scrim"));
   });
 });

--- a/packages/components/src/components/scrim/scrim.e2e.ts
+++ b/packages/components/src/components/scrim/scrim.e2e.ts
@@ -1,7 +1,7 @@
 // @ts-strict-ignore
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
-import { accessible, hidden, renders, t9n } from "../../tests/commonTests";
+import { accessible, renders, t9n } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 import { Scale } from "../interfaces";
 import { mockConsole } from "../../tests/utils/logging";
@@ -12,10 +12,6 @@ describe("calcite-scrim", () => {
 
   describe("renders", () => {
     renders("<calcite-scrim></calcite-scrim>", { display: "flex" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-scrim");
   });
 
   describe("accessible", () => {

--- a/packages/components/src/components/segmented-control-item/segmented-control-item.browser.e2e.tsx
+++ b/packages/components/src/components/segmented-control-item/segmented-control-item.browser.e2e.tsx
@@ -1,0 +1,9 @@
+import { describe } from "vitest";
+import { mount } from "@arcgis/lumina-compiler/testing";
+import { hidden } from "../../tests/commonTests/browser";
+
+describe("calcite-segmented-control-item", () => {
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-segmented-control-item"));
+  });
+});

--- a/packages/components/src/components/segmented-control-item/segmented-control-item.e2e.ts
+++ b/packages/components/src/components/segmented-control-item/segmented-control-item.e2e.ts
@@ -1,16 +1,12 @@
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
-import { renders, hidden, themed } from "../../tests/commonTests";
+import { renders, themed } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 import { CSS } from "./resources";
 
 describe("calcite-segmented-control-item", () => {
   describe("renders", () => {
     renders("calcite-segmented-control-item", { display: "flex" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-segmented-control-item");
   });
 
   it("is un-checked by default", async () => {

--- a/packages/components/src/components/segmented-control/segmented-control.browser.e2e.tsx
+++ b/packages/components/src/components/segmented-control/segmented-control.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults, reflects } from "../../tests/commonTests/browser";
+import { defaults, reflects, hidden } from "../../tests/commonTests/browser";
 
 describe("calcite-segmented-control", () => {
   describe("defaults", () => {
@@ -70,5 +70,9 @@ describe("calcite-segmented-control", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-segmented-control"));
   });
 });

--- a/packages/components/src/components/segmented-control/segmented-control.e2e.ts
+++ b/packages/components/src/components/segmented-control/segmented-control.e2e.ts
@@ -6,7 +6,6 @@ import {
   disabled,
   focusable,
   formAssociated,
-  hidden,
   internalLabel,
   labelable,
   renders,
@@ -20,10 +19,6 @@ import { CSS } from "./resources";
 describe("calcite-segmented-control", () => {
   describe("renders", () => {
     renders("calcite-segmented-control", { display: "flex" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-segmented-control");
   });
 
   describe("labelable", () => {

--- a/packages/components/src/components/select/select.browser.e2e.tsx
+++ b/packages/components/src/components/select/select.browser.e2e.tsx
@@ -1,7 +1,7 @@
 import { h } from "@arcgis/lumina";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import { describe } from "vitest";
-import { defaults, reflects } from "../../tests/commonTests/browser";
+import { defaults, reflects, hidden } from "../../tests/commonTests/browser";
 import { Select } from "./select";
 
 describe("calcite-select", () => {
@@ -46,5 +46,9 @@ describe("calcite-select", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-select"));
   });
 });

--- a/packages/components/src/components/select/select.e2e.ts
+++ b/packages/components/src/components/select/select.e2e.ts
@@ -6,7 +6,6 @@ import {
   disabled,
   focusable,
   formAssociated,
-  hidden,
   internalLabel,
   labelable,
   renders,
@@ -29,10 +28,6 @@ describe("calcite-select", () => {
 
   describe("renders", () => {
     renders(simpleTestMarkup, { display: "flex" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-select");
   });
 
   describe("accessible", () => {

--- a/packages/components/src/components/sheet/sheet.browser.e2e.tsx
+++ b/packages/components/src/components/sheet/sheet.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults, reflects } from "../../tests/commonTests/browser";
+import { defaults, reflects, hidden } from "../../tests/commonTests/browser";
 import { mockConsole } from "../../tests/utils/logging";
 
 describe("calcite-sheet", () => {
@@ -84,5 +84,9 @@ describe("calcite-sheet", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-sheet"));
   });
 });

--- a/packages/components/src/components/sheet/sheet.e2e.ts
+++ b/packages/components/src/components/sheet/sheet.e2e.ts
@@ -2,7 +2,7 @@
 import { E2EElement, E2EPage, newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { html } from "../../../support/formatting";
-import { accessible, focusable, hidden, openClose, renders, themed } from "../../tests/commonTests";
+import { accessible, focusable, openClose, renders, themed } from "../../tests/commonTests";
 import { GlobalTestProps, skipAnimations } from "../../tests/utils/puppeteer";
 import { resizeStep, resizeShiftStep } from "../../utils/resources";
 import { focusTrap } from "../../tests/commonTests/focusTrap";
@@ -15,10 +15,6 @@ describe("calcite-sheet", () => {
 
   describe("renders", () => {
     renders("calcite-sheet", { display: "flex", visible: false });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-sheet");
   });
 
   describe("accessible", () => {

--- a/packages/components/src/components/shell-panel/shell-panel.browser.e2e.tsx
+++ b/packages/components/src/components/shell-panel/shell-panel.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults, reflects } from "../../tests/commonTests/browser";
+import { defaults, reflects, hidden } from "../../tests/commonTests/browser";
 import { mockConsole } from "../../tests/utils/logging";
 
 describe("calcite-shell-panel", () => {
@@ -44,5 +44,9 @@ describe("calcite-shell-panel", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-shell-panel"));
   });
 });

--- a/packages/components/src/components/shell-panel/shell-panel.e2e.ts
+++ b/packages/components/src/components/shell-panel/shell-panel.e2e.ts
@@ -1,7 +1,7 @@
 // @ts-strict-ignore
 import { newE2EPage, E2EElement } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
-import { accessible, hidden, renders, slots, t9n, themed } from "../../tests/commonTests";
+import { accessible, renders, slots, t9n, themed } from "../../tests/commonTests";
 import { getElementRect, getElementXY } from "../../tests/utils/puppeteer";
 import { CSS_UTILITY } from "../../utils/resources";
 import { html } from "../../../support/formatting";
@@ -15,10 +15,6 @@ describe("calcite-shell-panel", () => {
 
   describe("renders", () => {
     renders("calcite-shell-panel", { display: "flex" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-shell-panel");
   });
 
   describe("slots", () => {

--- a/packages/components/src/components/shell/shell.browser.e2e.tsx
+++ b/packages/components/src/components/shell/shell.browser.e2e.tsx
@@ -1,0 +1,9 @@
+import { describe } from "vitest";
+import { mount } from "@arcgis/lumina-compiler/testing";
+import { hidden } from "../../tests/commonTests/browser";
+
+describe("calcite-shell", () => {
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-shell"));
+  });
+});

--- a/packages/components/src/components/shell/shell.e2e.ts
+++ b/packages/components/src/components/shell/shell.e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
-import { accessible, hidden, renders, slots, themed } from "../../tests/commonTests";
+import { accessible, renders, slots, themed } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 import { getFocusedElementProp } from "../../tests/utils/puppeteer";
 import { mockConsole } from "../../tests/utils/logging";
@@ -9,10 +9,6 @@ import { CSS, SLOTS } from "./resources";
 describe("calcite-shell", () => {
   describe("renders", () => {
     renders("calcite-shell", { display: "flex" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-shell");
   });
 
   describe("slots", () => {

--- a/packages/components/src/components/slider/slider.browser.e2e.tsx
+++ b/packages/components/src/components/slider/slider.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults, reflects } from "../../tests/commonTests/browser";
+import { defaults, reflects, hidden } from "../../tests/commonTests/browser";
 
 describe("calcite-slider", () => {
   describe("defaults", () => {
@@ -80,5 +80,9 @@ describe("calcite-slider", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-slider"));
   });
 });

--- a/packages/components/src/components/slider/slider.e2e.ts
+++ b/packages/components/src/components/slider/slider.e2e.ts
@@ -2,16 +2,7 @@
 import { E2EElement, E2EPage, EventSpy, newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { beforeEach, describe, expect, it } from "vitest";
 import { html } from "../../../support/formatting";
-import {
-  disabled,
-  formAssociated,
-  hidden,
-  internalLabel,
-  labelable,
-  renders,
-  t9n,
-  themed,
-} from "../../tests/commonTests";
+import { disabled, formAssociated, internalLabel, labelable, renders, t9n, themed } from "../../tests/commonTests";
 import { findAll, getElementRect, getElementXY, isElementFocused } from "../../tests/utils/puppeteer";
 import { CSS } from "./resources";
 import type { Slider } from "./slider";
@@ -21,10 +12,6 @@ describe("calcite-slider", () => {
 
   describe("renders", () => {
     renders("calcite-slider", { display: "block" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-slider");
   });
 
   describe("labelable", () => {

--- a/packages/components/src/components/sort-handle/sort-handle.browser.e2e.tsx
+++ b/packages/components/src/components/sort-handle/sort-handle.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults, reflects } from "../../tests/commonTests/browser";
+import { defaults, reflects, hidden } from "../../tests/commonTests/browser";
 
 describe("calcite-sort-handle", () => {
   describe("defaults", () => {
@@ -41,5 +41,9 @@ describe("calcite-sort-handle", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-sort-handle"));
   });
 });

--- a/packages/components/src/components/sort-handle/sort-handle.e2e.ts
+++ b/packages/components/src/components/sort-handle/sort-handle.e2e.ts
@@ -1,7 +1,7 @@
 // @ts-strict-ignore
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
-import { accessible, disabled, hidden, renders, t9n, openClose, focusable } from "../../tests/commonTests";
+import { accessible, disabled, renders, t9n, openClose, focusable } from "../../tests/commonTests";
 import { skipAnimations } from "../../tests/utils/puppeteer";
 import T9nStrings from "./assets/t9n/messages.en.json";
 import { CSS, IDS, REORDER_VALUES, SUBSTITUTIONS } from "./resources";
@@ -11,10 +11,6 @@ import type { ReorderEventDetail } from "./interfaces";
 describe("calcite-sort-handle", () => {
   describe("renders", () => {
     renders("calcite-sort-handle", { display: "flex" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-sort-handle");
   });
 
   describe("disabled", () => {

--- a/packages/components/src/components/sortable-list/sortable-list.browser.e2e.tsx
+++ b/packages/components/src/components/sortable-list/sortable-list.browser.e2e.tsx
@@ -1,0 +1,9 @@
+import { describe } from "vitest";
+import { mount } from "@arcgis/lumina-compiler/testing";
+import { hidden } from "../../tests/commonTests/browser";
+
+describe("calcite-sortable-list", () => {
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-sortable-list"));
+  });
+});

--- a/packages/components/src/components/sortable-list/sortable-list.e2e.ts
+++ b/packages/components/src/components/sortable-list/sortable-list.e2e.ts
@@ -1,16 +1,12 @@
 import { E2EPage, newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { beforeEach, describe, expect, it } from "vitest";
-import { accessible, disabled, hidden, renders } from "../../tests/commonTests";
+import { accessible, disabled, renders } from "../../tests/commonTests";
 import { dragAndDrop, findAll } from "../../tests/utils/puppeteer";
 import { html } from "../../../support/formatting";
 
 describe("calcite-sortable-list", () => {
   describe("renders", () => {
     renders("calcite-sortable-list", { display: "flex" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-sortable-list");
   });
 
   describe("accessible", () => {

--- a/packages/components/src/components/split-button/split-button.browser.e2e.tsx
+++ b/packages/components/src/components/split-button/split-button.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults, reflects } from "../../tests/commonTests/browser";
+import { defaults, reflects, hidden } from "../../tests/commonTests/browser";
 
 describe("calcite-split-button", () => {
   describe("defaults", () => {
@@ -65,5 +65,9 @@ describe("calcite-split-button", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-split-button"));
   });
 });

--- a/packages/components/src/components/split-button/split-button.e2e.ts
+++ b/packages/components/src/components/split-button/split-button.e2e.ts
@@ -2,7 +2,7 @@
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import { html } from "../../../support/formatting";
-import { accessible, disabled, focusable, hidden, renders, themed } from "../../tests/commonTests";
+import { accessible, disabled, focusable, renders, themed } from "../../tests/commonTests";
 import { CSS as DropdownCSS } from "../dropdown/resources";
 import { findAll } from "../../tests/utils/puppeteer";
 import { CSS } from "./resources";
@@ -16,10 +16,6 @@ describe("calcite-split-button", () => {
 
   describe("renders", () => {
     renders("calcite-split-button", { display: "inline-block" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-split-button");
   });
 
   describe("focusable", () => {

--- a/packages/components/src/components/stack/stack.browser.e2e.tsx
+++ b/packages/components/src/components/stack/stack.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults } from "../../tests/commonTests/browser";
+import { defaults, hidden } from "../../tests/commonTests/browser";
 
 describe("calcite-stack", () => {
   describe("defaults", () => {
@@ -13,5 +13,9 @@ describe("calcite-stack", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-stack"));
   });
 });

--- a/packages/components/src/components/stack/stack.e2e.ts
+++ b/packages/components/src/components/stack/stack.e2e.ts
@@ -1,14 +1,10 @@
 import { describe } from "vitest";
-import { hidden, renders, slots } from "../../tests/commonTests";
+import { renders, slots } from "../../tests/commonTests";
 import { SLOTS } from "./resources";
 
 describe("calcite-stack", () => {
   describe("renders", () => {
     renders("calcite-stack", { display: "flex" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-stack");
   });
 
   describe("slots", () => {

--- a/packages/components/src/components/stepper-item/stepper-item.browser.e2e.tsx
+++ b/packages/components/src/components/stepper-item/stepper-item.browser.e2e.tsx
@@ -1,0 +1,9 @@
+import { describe } from "vitest";
+import { mount } from "@arcgis/lumina-compiler/testing";
+import { hidden } from "../../tests/commonTests/browser";
+
+describe("calcite-stepper-item", () => {
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-stepper-item"));
+  });
+});

--- a/packages/components/src/components/stepper-item/stepper-item.e2e.ts
+++ b/packages/components/src/components/stepper-item/stepper-item.e2e.ts
@@ -1,16 +1,12 @@
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
-import { disabled, renders, hidden, t9n, themed, focusable } from "../../tests/commonTests";
+import { disabled, renders, t9n, themed, focusable } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 import { CSS } from "./resources";
 
 describe("calcite-stepper-item", () => {
   describe("renders", () => {
     renders("calcite-stepper-item", { display: "flex" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-stepper-item");
   });
 
   describe("disabled", () => {

--- a/packages/components/src/components/stepper/stepper.browser.e2e.tsx
+++ b/packages/components/src/components/stepper/stepper.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults, reflects } from "../../tests/commonTests/browser";
+import { defaults, reflects, hidden } from "../../tests/commonTests/browser";
 
 describe("calcite-stepper", () => {
   describe("defaults", () => {
@@ -49,5 +49,9 @@ describe("calcite-stepper", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-stepper"));
   });
 });

--- a/packages/components/src/components/stepper/stepper.e2e.ts
+++ b/packages/components/src/components/stepper/stepper.e2e.ts
@@ -1,7 +1,7 @@
 // @ts-strict-ignore
 import { E2EPage, newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { hidden, renders, t9n, themed } from "../../tests/commonTests";
+import { renders, t9n, themed } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 import { NumberStringFormatOptions } from "../../utils/locale";
 import { findAll, isElementFocused } from "../../tests/utils/puppeteer";
@@ -83,10 +83,6 @@ describe("calcite-stepper", () => {
       expect(await item.getProperty("scale")).toBe("l");
       expect(await item.getProperty("numbered")).toBe(true);
     }
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-stepper");
   });
 
   it("adds selected attribute to requested item", async () => {

--- a/packages/components/src/components/swatch-group/swatch-group.browser.e2e.tsx
+++ b/packages/components/src/components/swatch-group/swatch-group.browser.e2e.tsx
@@ -1,0 +1,9 @@
+import { describe } from "vitest";
+import { mount } from "@arcgis/lumina-compiler/testing";
+import { hidden } from "../../tests/commonTests/browser";
+
+describe("calcite-swatch-group", () => {
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-swatch-group"));
+  });
+});

--- a/packages/components/src/components/swatch-group/swatch-group.e2e.ts
+++ b/packages/components/src/components/swatch-group/swatch-group.e2e.ts
@@ -1,7 +1,7 @@
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import { html } from "../../../support/formatting";
-import { accessible, renders, hidden, disabled } from "../../tests/commonTests";
+import { accessible, renders, disabled } from "../../tests/commonTests";
 import { createSelectedItemsAsserter } from "../../tests/utils/puppeteer";
 
 describe("calcite-swatch-group", () => {
@@ -9,10 +9,6 @@ describe("calcite-swatch-group", () => {
     renders("<calcite-swatch-group><calcite-swatch></calcite-swatch></calcite-swatch-group>", {
       display: "flex",
     });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-swatch-group");
   });
 
   describe("disabled", () => {

--- a/packages/components/src/components/swatch/swatch.browser.e2e.tsx
+++ b/packages/components/src/components/swatch/swatch.browser.e2e.tsx
@@ -1,0 +1,9 @@
+import { describe } from "vitest";
+import { mount } from "@arcgis/lumina-compiler/testing";
+import { hidden } from "../../tests/commonTests/browser";
+
+describe("calcite-swatch", () => {
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-swatch"));
+  });
+});

--- a/packages/components/src/components/swatch/swatch.e2e.ts
+++ b/packages/components/src/components/swatch/swatch.e2e.ts
@@ -1,16 +1,12 @@
 import { E2EPage, newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { beforeEach, describe, expect, it } from "vitest";
-import { accessible, disabled, focusable, hidden, renders, slots, themed } from "../../tests/commonTests";
+import { accessible, disabled, focusable, renders, slots, themed } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 import { CSS, IDS, SLOTS } from "./resources";
 
 describe("calcite-swatch", () => {
   describe("renders", () => {
     renders("calcite-swatch", { display: "block" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-swatch");
   });
 
   describe("accessible", () => {

--- a/packages/components/src/components/switch/switch.browser.e2e.tsx
+++ b/packages/components/src/components/switch/switch.browser.e2e.tsx
@@ -1,0 +1,9 @@
+import { describe } from "vitest";
+import { mount } from "@arcgis/lumina-compiler/testing";
+import { hidden } from "../../tests/commonTests/browser";
+
+describe("calcite-switch", () => {
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-switch"));
+  });
+});

--- a/packages/components/src/components/switch/switch.e2e.ts
+++ b/packages/components/src/components/switch/switch.e2e.ts
@@ -5,7 +5,6 @@ import {
   disabled,
   focusable,
   formAssociated,
-  hidden,
   HYDRATED_ATTR,
   internalLabel,
   labelable,
@@ -24,10 +23,6 @@ describe("calcite-switch", () => {
 
     expect(calciteSwitch).toHaveAttribute(HYDRATED_ATTR);
     expect(calciteSwitch).toHaveAttribute("checked");
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-switch");
   });
 
   describe("accessible", () => {

--- a/packages/components/src/components/tab-nav/tab-nav.browser.e2e.tsx
+++ b/packages/components/src/components/tab-nav/tab-nav.browser.e2e.tsx
@@ -1,9 +1,13 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults } from "../../tests/commonTests/browser";
+import { defaults, hidden } from "../../tests/commonTests/browser";
 
 describe("calcite-tab-nav", () => {
   describe("defaults", () => {
     defaults(() => mount("calcite-tab-nav"), [{ propertyName: "scale", defaultValue: "m" }]);
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-tab-nav"));
   });
 });

--- a/packages/components/src/components/tab-nav/tab-nav.e2e.ts
+++ b/packages/components/src/components/tab-nav/tab-nav.e2e.ts
@@ -1,7 +1,7 @@
 // @ts-strict-ignore
 import { newE2EPage, E2EPage, E2EElement, EventSpy } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it, beforeEach } from "vitest";
-import { accessible, hidden, renders, t9n, themed } from "../../tests/commonTests";
+import { accessible, renders, t9n, themed } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 import { getElementRect } from "../../tests/utils/puppeteer";
 import { CSS } from "./resources";
@@ -9,10 +9,6 @@ import { CSS } from "./resources";
 describe("calcite-tab-nav", () => {
   describe("renders", () => {
     renders("calcite-tab-nav", { display: "flex" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-tab-nav");
   });
 
   describe("accessible: checked", () => {

--- a/packages/components/src/components/tab-title/tab-title.browser.e2e.tsx
+++ b/packages/components/src/components/tab-title/tab-title.browser.e2e.tsx
@@ -1,0 +1,9 @@
+import { describe } from "vitest";
+import { mount } from "@arcgis/lumina-compiler/testing";
+import { hidden } from "../../tests/commonTests/browser";
+
+describe("calcite-tab-title", () => {
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-tab-title"));
+  });
+});

--- a/packages/components/src/components/tab-title/tab-title.e2e.ts
+++ b/packages/components/src/components/tab-title/tab-title.e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage, E2EPage, E2EElement } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it, beforeEach } from "vitest";
-import { disabled, HYDRATED_ATTR, renders, hidden, themed } from "../../tests/commonTests";
+import { disabled, HYDRATED_ATTR, renders, themed } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 import { CSS as XButtonCSS } from "../functional/XButton";
 import { CSS } from "./resources";
@@ -45,10 +45,6 @@ describe("calcite-tab-title", () => {
   describe("renders", () => {
     renders("calcite-tab-title", { display: "block" });
     renders(multiTabTitleClosableMarkup, { display: "flex" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-tab-title");
   });
 
   describe("disabled", () => {
@@ -185,13 +181,13 @@ describe("calcite-tab-title", () => {
     });
 
     it(`when closing tab-titles in sequence 1 (first selected) through 4, 
-        tab-title and corresponding tab become hidden, 
+        tab-title and corresponding tab become hidden  
         and selection fallback is the next tab`, async () => {
       await closeTabsInSequenceOfGivenArrayOfIds(["title1", "title2", "title3", "title4"]);
     });
 
     it(`when closing tab-titles in sequence 4 (last selected) through 1, 
-        tab-title and corresponding tab become hidden, 
+        tab-title and corresponding tab become hidden  
         and selection fallback is the previous tab`, async () => {
       const arrayOfReversedIds = ["title1", "title2", "title3", "title4"].reverse();
 

--- a/packages/components/src/components/tab/tab.browser.e2e.tsx
+++ b/packages/components/src/components/tab/tab.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults } from "../../tests/commonTests/browser";
+import { defaults, hidden } from "../../tests/commonTests/browser";
 
 describe("calcite-tab", () => {
   describe("defaults", () => {
@@ -12,5 +12,9 @@ describe("calcite-tab", () => {
         { propertyName: "scale", defaultValue: "m" },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-tab"));
   });
 });

--- a/packages/components/src/components/tab/tab.e2e.ts
+++ b/packages/components/src/components/tab/tab.e2e.ts
@@ -1,5 +1,5 @@
 import { describe } from "vitest";
-import { renders, hidden, themed } from "../../tests/commonTests";
+import { renders, themed } from "../../tests/commonTests";
 import { CSS } from "./resources";
 
 describe("calcite-tab", () => {
@@ -9,10 +9,6 @@ describe("calcite-tab", () => {
   describe("renders", () => {
     renders(tabHtml, { display: "none", visible: false });
     renders(tabHtmlSelected, { display: "flex", visible: true });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-tab");
   });
 
   describe("theme", () => {

--- a/packages/components/src/components/table/table.browser.e2e.tsx
+++ b/packages/components/src/components/table/table.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults, reflects } from "../../tests/commonTests/browser";
+import { defaults, hidden, reflects } from "../../tests/commonTests/browser";
 
 describe("calcite-table", () => {
   describe("defaults", () => {
@@ -41,6 +41,10 @@ describe("calcite-table", () => {
         },
       ],
     );
+  });
+
+  describe("hidden", () => {
+    hidden(() => mount("calcite-table"));
   });
 
   describe("reflects", () => {

--- a/packages/components/src/components/table/table.e2e.ts
+++ b/packages/components/src/components/table/table.e2e.ts
@@ -2,7 +2,7 @@
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import { html } from "../../../support/formatting";
-import { accessible, renders, hidden, themed } from "../../tests/commonTests";
+import { accessible, renders, themed } from "../../tests/commonTests";
 import {
   createSelectedItemsAsserter,
   getFocusedElementProp,
@@ -40,10 +40,6 @@ describe("calcite-table", () => {
       </calcite-table>`,
       { display: "flex" },
     );
-  });
-
-  describe("hidden", () => {
-    hidden("calcite-table");
   });
 
   describe("accessible", () => {

--- a/packages/components/src/components/tabs/tabs.browser.e2e.tsx
+++ b/packages/components/src/components/tabs/tabs.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults, reflects } from "../../tests/commonTests/browser";
+import { defaults, reflects, hidden } from "../../tests/commonTests/browser";
 
 describe("calcite-tabs", () => {
   describe("defaults", () => {
@@ -23,5 +23,9 @@ describe("calcite-tabs", () => {
         { propertyName: "scale", value: "m" },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-tabs"));
   });
 });

--- a/packages/components/src/components/tabs/tabs.e2e.ts
+++ b/packages/components/src/components/tabs/tabs.e2e.ts
@@ -2,7 +2,7 @@
 import { E2EElement, E2EPage, EventSpy, newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { beforeEach, describe, expect, it } from "vitest";
 import { html } from "../../../support/formatting";
-import { accessible, hidden, renders, themed } from "../../tests/commonTests";
+import { accessible, renders, themed } from "../../tests/commonTests";
 import { findAll, GlobalTestProps } from "../../tests/utils/puppeteer";
 import { Scale } from "../interfaces";
 import { CSS as XButtonCSS } from "../functional/XButton";
@@ -29,10 +29,6 @@ describe("calcite-tabs", () => {
 
   describe("renders", () => {
     renders(tabsSnippet, { display: "flex" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-tabs");
   });
 
   describe("accessible: checked", () => {

--- a/packages/components/src/components/text-area/text-area.browser.e2e.tsx
+++ b/packages/components/src/components/text-area/text-area.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { cancelable, defaults, reflects } from "../../tests/commonTests/browser";
+import { cancelable, defaults, reflects, hidden } from "../../tests/commonTests/browser";
 
 describe("calcite-text-area", () => {
   describe("cancelable", () => {
@@ -69,5 +69,9 @@ describe("calcite-text-area", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-text-area"));
   });
 });

--- a/packages/components/src/components/text-area/text-area.e2e.ts
+++ b/packages/components/src/components/text-area/text-area.e2e.ts
@@ -6,7 +6,6 @@ import {
   disabled,
   focusable,
   formAssociated,
-  hidden,
   internalLabel,
   labelable,
   renders,
@@ -20,10 +19,6 @@ import { CSS } from "./resources";
 describe("calcite-text-area", () => {
   describe("renders", () => {
     renders("calcite-text-area", { display: "inline-block" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-text-area");
   });
 
   describe("labelable", () => {

--- a/packages/components/src/components/tile-group/tile-group.browser.e2e.tsx
+++ b/packages/components/src/components/tile-group/tile-group.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults, reflects } from "../../tests/commonTests/browser";
+import { defaults, hidden, reflects } from "../../tests/commonTests/browser";
 
 describe("calcite-tile-group", () => {
   describe("defaults", () => {
@@ -13,6 +13,10 @@ describe("calcite-tile-group", () => {
         { propertyName: "selectionMode", defaultValue: "none" },
       ],
     );
+  });
+
+  describe("hidden", () => {
+    hidden(() => mount("calcite-tile-group"));
   });
 
   describe("reflects", () => {

--- a/packages/components/src/components/tile-group/tile-group.e2e.ts
+++ b/packages/components/src/components/tile-group/tile-group.e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
-import { accessible, disabled, hidden, renders } from "../../tests/commonTests";
+import { accessible, disabled, renders } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 import { createSelectedItemsAsserter, findAll, isElementFocused } from "../../tests/utils/puppeteer";
 import type { TileGroup } from "./tile-group";
@@ -58,10 +58,6 @@ describe("calcite-tile-group", () => {
       </calcite-tile-group>`,
       { focusTarget: "child" },
     );
-  });
-
-  describe("hidden", () => {
-    hidden("calcite-tile-group");
   });
 
   describe("renders", () => {

--- a/packages/components/src/components/tile/tile.browser.e2e.tsx
+++ b/packages/components/src/components/tile/tile.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults, reflects } from "../../tests/commonTests/browser";
+import { defaults, hidden, reflects } from "../../tests/commonTests/browser";
 
 describe("calcite-tile", () => {
   describe("defaults", () => {
@@ -21,6 +21,10 @@ describe("calcite-tile", () => {
         { propertyName: "selectionMode", defaultValue: "none" },
       ],
     );
+  });
+
+  describe("hidden", () => {
+    hidden(() => mount("calcite-tile"));
   });
 
   describe("reflects", () => {

--- a/packages/components/src/components/tile/tile.e2e.ts
+++ b/packages/components/src/components/tile/tile.e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
-import { accessible, disabled, focusable, hidden, renders, slots, themed } from "../../tests/commonTests";
+import { accessible, disabled, focusable, renders, slots, themed } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 import { isElementFocused } from "../../tests/utils/puppeteer";
 import { CSS, SLOTS } from "./resources";
@@ -87,10 +87,6 @@ describe("calcite-tile", () => {
 
   describe("focusable", () => {
     focusable(html` <calcite-tile interactive></calcite-tile> `);
-  });
-
-  describe("hidden", () => {
-    hidden("calcite-tile");
   });
 
   describe("keyboard", () => {

--- a/packages/components/src/components/time-picker/time-picker.browser.e2e.tsx
+++ b/packages/components/src/components/time-picker/time-picker.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults } from "../../tests/commonTests/browser";
+import { defaults, hidden } from "../../tests/commonTests/browser";
 import { mockConsole } from "../../tests/utils/logging";
 
 describe("calcite-time-picker", () => {
@@ -15,5 +15,9 @@ describe("calcite-time-picker", () => {
         { propertyName: "step", defaultValue: 60 },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-time-picker"));
   });
 });

--- a/packages/components/src/components/time-picker/time-picker.e2e.ts
+++ b/packages/components/src/components/time-picker/time-picker.e2e.ts
@@ -1,7 +1,7 @@
 // @ts-strict-ignore
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
-import { accessible, focusable, hidden, renders, t9n, themed } from "../../tests/commonTests";
+import { accessible, focusable, renders, t9n, themed } from "../../tests/commonTests";
 import { formatTimePart, getLocaleHourFormat, localizeTimeStringToParts } from "../../utils/time";
 import { getElementXY, getFocusedElementProp } from "../../tests/utils/puppeteer";
 import { supportedLocales } from "../../utils/locale";
@@ -42,10 +42,6 @@ export type NumericString = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" 
 describe("calcite-time-picker", () => {
   describe("renders", () => {
     renders("calcite-time-picker", { display: "inline-block" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-time-picker");
   });
 
   describe("accessible", () => {

--- a/packages/components/src/components/tooltip/tooltip.browser.e2e.tsx
+++ b/packages/components/src/components/tooltip/tooltip.browser.e2e.tsx
@@ -1,7 +1,7 @@
 import { h } from "@arcgis/lumina";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import { it, expect, beforeAll, afterAll, describe, vi } from "vitest";
-import { defaults } from "../../tests/commonTests/browser";
+import { defaults, hidden } from "../../tests/commonTests/browser";
 import { mockConsole } from "../../tests/utils/logging";
 import { TOOLTIP_CLOSE_DELAY_MS, TOOLTIP_OPEN_DELAY_MS } from "./resources";
 import { Tooltip } from "./tooltip";
@@ -169,5 +169,9 @@ describe("calcite-tooltip", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount(<calcite-tooltip open />));
   });
 });

--- a/packages/components/src/components/tooltip/tooltip.e2e.ts
+++ b/packages/components/src/components/tooltip/tooltip.e2e.ts
@@ -1,7 +1,7 @@
 // @ts-strict-ignore
 import { newE2EPage, E2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
-import { accessible, floatingUIOwner, hidden, openClose, renders, themed } from "../../tests/commonTests";
+import { accessible, floatingUIOwner, openClose, renders, themed } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 import { getElementXY, GlobalTestProps, skipAnimations } from "../../tests/utils/puppeteer";
 import { FloatingCSS } from "../../utils/floating-ui";
@@ -103,10 +103,6 @@ describe("calcite-tooltip", () => {
     accessible(
       `<calcite-tooltip open reference-element="ref" label="hello world">Hello World!</calcite-tooltip><div id="ref">Tooltip Reference</div>`,
     );
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden(`<calcite-tooltip open></calcite-tooltip >`);
   });
 
   const simpleTooltipHtml = html`

--- a/packages/components/src/components/tree-item/tree-item.browser.e2e.tsx
+++ b/packages/components/src/components/tree-item/tree-item.browser.e2e.tsx
@@ -1,6 +1,7 @@
+import { h } from "@arcgis/lumina";
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults } from "../../tests/commonTests/browser";
+import { defaults, hidden } from "../../tests/commonTests/browser";
 
 describe("calcite-tree-item", () => {
   describe("defaults", () => {
@@ -33,5 +34,9 @@ describe("calcite-tree-item", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount(<calcite-tree-item expanded />));
   });
 });

--- a/packages/components/src/components/tree-item/tree-item.e2e.ts
+++ b/packages/components/src/components/tree-item/tree-item.e2e.ts
@@ -1,7 +1,7 @@
 // @ts-strict-ignore
 import { E2EPage, newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { beforeEach, describe, expect, it } from "vitest";
-import { accessible, disabled, hidden, renders, slots, themed } from "../../tests/commonTests";
+import { accessible, disabled, renders, slots, themed } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 import type { Tree } from "../tree/tree";
 import { findAll } from "../../tests/utils/puppeteer";
@@ -11,10 +11,6 @@ import { CSS, SLOTS } from "./resources";
 describe("calcite-tree-item", () => {
   describe("renders", () => {
     renders("calcite-tree-item", { visible: false, display: "block" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden(`<calcite-tree-item expanded></calcite-tree-item>`);
   });
 
   describe("accessible", () => {

--- a/packages/components/src/components/tree/tree.browser.e2e.tsx
+++ b/packages/components/src/components/tree/tree.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults } from "../../tests/commonTests/browser";
+import { defaults, hidden } from "../../tests/commonTests/browser";
 import { mockConsole } from "../../tests/utils/logging";
 
 describe("calcite-tree", () => {
@@ -24,5 +24,9 @@ describe("calcite-tree", () => {
         },
       ],
     );
+  });
+
+  describe("honors hidden attribute", () => {
+    hidden(() => mount("calcite-tree"));
   });
 });

--- a/packages/components/src/components/tree/tree.e2e.ts
+++ b/packages/components/src/components/tree/tree.e2e.ts
@@ -2,7 +2,7 @@
 import { E2EElement, E2EPage, newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import { html } from "../../../support/formatting";
-import { accessible, hidden, renders } from "../../tests/commonTests";
+import { accessible, renders } from "../../tests/commonTests";
 import { CSS } from "../tree-item/resources";
 import { findAll, getFocusedElementProp } from "../../tests/utils/puppeteer";
 import { SelectionMode } from "../interfaces";
@@ -27,10 +27,6 @@ describe("calcite-tree", () => {
 
   describe("renders", () => {
     renders("calcite-tree", { display: "block" });
-  });
-
-  describe("honors hidden attribute", () => {
-    hidden("calcite-tree");
   });
 
   describe("accessible", () => {

--- a/packages/components/src/tests/commonTests/browser/hidden.ts
+++ b/packages/components/src/tests/commonTests/browser/hidden.ts
@@ -1,0 +1,22 @@
+import { expect, it } from "vitest";
+import { mount } from "@arcgis/lumina-compiler/testing";
+
+/**
+ * Helper for asserting that a component is not visible when hidden
+ *
+ * Note that this helper should be used within a describe block.
+ *
+ * @example
+ * describe("honors hidden attribute", () => {
+ *    hidden(() => mount("calcite-accordion"))
+ * });
+ */
+export async function hidden(setup: () => ReturnType<typeof mount>): Promise<void> {
+  it("is hidden", async () => {
+    const { el } = await setup();
+
+    el.hidden = true;
+
+    await expect.element(el).not.toBeVisible();
+  });
+}

--- a/packages/components/src/tests/commonTests/browser/index.ts
+++ b/packages/components/src/tests/commonTests/browser/index.ts
@@ -1,3 +1,4 @@
 export { cancelable } from "./cancelable";
 export { defaults } from "./defaults";
+export { hidden } from "./hidden";
 export { reflects } from "./reflects";

--- a/packages/components/src/tests/commonTests/index.ts
+++ b/packages/components/src/tests/commonTests/index.ts
@@ -2,7 +2,6 @@ export { accessible } from "./accessible";
 export { openClose } from "./openClose";
 export { renders } from "./renders";
 export { disabled } from "./disabled";
-export { hidden } from "./hidden";
 export { floatingUIOwner, delegatesToFloatingUiOwningComponent, handlesActionMenuPlacements } from "./floatingUI";
 export { focusable } from "./focusable";
 export { formAssociated } from "./formAssociated";


### PR DESCRIPTION
**Related Issue:** #11268

## Summary

Continues migration of Puppeteer-based common test helpers to Vitest browser mode. 
