### PR TITLE
feat(input-time-picker): support French Canadian (fr-CA) locale

### DIFF
--- a/packages/components/src/components/input-time-picker/input-time-picker.e2e.ts
+++ b/packages/components/src/components/input-time-picker/input-time-picker.e2e.ts
@@ -15,6 +15,7 @@ import { letterKeys } from "../../utils/key";
 import { CSS } from "./resources";
 
 async function getInputValue(page: E2EPage, locale: SupportedLocale = "en"): Promise<string> {
+  const whitespaceRegexPattern = /[\u00A0\u202f]/g; // some locales like es and ca contain narrow and regular non-breaking space characters, so we remove them to make text assertions more uniform.
   const hour = (await page.find(`calcite-input-time-picker >>> .${CSS.hour}`))?.innerText || "";
   const hourSuffix = (await page.find(`calcite-input-time-picker >>> .${CSS.hourSuffix}`))?.innerText || "";
   const minute = (await page.find(`calcite-input-time-picker >>> .${CSS.minute}`))?.innerText || "";
@@ -22,9 +23,16 @@ async function getInputValue(page: E2EPage, locale: SupportedLocale = "en"): Pro
   const second = (await page.find(`calcite-input-time-picker >>> .${CSS.second}`))?.innerText || "";
   const decimalSeparator = (await page.find(`calcite-input-time-picker >>> .${CSS.decimalSeparator}`))?.innerText || "";
   const fractionalSecond = (await page.find(`calcite-input-time-picker >>> .${CSS.fractionalSecond}`))?.innerText || "";
-  const secondSuffix = (await page.find(`calcite-input-time-picker >>> .${CSS.secondSuffix}`))?.innerText || "";
+  const secondSuffix =
+    (await page.find(`calcite-input-time-picker >>> .${CSS.secondSuffix}`))?.innerText.replaceAll(
+      whitespaceRegexPattern,
+      "",
+    ) || "";
   const meridiem =
-    (await page.find(`calcite-input-time-picker >>> .${CSS.meridiem}`))?.innerText.replaceAll(/\u00A0/g, "") || ""; // some locales like es and ca contain non-breaking space characters, so we remove them to make text assertions more uniform.
+    (await page.find(`calcite-input-time-picker >>> .${CSS.meridiem}`))?.innerText.replaceAll(
+      whitespaceRegexPattern,
+      "",
+    ) || "";
   const meridiemOrder = getMeridiemOrder(locale);
   return `${meridiem && meridiemOrder === 0 ? meridiem : ""}${hour}${hourSuffix}${minute}${minuteSuffix}${second}${decimalSeparator}${fractionalSecond}${secondSuffix}${meridiem && meridiemOrder !== 0 ? meridiem : ""}`;
 }

--- a/packages/components/src/components/input-time-picker/input-time-picker.e2e.ts
+++ b/packages/components/src/components/input-time-picker/input-time-picker.e2e.ts
@@ -15,7 +15,7 @@ import { letterKeys } from "../../utils/key";
 import { CSS } from "./resources";
 
 async function getInputValue(page: E2EPage, locale: SupportedLocale = "en"): Promise<string> {
-  const whitespaceRegexPattern = /[\u00A0\u202f]/g; // some locales like es and ca contain narrow and regular non-breaking space characters, so we remove them to make text assertions more uniform.
+  const whitespaceRegexPattern = /[\s\u00A0\u202f]/g; // some locales like es and ca contain narrow and regular non-breaking space characters, so we remove them to make text assertions more uniform.
   const hour = (await page.find(`calcite-input-time-picker >>> .${CSS.hour}`))?.innerText || "";
   const hourSuffix = (await page.find(`calcite-input-time-picker >>> .${CSS.hourSuffix}`))?.innerText || "";
   const minute = (await page.find(`calcite-input-time-picker >>> .${CSS.minute}`))?.innerText || "";

--- a/packages/components/src/components/input-time-picker/input-time-picker.scss
+++ b/packages/components/src/components/input-time-picker/input-time-picker.scss
@@ -75,6 +75,12 @@ calcite-time-picker {
   }
 }
 
+.hour-suffix,
+.minute-suffix,
+.second-suffix {
+  white-space: pre;
+}
+
 .input-container {
   display: flex;
   flex-grow: 1;

--- a/packages/components/src/components/input-time-picker/input-time-picker.stories.ts
+++ b/packages/components/src/components/input-time-picker/input-time-picker.stories.ts
@@ -118,6 +118,11 @@ export const open_TestOnly = (): string => html`
   <calcite-input-time-picker value="10:37" open> </calcite-input-time-picker>
 `;
 
+export const frenchCanadianLocale_TestOnly = (): string => html`
+  <calcite-input-time-picker lang="fr-CA" value="10:37:45.321" step=".001" hour-format="12" open>
+  </calcite-input-time-picker>
+`;
+
 export const koreanLocale_TestOnly = (): string => html`
   <calcite-input-time-picker lang="ko" value="10:37" step="1" open> </calcite-input-time-picker>
 `;

--- a/packages/components/src/components/time-picker/time-picker.tsx
+++ b/packages/components/src/components/time-picker/time-picker.tsx
@@ -596,7 +596,7 @@ export class TimePicker extends LitElement implements TimeComponent {
         )}
         {showSecondSuffix && (
           <span class={{ [CSS.delimiter]: true, [CSS.secondSuffix]: true }}>
-            {localizedSecondSuffix}
+            {localizedSecondSuffix.trim()}
           </span>
         )}
         {showMeridiem && (

--- a/packages/components/src/utils/locale.ts
+++ b/packages/components/src/utils/locale.ts
@@ -344,8 +344,6 @@ function buildDateTimeFormatCacheKey(options: Intl.DateTimeFormatOptions = {}): 
  * @private
  */
 export function getDateTimeFormat(locale: string, options?: Intl.DateTimeFormatOptions): Intl.DateTimeFormat {
-  locale = getSupportedLocale(locale);
-
   if (!dateTimeFormatCache) {
     dateTimeFormatCache = new Map();
   }

--- a/packages/components/src/utils/locale.ts
+++ b/packages/components/src/utils/locale.ts
@@ -344,6 +344,8 @@ function buildDateTimeFormatCacheKey(options: Intl.DateTimeFormatOptions = {}): 
  * @private
  */
 export function getDateTimeFormat(locale: string, options?: Intl.DateTimeFormatOptions): Intl.DateTimeFormat {
+  locale = locale === "fr-CA" ? locale : getSupportedLocale(locale);
+
   if (!dateTimeFormatCache) {
     dateTimeFormatCache = new Map();
   }

--- a/packages/components/src/utils/time.browser.spec.ts
+++ b/packages/components/src/utils/time.browser.spec.ts
@@ -470,7 +470,7 @@ describe("localizeTimeString", () => {
       second: "30",
       decimalSeparator: ".",
       fractionalSecond: "04",
-      secondSuffix: null,
+      secondSuffix: " ",
       meridiem: "AM",
     });
     expect(localizeTimeString({ step: 0.001, parts: true, value: "06:45:30.003", locale: "en" })).toEqual({
@@ -481,7 +481,7 @@ describe("localizeTimeString", () => {
       second: "30",
       decimalSeparator: ".",
       fractionalSecond: "003",
-      secondSuffix: null,
+      secondSuffix: " ",
       meridiem: "AM",
     });
     expect(
@@ -500,7 +500,7 @@ describe("localizeTimeString", () => {
       second: "٣٠",
       decimalSeparator: "٫",
       fractionalSecond: "٠٠٧",
-      secondSuffix: null,
+      secondSuffix: " ",
       meridiem: "ص",
     });
   });

--- a/packages/components/src/utils/time.ts
+++ b/packages/components/src/utils/time.ts
@@ -225,7 +225,7 @@ function getLocalizedTimePart(
     const minuteIndex = parts.indexOf(parts.find(({ type }): boolean => type === "minute"));
     const hourSuffix = parts[hourIndex + 1];
     return hourSuffix && hourSuffix.type === "literal" && minuteIndex - hourIndex === 2
-      ? hourSuffix.value?.trim() || null
+      ? hourSuffix.value || null
       : null;
   }
   if (part === "minuteSuffix") {
@@ -233,7 +233,7 @@ function getLocalizedTimePart(
     const secondIndex = parts.indexOf(parts.find(({ type }): boolean => type === "second"));
     const minuteSuffix = parts[minuteIndex + 1];
     return minuteSuffix && minuteSuffix.type === "literal" && secondIndex - minuteIndex === 2
-      ? minuteSuffix.value?.trim() || null
+      ? minuteSuffix.value || null
       : null;
   }
   if (part === "secondSuffix") {
@@ -245,7 +245,7 @@ function getLocalizedTimePart(
       const secondIndex = parts.indexOf(parts.find(({ type }): boolean => type === "second"));
       secondSuffixPart = parts[secondIndex + 1];
     }
-    return (secondSuffixPart?.type === "literal" && secondSuffixPart.value?.trim()) || null;
+    return (secondSuffixPart?.type === "literal" && secondSuffixPart.value) || null;
   }
   if (part === "meridiem") {
     const meridiemFromBrowser = parts.find(({ type }) => type === "dayPeriod")?.value || null;

--- a/packages/components/src/utils/time.ts
+++ b/packages/components/src/utils/time.ts
@@ -209,7 +209,7 @@ export function getLocalizedTimePartSuffix(
 ): string {
   const formatter = createLocaleDateTimeFormatter({ locale, numberingSystem });
   const parts = formatter.formatToParts(new Date(Date.UTC(0, 0, 0, 0, 0, 0)));
-  return getLocalizedTimePart(`${part}Suffix` as TimePart, parts);
+  return getLocalizedTimePart(`${part}Suffix` as TimePart, parts, locale);
 }
 
 function getLocalizedTimePart(
@@ -239,7 +239,7 @@ function getLocalizedTimePart(
   if (part === "secondSuffix") {
     let secondSuffixPart;
     const fractionalSecondIndex = parts.indexOf(parts.find(({ type }): boolean => type === "fractionalSecond"));
-    if (fractionalSecondIndex) {
+    if (fractionalSecondIndex !== -1) {
       secondSuffixPart = parts[fractionalSecondIndex + 1];
     } else {
       const secondIndex = parts.indexOf(parts.find(({ type }): boolean => type === "second"));


### PR DESCRIPTION
**Related Issue:** #12723

## Summary

This PR adds official support to `input-time-picker` and `time-picker` for the French Canadian (fr-CA) locale.
