### PR TITLE
chore(github): fix path used in `updateIssueTemplateComponents`

### DIFF
--- a/.github/scripts/updateIssueTemplateComponents.js
+++ b/.github/scripts/updateIssueTemplateComponents.js
@@ -2,7 +2,7 @@
 const fs = require("fs");
 const path = require("path");
 
-const componentsDir = path.join(process.cwd(), "packages", "calcite-components", "src", "components");
+const componentsDir = path.join(process.cwd(), "packages", "components", "src", "components");
 const blockList = new Set([
   "Action Menu",
   "Color Picker Hex Input",


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Fixes a path still using the `calcite` directory prefix that was removed in https://github.com/Esri/calcite-design-system/pull/13208.