### PR TITLE
fix(combobox, filter, list): stop warning when filtering on empty data source

### DIFF
--- a/packages/components/src/components/list/list.browser.e2e.tsx
+++ b/packages/components/src/components/list/list.browser.e2e.tsx
@@ -58,7 +58,7 @@ describe("calcite-list", () => {
         },
         {
           propertyName: "filterText",
-          defaultValue: undefined,
+          defaultValue: "",
         },
         {
           propertyName: "filterPlaceholder",

--- a/packages/components/src/components/list/list.e2e.ts
+++ b/packages/components/src/components/list/list.e2e.ts
@@ -492,7 +492,7 @@ describe("calcite-list", () => {
       await page.waitForTimeout(DEBOUNCE.filter);
       expect(await list.getProperty("filteredItems")).toHaveLength(2);
       expect(await list.getProperty("filteredData")).toHaveLength(2);
-      expect(await list.getProperty("filterText")).toBeUndefined();
+      expect(await list.getProperty("filterText")).toBe("");
 
       expect(await items[0].getProperty("filterHidden")).toBe(false);
       expect(await items[0].getProperty("setPosition")).toBe(1);
@@ -583,7 +583,7 @@ describe("calcite-list", () => {
       await page.waitForTimeout(DEBOUNCE.filter);
       expect(await list.getProperty("filteredItems")).toHaveLength(3);
       expect(await list.getProperty("filteredData")).toHaveLength(3);
-      expect(await list.getProperty("filterText")).toBeUndefined();
+      expect(await list.getProperty("filterText")).toBe("");
 
       listItems[0].setProperty("selected", true);
       list.setProperty("filterText", "two");

--- a/packages/components/src/components/list/list.tsx
+++ b/packages/components/src/components/list/list.tsx
@@ -191,7 +191,7 @@ export class List extends LitElement implements InteractiveComponent, SortableCo
   @property() filterProps: string[];
 
   /** Text for the component's filter input field. */
-  @property({ reflect: true }) filterText: string;
+  @property({ reflect: true }) filterText: string = "";
 
   /**
    * The currently filtered `calcite-list-item` data.

--- a/packages/components/src/utils/filter.browser.spec.ts
+++ b/packages/components/src/utils/filter.browser.spec.ts
@@ -5,9 +5,8 @@ import { filter } from "./filter";
 describe("filter function", () => {
   mockConsole();
 
-  it("warns and returns empty array for empty data", () => {
+  it("returns empty array for empty data", () => {
     const result = filter([], "test");
-    expect(console.warn).toHaveBeenCalledTimes(1);
     expect(result).toEqual([]);
   });
 

--- a/packages/components/src/utils/filter.ts
+++ b/packages/components/src/utils/filter.ts
@@ -3,15 +3,9 @@ import { escapeRegExp, forIn } from "es-toolkit/compat";
 export const filter = (data: Array<object>, value: string, filterProps?: string[]): Array<any> => {
   const escapedValue = escapeRegExp(value);
   const regex = new RegExp(escapedValue, "i");
-
-  if (data.length === 0) {
-    console.warn(`No data was passed to the filter function.
-    The data argument should be an array of objects`);
-  }
-
   const matchAll = value === "";
 
-  if (matchAll) {
+  if (matchAll || data.length === 0) {
     return data;
   }
 


### PR DESCRIPTION
**Related Issue:** #12264

## Summary

Removes empty source warnings due to the following:

* it hasn’t provided much practical value and mostly added noise
* similar filtering utilities (e.g., `es-toolkit`) do not warn when the source is empty
* other components do not warn about missing pieces during initialization
* some valid setups intentionally start empty

### Noteworthy changes

* Changes default value of list's `filterText` from `undefined` to `""` for consistency.