### PR TITLE
chore: remove data-test attributes from production builds

### DIFF
--- a/packages/components/build/transforms/remove-test-data-attributes.ts
+++ b/packages/components/build/transforms/remove-test-data-attributes.ts
@@ -1,0 +1,22 @@
+import { FileTransformer } from "@arcgis/lumina-compiler";
+import ts from "typescript";
+
+export default function (): FileTransformer {
+  return (sourceFile, context): readonly ts.Statement[] => {
+    if (process.env.NODE_ENV !== "production") {
+      return sourceFile.statements;
+    }
+
+    const testDataAttrPrefix = "data-test-";
+
+    function removeTestDataAttr(node: ts.Node): ts.Node | undefined {
+      return ts.isJsxAttribute(node) && node.name.getText(sourceFile).startsWith(testDataAttrPrefix)
+        ? undefined
+        : ts.visitEachChild(node, removeTestDataAttr, context.transformation);
+    }
+
+    return sourceFile.text.includes(testDataAttrPrefix)
+      ? sourceFile.statements.map((statement) => ts.visitNode(statement, removeTestDataAttr) as ts.Statement)
+      : sourceFile.statements;
+  };
+}

--- a/packages/components/vite.config.ts
+++ b/packages/components/vite.config.ts
@@ -6,6 +6,7 @@ import stylelint from "stylelint";
 import { defineConfig } from "vite";
 import { useLumina } from "@arcgis/lumina-compiler";
 import { defaultExclude } from "vitest/config";
+import ts from "typescript";
 import { version } from "./package.json";
 import tailwindConfig from "./tailwind.config";
 
@@ -17,6 +18,55 @@ const specAndE2EFileExtensions = `{e2e,spec}.?(c|m)[jt]s?(x)`;
 const browserTestMatch = `${allDirsAndFiles}.browser.${specAndE2EFileExtensions}`;
 const allSpecAndE2ETestMatch = `${allDirsAndFiles}.${specAndE2EFileExtensions}`;
 
+const lumina = useLumina({
+  build: {
+    dependencies: {
+      // Workaround for https://github.com/Esri/calcite-design-system/issues/10761
+      bundleIn: nonEsmDependencies,
+    },
+    wrappers: [
+      {
+        type: "react18",
+        proxiesFile: "../components-react/src/components.ts",
+      },
+    ],
+    preamble: `All material copyright ESRI, All Rights Reserved, unless otherwise specified.\nSee https://github.com/Esri/calcite-design-system/blob/dev/LICENSE.md for details.\nv${version}`,
+  },
+  css: {
+    globalStylesPath: "src/styles/global/index.scss",
+    hydratedAttribute: "calcite-hydrated",
+  },
+  puppeteerTesting: {
+    enabled: !runBrowserTests,
+    waitForChangesDelay: 100,
+    launchOptions: {
+      devtools: process.env.DEVTOOLS === "true",
+      headless: process.env.HEADLESS === "false" ? false : undefined,
+    },
+  },
+  types: {
+    sourceFileTransformers: [
+      (sourceFile, context): readonly ts.Statement[] => {
+        if (process.env.NODE_ENV !== "production") {
+          return sourceFile.statements;
+        }
+
+        const testDataAttrPrefix = "data-test-";
+
+        function removeTestDataAttr(node: ts.Node): ts.Node | undefined {
+          return ts.isJsxAttribute(node) && node.name.getText(sourceFile).startsWith(testDataAttrPrefix)
+            ? undefined
+            : ts.visitEachChild(node, removeTestDataAttr, context.transformation);
+        }
+
+        return sourceFile.text.includes(testDataAttrPrefix)
+          ? sourceFile.statements.map((statement) => ts.visitNode(statement, removeTestDataAttr) as ts.Statement)
+          : sourceFile.statements;
+      },
+    ],
+  },
+});
+
 export default defineConfig({
   build: { minify: false },
   cacheDir: runBrowserTests ? undefined : "node_modules/.vite/puppeteer",
@@ -25,35 +75,7 @@ export default defineConfig({
     noExternal: nonEsmDependencies,
   },
 
-  plugins: [
-    useLumina({
-      build: {
-        dependencies: {
-          // Workaround for https://github.com/Esri/calcite-design-system/issues/10761
-          bundleIn: nonEsmDependencies,
-        },
-        wrappers: [
-          {
-            type: "react18",
-            proxiesFile: "../components-react/src/components.ts",
-          },
-        ],
-        preamble: `All material copyright ESRI, All Rights Reserved, unless otherwise specified.\nSee https://github.com/Esri/calcite-design-system/blob/dev/LICENSE.md for details.\nv${version}`,
-      },
-      css: {
-        globalStylesPath: "src/styles/global/index.scss",
-        hydratedAttribute: "calcite-hydrated",
-      },
-      puppeteerTesting: {
-        enabled: !runBrowserTests,
-        waitForChangesDelay: 100,
-        launchOptions: {
-          devtools: process.env.DEVTOOLS === "true",
-          headless: process.env.HEADLESS === "false" ? false : undefined,
-        },
-      },
-    }),
-  ],
+  plugins: [lumina],
 
   css: {
     postcss: {

--- a/packages/components/vite.config.ts
+++ b/packages/components/vite.config.ts
@@ -6,7 +6,7 @@ import stylelint from "stylelint";
 import { defineConfig } from "vite";
 import { useLumina } from "@arcgis/lumina-compiler";
 import { defaultExclude } from "vitest/config";
-import ts from "typescript";
+import removeTestDataAttr from "./build/transforms/remove-test-data-attributes";
 import { version } from "./package.json";
 import tailwindConfig from "./tailwind.config";
 
@@ -45,25 +45,7 @@ const lumina = useLumina({
     },
   },
   types: {
-    sourceFileTransformers: [
-      (sourceFile, context): readonly ts.Statement[] => {
-        if (process.env.NODE_ENV !== "production") {
-          return sourceFile.statements;
-        }
-
-        const testDataAttrPrefix = "data-test-";
-
-        function removeTestDataAttr(node: ts.Node): ts.Node | undefined {
-          return ts.isJsxAttribute(node) && node.name.getText(sourceFile).startsWith(testDataAttrPrefix)
-            ? undefined
-            : ts.visitEachChild(node, removeTestDataAttr, context.transformation);
-        }
-
-        return sourceFile.text.includes(testDataAttrPrefix)
-          ? sourceFile.statements.map((statement) => ts.visitNode(statement, removeTestDataAttr) as ts.Statement)
-          : sourceFile.statements;
-      },
-    ],
+    sourceFileTransformers: [removeTestDataAttr()],
   },
 });
 


### PR DESCRIPTION
**Related Issue:** #6760 

## Summary

Adds Lumina build source file transformer to remove test-related attributes (e.g., `data-test-id`, `data-test-active`) from production builds.