### PR TITLE
refactor(input)!: drop `textarea` type

### DIFF
--- a/packages/components/src/components/input/input.e2e.ts
+++ b/packages/components/src/components/input/input.e2e.ts
@@ -1772,35 +1772,6 @@ describe("calcite-input", () => {
       page = await newE2EPage();
     });
 
-    it("works for type textarea", async () => {
-      await page.setContent(`<calcite-input type="textarea"></calcite-input>`);
-      const element = await page.find("calcite-input");
-
-      await element.callMethod("setFocus");
-      await page.waitForChanges();
-      await page.keyboard.type("test");
-      await page.waitForChanges();
-
-      await page.keyboard.press("ArrowUp");
-      await page.waitForChanges();
-
-      await assertCaretPosition({
-        page,
-        componentTag: "calcite-input",
-        shadowInputTypeSelector: "textarea",
-        position: 0,
-      });
-
-      await page.keyboard.press("ArrowDown");
-      await page.waitForChanges();
-
-      await assertCaretPosition({
-        page,
-        componentTag: "calcite-input",
-        shadowInputTypeSelector: "textarea",
-      });
-    });
-
     it("works for type text", async () => {
       await page.setContent(`<calcite-input type="text"></calcite-input>`);
       const element = await page.find("calcite-input");

--- a/packages/components/src/components/input/input.scss
+++ b/packages/components/src/components/input/input.scss
@@ -63,8 +63,7 @@
     padding-inline: var(--calcite-spacing-sm);
   }
   @include input-affix-spacing(var(--calcite-spacing-sm), var(--calcite-spacing-xxs));
-  & input[type="file"],
-  & textarea {
+  & input[type="file"] {
     min-block-size: theme("spacing.6");
   }
   & .number-button-wrapper,
@@ -74,12 +73,6 @@
   & .clear-button {
     min-block-size: theme("spacing.6");
     min-inline-size: theme("spacing.6");
-  }
-  & textarea {
-    @apply text-n2h
-    h-auto
-    py-1
-    px-2;
   }
 }
 
@@ -93,7 +86,6 @@
     padding-inline: var(--calcite-spacing-md);
   }
   @include input-affix-spacing(var(--calcite-spacing-md), var(--calcite-spacing-xs));
-  & textarea,
   & input[type="file"] {
     min-block-size: theme("spacing.8");
   }
@@ -104,12 +96,6 @@
   & .clear-button {
     min-block-size: theme("spacing.8");
     min-inline-size: theme("spacing.8");
-  }
-  & textarea {
-    @apply text-n1h
-      h-auto
-      py-2
-      px-3;
   }
 }
 
@@ -123,7 +109,6 @@
     padding-inline: var(--calcite-spacing-lg);
   }
   @include input-affix-spacing(var(--calcite-spacing-lg), var(--calcite-spacing-sm));
-  & textarea,
   & input[type="file"] {
     min-block-size: theme("spacing.11");
   }
@@ -135,21 +120,10 @@
     min-block-size: theme("spacing.11");
     min-inline-size: theme("spacing.11");
   }
-  & textarea {
-    @apply text-0h
-      h-auto
-      py-3
-      px-4;
-  }
 }
 
-@include includes.disabled() {
-  & textarea {
-    resize: none;
-  }
-}
+@include includes.disabled();
 
-textarea,
 input {
   @apply font-inherit
     relative
@@ -176,10 +150,6 @@ input {
   &:placeholder-shown {
     @apply text-ellipsis;
   }
-}
-
-textarea {
-  border-radius: var(--calcite-input-corner-radius, var(--calcite-corner-radius-sharp));
 }
 
 input {
@@ -256,38 +226,31 @@ input[type="search"]::-webkit-search-decoration {
 
 // states
 
-input:focus,
-textarea:focus {
+input:focus {
   @apply border-color-brand;
   color: var(--calcite-input-text-color, var(--calcite-color-text-1));
 }
-input[readonly],
-textarea[readonly] {
+input[readonly] {
   @apply font-medium;
   background-color: var(--calcite-input-background-color, var(--calcite-color-background));
 }
-input[readonly]:focus,
-textarea[readonly]:focus {
+input[readonly]:focus {
   color: var(--calcite-input-text-color, var(--calcite-color-text-1));
 }
 
 //focus
-textarea,
 input {
   @apply focus-base;
 }
-textarea:focus,
 input:focus {
   @apply focus-inset;
 }
 
 :host([status="invalid"]) {
-  & input,
-  & textarea {
+  & input {
     @apply border-color-danger;
   }
-  & input:focus,
-  & textarea:focus {
+  & input:focus {
     @apply focus-inset-danger;
   }
 }
@@ -463,14 +426,12 @@ input[type="time"]::-webkit-clear-button {
 
 // alignment type
 :host([alignment="start"]) {
-  & textarea,
   & input {
     text-align: start;
   }
 }
 
 :host([alignment="end"]) {
-  & textarea,
   & input {
     text-align: end;
   }
@@ -503,8 +464,7 @@ input[type="number"] {
 }
 
 :host([number-button-type="vertical"]) {
-  & input,
-  textarea {
+  & input {
     @apply order-2;
   }
 }

--- a/packages/components/src/components/input/input.stories.ts
+++ b/packages/components/src/components/input/input.stories.ts
@@ -128,20 +128,6 @@ export const withSlottedAction = (): string => html`
   </div>
 `;
 
-export const textarea_TestOnly = (): string => html`
-  <div style="width:300px;max-width:100%;text-align:center;">
-    <calcite-input
-      id="input-with-text-area"
-      type="textarea"
-      scale="m"
-      status="idle"
-      placeholder="Placeholder text"
-      validation-message="My great input message"
-    >
-    </calcite-input>
-  </div>
-`;
-
 export const disabled_TestOnly = (): string => html`<calcite-input disabled value="disabled"></calcite-input>`;
 
 export const darkModeRTL_TestOnly = (): string => html`

--- a/packages/components/src/components/input/input.tsx
+++ b/packages/components/src/components/input/input.tsx
@@ -1,7 +1,6 @@
 // @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { createRef } from "lit-html/directives/ref.js";
-import { literal } from "lit-html/static.js";
 import {
   LitElement,
   property,
@@ -90,10 +89,7 @@ export class Input
   );
 
   /** keep track of the rendered child type */
-  private childRef = createRef<HTMLInputElement | HTMLTextAreaElement>();
-
-  /** keep track of the rendered child type */
-  private childElType?: "input" | "textarea" = "input";
+  private childRef = createRef<HTMLInputElement>();
 
   /** number text input element for locale */
   private childNumberRef = createRef<HTMLInputElement>();
@@ -179,7 +175,7 @@ export class Input
    */
   @property() autocomplete: AutoFill;
 
-  /** When `true`, a clear button is displayed when the component has a value. The clear button shows by default for `"search"`, `"time"`, and `"date"` types, and will not display for the `"textarea"` type. */
+  /** When `true`, a clear button is displayed when the component has a value. The clear button shows by default for `"search"`, `"time"`, and `"date"` types. */
   @property({ reflect: true }) clearable = false;
 
   /**
@@ -342,8 +338,6 @@ export class Input
    * Specifies the component type.
    *
    * Note that the following `type`s add type-specific icons by default: `"date"`, `"email"`, `"password"`, `"search"`, `"tel"`, `"time"`.
-   *
-   *  `"textarea"` [Deprecated] use the `calcite-text-area` component instead.
    */
   @property({ reflect: true }) type:
     | "color"
@@ -358,7 +352,6 @@ export class Input
     | "search"
     | "tel"
     | "text"
-    | "textarea"
     | "time"
     | "url"
     | "week" = "text";
@@ -476,7 +469,6 @@ export class Input
   }
 
   async load(): Promise<void> {
-    this.childElType = this.type === "textarea" ? "textarea" : "input";
     this.maxString = this.max?.toString();
     this.minString = this.min?.toString();
     this.requestedIcon = setRequestedIcon(INPUT_TYPE_ICONS, this.icon, this.type);
@@ -533,11 +525,7 @@ export class Input
   //#region Private Methods
 
   get isClearable(): boolean {
-    return !this.isTextarea && (this.clearable || this.type === "search") && this.value?.length > 0;
-  }
-
-  get isTextarea(): boolean {
-    return this.childElType === "textarea";
+    return (this.clearable || this.type === "search") && this.value?.length > 0;
   }
 
   private handleGlobalAttributesChanged(): void {
@@ -1091,14 +1079,10 @@ export class Input
           value={this.displayedValue}
         />
       ) : null;
-    const DynamicHtmlTag =
-      this.childElType === "input"
-        ? (literal`input` as unknown as "input")
-        : (literal`textarea` as unknown as "textarea");
 
     const childEl =
       this.type !== "number" ? (
-        <DynamicHtmlTag
+        <input
           accept={this.accept}
           aria-errormessage={IDS.validationMessage}
           ariaInvalid={this.status === "invalid"}
@@ -1123,7 +1107,6 @@ export class Input
           onFocus={this.inputFocusHandler}
           onInput={this.inputInputHandler}
           onKeyDown={this.inputKeyDownHandler}
-          // eslint-disable-next-line react/forbid-component-props -- intentional onKeyUp usage
           onKeyUp={this.inputKeyUpHandler}
           pattern={this.pattern}
           placeholder={this.placeholder || ""}


### PR DESCRIPTION
**Related Issue:** #13079 

## Summary

BREAKING CHANGE: The deprecated `textarea` type was removed. Developers should use `calcite-text-area` instead.