### PR TITLE
feat(block): add content-end slot

### DIFF
--- a/packages/components/src/components/block/block.e2e.ts
+++ b/packages/components/src/components/block/block.e2e.ts
@@ -352,6 +352,7 @@ describe("calcite-block", () => {
           icon-start="pen"
         >
           <calcite-icon icon="compass" slot="content-start"></calcite-icon>
+          <calcite-icon icon="compass" slot="content-end"></calcite-icon>
           <div>content</div>
         </calcite-block>`,
         {
@@ -431,6 +432,7 @@ describe("calcite-block", () => {
           icon-start="pen"
         >
           <calcite-icon icon="compass" slot="content-start"></calcite-icon>
+          <calcite-icon icon="compass" slot="content-end"></calcite-icon>
           <div>content</div>
         </calcite-block>`,
         {

--- a/packages/components/src/components/block/block.scss
+++ b/packages/components/src/components/block/block.scss
@@ -263,6 +263,7 @@ calcite-sort-handle {
   padding-inline: var(--calcite-internal-block-padding-inline);
 }
 
+.content-end,
 .content-start {
   @apply flex items-center;
 

--- a/packages/components/src/components/block/block.stories.ts
+++ b/packages/components/src/components/block/block.stories.ts
@@ -278,7 +278,7 @@ export const icons_TestOnly = (): string => html`
 `;
 
 export const iconStartEnd = (): string => html`
-  <h1>content-start and actions-end</h1>
+  <h1>content-start, content-end and actions-end</h1>
 
   <calcite-block
     heading="Valid status"
@@ -294,6 +294,14 @@ export const iconStartEnd = (): string => html`
       style="color: var(--calcite-color-status-success)"
       scale="s"
     ></calcite-icon>
+
+    <calcite-icon
+      icon="compass"
+      slot="content-end"
+      style="color: var(--calcite-color-status-success)"
+      scale="s"
+    ></calcite-icon>
+
     <calcite-action appearance="transparent" icon="ellipsis" text="menu" label="menu" slot="actions-end" />
   </calcite-block>
 
@@ -362,6 +370,9 @@ export const nonCollapsible = (): string =>
     drag-handle
   >
     <div slot="content-start">
+      <calcite-action icon="information"></calcite-action>
+    </div>
+    <div slot="content-end">
       <calcite-action icon="information"></calcite-action>
     </div>
     <calcite-action icon="layers" slot="actions-end"></calcite-action>

--- a/packages/components/src/components/block/block.tsx
+++ b/packages/components/src/components/block/block.tsx
@@ -457,8 +457,13 @@ export class Block extends LitElement implements InteractiveComponent {
 
   private renderContentEnd(): JsxNode {
     return (
-      <div class={CSS.contentEnd} hidden={!this.hasContentEnd}>
-        <slot name={SLOTS.contentEnd} onSlotChange={this.handleContentEndSlotChange} />
+      <div
+        class={{ [CSS.iconEndContainer]: !this.iconEnd && !this.collapsible }}
+        hidden={!this.hasContentEnd}
+      >
+        <div class={CSS.contentEnd}>
+          <slot name={SLOTS.contentEnd} onSlotChange={this.handleContentEndSlotChange} />
+        </div>
       </div>
     );
   }
@@ -605,14 +610,13 @@ export class Block extends LitElement implements InteractiveComponent {
           headerContent
         )}
         {(() => {
-          const hasContentEndRendered = this.renderContentEnd();
-          const hasIconEnd = !!iconEnd;
-          const showIconEndContainer = (hasContentEndRendered || hasIconEnd) && !collapsible;
-          return showIconEndContainer ? (
+          return iconEnd && !collapsible ? (
             <div class={CSS.iconEndContainer}>
-              {hasContentEndRendered}
+              {this.renderContentEnd()}
               {this.renderIcon("end")}
             </div>
+          ) : !iconEnd && !collapsible ? (
+            this.renderContentEnd()
           ) : null;
         })()}
         <calcite-action-menu

--- a/packages/components/src/components/block/block.tsx
+++ b/packages/components/src/components/block/block.tsx
@@ -39,6 +39,7 @@ declare global {
 /**
  * @slot - A slot for adding custom content.
  * @slot actions-end - A slot for adding actionable `calcite-action` elements after the content of the component. It is recommended to use two or fewer actions.
+ * @slot content-end - A slot for adding non-actionable elements after content of the component.
  * @slot content-start - A slot for adding non-actionable elements before content of the component.
  * @slot header-menu-actions - A slot for adding an overflow menu with `calcite-action`s inside a dropdown menu.
  */
@@ -71,6 +72,8 @@ export class Block extends LitElement implements InteractiveComponent {
   //#endregion
 
   //#region State Properties
+
+  @state() hasContentEnd = false;
 
   @state() hasContentStart = false;
 
@@ -392,6 +395,10 @@ export class Block extends LitElement implements InteractiveComponent {
     this.hasEndActions = slotChangeHasAssignedElement(event);
   }
 
+  private handleContentEndSlotChange(event: Event): void {
+    this.hasContentEnd = slotChangeHasAssignedElement(event);
+  }
+
   private handleContentStartSlotChange(event: Event): void {
     this.hasContentStart = slotChangeHasAssignedElement(event);
   }
@@ -444,6 +451,14 @@ export class Block extends LitElement implements InteractiveComponent {
     return (
       <div class={CSS.actionsEnd} hidden={!this.hasEndActions}>
         <slot name={SLOTS.actionsEnd} onSlotChange={this.actionsEndSlotChangeHandler} />
+      </div>
+    );
+  }
+
+  private renderContentEnd(): JsxNode {
+    return (
+      <div class={CSS.contentEnd} hidden={!this.hasContentEnd}>
+        <slot name={SLOTS.contentEnd} onSlotChange={this.handleContentEndSlotChange} />
       </div>
     );
   }
@@ -512,6 +527,7 @@ export class Block extends LitElement implements InteractiveComponent {
       dragDisabled,
       sortDisabled,
       iconEnd,
+      hasContentEnd,
       hasContentStart,
       iconStart,
     } = this;
@@ -520,6 +536,7 @@ export class Block extends LitElement implements InteractiveComponent {
     const headerHasContent = !!(
       heading ||
       description ||
+      hasContentEnd ||
       hasContentStart ||
       iconStart ||
       loading ||
@@ -575,6 +592,7 @@ export class Block extends LitElement implements InteractiveComponent {
           >
             {headerContent}
             <div class={CSS.iconEndContainer}>
+              {this.renderContentEnd()}
               {this.renderIcon("end")}
               <calcite-icon
                 class={CSS.toggleIcon}
@@ -586,9 +604,17 @@ export class Block extends LitElement implements InteractiveComponent {
         ) : (
           headerContent
         )}
-        {iconEnd && !collapsible ? (
-          <div class={CSS.iconEndContainer}>{this.renderIcon("end")}</div>
-        ) : null}
+        {(() => {
+          const hasContentEndRendered = this.renderContentEnd();
+          const hasIconEnd = !!iconEnd;
+          const showIconEndContainer = (hasContentEndRendered || hasIconEnd) && !collapsible;
+          return showIconEndContainer ? (
+            <div class={CSS.iconEndContainer}>
+              {hasContentEndRendered}
+              {this.renderIcon("end")}
+            </div>
+          ) : null;
+        })()}
         <calcite-action-menu
           flipPlacements={menuFlipPlacements ?? ["top", "bottom"]}
           hidden={!this.hasMenuActions}

--- a/packages/components/src/components/block/resources.ts
+++ b/packages/components/src/components/block/resources.ts
@@ -11,6 +11,7 @@ export const CSS = {
   button: "button",
   container: "container",
   content: "content",
+  contentEnd: "content-end",
   contentStart: "content-start",
   description: "description",
   header: "header",
@@ -32,6 +33,7 @@ export const CSS = {
 
 export const SLOTS = {
   actionsEnd: "actions-end",
+  contentEnd: "content-end",
   contentStart: "content-start",
   headerMenuActions: "header-menu-actions",
 };


### PR DESCRIPTION
**Related Issue:** [#10714](https://github.com/Esri/calcite-design-system/issues/10714)

## Summary
Add `content-end` slot for non-interactive content.
