### PR TITLE
feat(card): Update selection state styling for 5.0

### DIFF
--- a/packages/components/src/components/card/card.scss
+++ b/packages/components/src/components/card/card.scss
@@ -105,7 +105,7 @@
 }
 
 :host([selected]) .content-wrapper {
-  box-shadow: inset 0 -4px 0 0 var(--calcite-card-accent-color-selected, var(--calcite-color-brand));
+  border: 1px solid var(--calcite-card-accent-color-selected, var(--calcite-color-brand));
 }
 
 :host([selectable]) .header {


### PR DESCRIPTION
**Related Issue:** [#10771](https://github.com/Esri/calcite-design-system/issues/10771)

## Summary

Remove 4px bottom border.
Add 1px brand border on all sides.
