### PR TITLE
ci(actions): check if product mapping already exists

### DIFF
--- a/.github/scripts/support/monday.js
+++ b/.github/scripts/support/monday.js
@@ -655,8 +655,8 @@ module.exports = function Monday(issue, core) {
 
     if (existingLabels.length === 0 && labels?.length) {
       for (const { name, color } of labels) {
-        const labelName = createProductLabelIfNeeded(name, color);
-        const info = labelMap.get(labelName);
+        createProductLabelIfNeeded(name, color);
+        const info = labelMap.get(name);
         if (info?.column.id === labelInfo.column.id && info.value) {
           existingLabels.push(`${info.value}`);
         }
@@ -971,7 +971,8 @@ module.exports = function Monday(issue, core) {
       return;
     }
 
-    updateLabel(createProductLabelIfNeeded(label, color), "add");
+    createProductLabelIfNeeded(label, color);
+    updateLabel(label, "add");
   }
 
   /**
@@ -981,35 +982,34 @@ module.exports = function Monday(issue, core) {
    * @returns {void}
    */
   function clearLabel(label, color = "") {
-    updateLabel(createProductLabelIfNeeded(label, color), "remove");
+    createProductLabelIfNeeded(label, color);
+    updateLabel(label, "remove");
   }
 
   /**
    * If the label qualifies, create a Esri Product label in `labelMap` and set `createLabelsIfMissing` to `true`
    * @param {string} label - The label name
    * @param {string | undefined} color - The color of the label
-   * @returns {string} - The new key for the label in `labelMap`, or the original label name if not created
+   * @returns {void}
    */
   function createProductLabelIfNeeded(label, color) {
-    if (color !== productColor) {
-      return label;
+    if (labelMap.has(label) || color !== productColor) {
+      return;
     }
 
-    const labelName = label.replace(/(for )?ArcGIS/g, "").trim();
     /** @type {MondayLabel} */
     const labelInfo = {
       column: mondayColumns.product,
-      value: labelName,
+      value: label.replace(/(for )?ArcGIS/g, "").trim(),
       clearable: true,
     };
 
-    labelMap.set(labelName, labelInfo);
+    labelMap.set(label, labelInfo);
     createLabelsIfMissing = true;
 
     core.notice(`Created label "${labelInfo.value}" in label map.`, {
       title: "Create Esri Product Label",
     });
-    return labelName;
   }
 
   /**


### PR DESCRIPTION
**Related Issue:** #13182

## Summary
Improves the `createProductLabelIfNeeded` function and usage pattern by using the GitHub label name for the map key instead of stripped name and checking if the label aready exists.

- Stops the mapping from being created/updated multiple times due to it being called in `createDropdownValue()` after it is already created.
- This also changes the function to return void, which makes the purpose of the function clearer. It only creates the label mapping if needed, and isn't relied on for returning the label name.
- Brings the mapping into alignment with the manual mappings by using the GitHub label name as the key instead of a custom value (stripped name).
