### PR TITLE
chore(option-group): drop unnecessary styles

### DIFF
--- a/packages/components/src/components/option-group/option-group.browser.e2e.tsx
+++ b/packages/components/src/components/option-group/option-group.browser.e2e.tsx
@@ -32,6 +32,6 @@ describe("calcite-option-group", () => {
   });
 
   describe("renders", () => {
-    renders(() => mount("calcite-option-group"), { display: "block", visible: false });
+    renders(() => mount("calcite-option-group"), { display: "inline", visible: false });
   });
 });

--- a/packages/components/src/components/option-group/option-group.scss
+++ b/packages/components/src/components/option-group/option-group.scss
@@ -1,7 +1,0 @@
-@use "../../styles/includes";
-
-:host {
-  @apply block;
-}
-
-@include includes.base-component();

--- a/packages/components/src/components/option-group/option-group.tsx
+++ b/packages/components/src/components/option-group/option-group.tsx
@@ -1,7 +1,6 @@
 // @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { LitElement, property, createEvent, Fragment, h, JsxNode } from "@arcgis/lumina";
-import { styles } from "./option-group.scss";
 
 declare global {
   interface DeclareElements {
@@ -10,12 +9,6 @@ declare global {
 }
 /** @slot - A slot for adding `calcite-option`s. */
 export class OptionGroup extends LitElement {
-  //#region Static Members
-
-  static override styles = styles;
-
-  //#endregion
-
   //#region Public Properties
 
   /** When `true`, interaction is prevented and the component is displayed with lower opacity. */


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Removes styles as option group is not meant to be rendered.