### PR TITLE
docs: remove references to recently removed components

### DIFF
--- a/packages/components/src/components/shell/shell.scss
+++ b/packages/components/src/components/shell/shell.scss
@@ -4,7 +4,6 @@
  * These properties can be overridden using the component's tag as selector.
  *
  * @prop --calcite-shell-border-color: Specifies the component's border color.
- * @prop --calcite-shell-tip-spacing: [Deprecated] This component has been deprecated. The left and right spacing of the `calcite-tip-manager` when slotted in the component.
  */
 
 @use "../../styles/includes";

--- a/packages/components/src/components/shell/shell.tsx
+++ b/packages/components/src/components/shell/shell.tsx
@@ -23,7 +23,6 @@ declare global {
  * @slot panel-end - A slot for adding the ending `calcite-shell-panel`.
  * @slot panel-top - A slot for adding the top `calcite-shell-panel`.
  * @slot panel-bottom - A slot for adding the bottom `calcite-shell-panel`.
- * @slot modals - A slot for adding `calcite-modal` components. When placed in this slot, the modal position will be constrained to the extent of the `calcite-shell`.
  * @slot dialogs - A slot for adding `calcite-dialog` components. When placed in this slot, the dialog position will be constrained to the extent of the `calcite-shell`.
  * @slot alerts - A slot for adding `calcite-alert` components. When placed in this slot, the alert position will be constrained to the extent of the `calcite-shell`.
  * @slot sheets - A slot for adding `calcite-sheet` components. When placed in this slot, the sheet position will be constrained to the extent of the `calcite-shell`.


### PR DESCRIPTION
**Related Issue:** #13345 

## Summary
Removes two references to components that have been removed as apart of https://github.com/Esri/calcite-design-system/issues/13078