### PR TITLE
feat(date-picker, input-date-picker): add support for fr-CA

### DIFF
--- a/packages/components/src/components/date-picker/assets/nls/fr-CA.json
+++ b/packages/components/src/components/date-picker/assets/nls/fr-CA.json
@@ -1,0 +1,32 @@
+{
+  "default-calendar": "gregorian",
+  "separator": "-",
+  "unitOrder": "YYYY-MM-DD",
+  "weekStart": 7,
+  "placeholder": "YYYY-MM-DD",
+  "days": {
+    "abbreviated": ["dim.", "lun.", "mar.", "mer.", "jeu.", "ven.", "sam."],
+    "narrow": ["D", "L", "M", "M", "J", "V", "S"],
+    "short": ["di", "lu", "ma", "me", "je", "ve", "sa"],
+    "wide": ["dimanche", "lundi", "mardi", "mercredi", "jeudi", "vendredi", "samedi"]
+  },
+  "numerals": "0123456789",
+  "months": {
+    "abbreviated": ["janv.", "févr.", "mars", "avr.", "mai", "juin", "juill.", "août", "sept.", "oct.", "nov.", "déc."],
+    "narrow": ["J", "F", "M", "A", "M", "J", "J", "A", "S", "O", "N", "D"],
+    "wide": [
+      "janvier",
+      "février",
+      "mars",
+      "avril",
+      "mai",
+      "juin",
+      "juillet",
+      "août",
+      "septembre",
+      "octobre",
+      "novembre",
+      "décembre"
+    ]
+  }
+}

--- a/packages/components/src/components/date-picker/date-picker.stories.ts
+++ b/packages/components/src/components/date-picker/date-picker.stories.ts
@@ -201,7 +201,10 @@ export const localized = (): string => {
   `;
 };
 localized.parameters = {
-  chromatic: { diffThreshold: 1 },
+  chromatic: {
+    delay: 1000,
+    diffThreshold: 1,
+  },
 };
 
 export const widthSetToBreakpoints_TestOnly = (): string =>

--- a/packages/components/src/components/date-picker/date-picker.stories.ts
+++ b/packages/components/src/components/date-picker/date-picker.stories.ts
@@ -167,55 +167,40 @@ export const darkModeRTL_TestOnly = (): string => html`
 
 darkModeRTL_TestOnly.parameters = { themes: modesDarkDefault };
 
-export const bgLang_TestOnly = (): string => html`
-  <div style="width: 400px">
-    <calcite-date-picker lang="bg" scale="m" value="2020-02-28"></calcite-date-picker>
-  </div>
-`;
+export const localized = (): string => {
+  const locales = [
+    { label: "Arabic (ar):", lang: "ar" },
+    { label: "Arabic (ar) + Arab numbering system:", lang: "ar", numberingSystem: "arab" },
+    { label: "Bulgarian (bg):", lang: "bg" },
+    { label: "British English (en-gb):", lang: "en-gb" },
+    { label: "Chinese (zh-cn):", lang: "zh-cn" },
+    { label: "German (de):", lang: "de" },
+    { label: "French Canadian (fr-CA):", lang: "fr-CA" },
+    { label: "Norwegian (nb):", lang: "nb" },
+    { label: "Portuguese (pt-PT):", lang: "pt-PT" },
+    { label: "Spanish (es):", lang: "es" },
+  ];
 
-export const ptPTLang_TestOnly = (): string => html`
-  <div style="width: 400px">
-    <calcite-date-picker lang="pt-PT" scale="m" value="2020-02-28"></calcite-date-picker>
-  </div>
-`;
-
-export const germanLang_TestOnly = (): string => html`
-  <div style="width: 400px">
-    <calcite-date-picker lang="de" scale="m" value="2022-08-11"></calcite-date-picker>
-  </div>
-`;
-
-export const spanishLang_TestOnly = (): string => html`
-  <div style="width: 400px">
-    <calcite-date-picker lang="es" scale="m" value="2023-05-11"></calcite-date-picker>
-  </div>
-`;
-
-export const norwegianLang_TestOnly = (): string => html`
-  <div style="width: 400px">
-    <calcite-date-picker lang="nb" scale="m" value="2023-05-11"></calcite-date-picker>
-  </div>
-`;
-
-export const britishLang_TestOnly = (): string => html`
-  <div style="width: 400px">
-    <calcite-date-picker lang="en-gb" scale="m" value="2024-01-11"></calcite-date-picker>
-  </div>
-`;
-
-export const chineseLang_TestOnly = (): string => html`
-  <div style="width: 400px">
-    <calcite-date-picker lang="zh-cn" scale="m" value="2024-01-11"></calcite-date-picker>
-  </div>
-`;
-
-export const arabLangNumberingSystem_TestOnly = (): string => html`
-  <div style="width: 400px">
-    <calcite-date-picker lang="ar" numbering-system="arab" scale="m" value="2022-08-11"></calcite-date-picker>
-  </div>
-`;
-
-arabLangNumberingSystem_TestOnly.parameters = {
+  return html`
+    <div style="width: 400px; display: flex; flex-direction: column; gap: 16px;">
+      ${locales
+        .map(
+          ({ label, lang, numberingSystem }) => html`
+            <div>
+              <strong>${label}</strong>
+              <calcite-date-picker
+                lang="${lang}"
+                value="2020-02-28"
+                ${numberingSystem ? `numbering-system="${numberingSystem}"` : ""}
+              ></calcite-date-picker>
+            </div>
+          `,
+        )
+        .join("")}
+    </div>
+  `;
+};
+localized.parameters = {
   chromatic: { diffThreshold: 1 },
 };
 

--- a/packages/components/src/components/date-picker/date-picker.stories.ts
+++ b/packages/components/src/components/date-picker/date-picker.stories.ts
@@ -170,7 +170,7 @@ darkModeRTL_TestOnly.parameters = { themes: modesDarkDefault };
 export const localized = (): string => {
   const locales = [
     { label: "Arabic (ar):", lang: "ar" },
-    { label: "Arabic (ar) + Arab numbering system:", lang: "ar", numberingSystem: "arab" },
+    { label: "Arabic (ar) + Arabic numbering system:", lang: "ar", numberingSystem: "arab" },
     { label: "Bulgarian (bg):", lang: "bg" },
     { label: "British English (en-gb):", lang: "en-gb" },
     { label: "Chinese (zh-cn):", lang: "zh-cn" },

--- a/packages/components/src/components/date-picker/utils.ts
+++ b/packages/components/src/components/date-picker/utils.ts
@@ -58,6 +58,7 @@ const extraNlsLocales = [
   "en-CA",
   "en-GB",
   "es-MX",
+  "fr-CA",
   "fr-CH",
   "hi",
   "it-CH",

--- a/packages/components/src/components/input-date-picker/input-date-picker.stories.ts
+++ b/packages/components/src/components/input-date-picker/input-date-picker.stories.ts
@@ -387,3 +387,8 @@ export const localized = (): string => {
     </div>
   `;
 };
+localized.parameters = {
+  chromatic: {
+    delay: 1000,
+  },
+};

--- a/packages/components/src/components/input-date-picker/input-date-picker.stories.ts
+++ b/packages/components/src/components/input-date-picker/input-date-picker.stories.ts
@@ -370,10 +370,14 @@ export const localized = (): string => {
     <style>
       .use-cases {
         display: flex;
-        gap: 40px;
+        flex-wrap: wrap;
+        flex-direction: row;
+        gap: 350px 25px;
+        max-width: 1200px;
       }
       calcite-input-date-picker {
         width: 300px;
+        height: 300px;
       }
     </style>
     <div class="use-cases">
@@ -381,7 +385,12 @@ export const localized = (): string => {
         (locale) =>
           html`<div>
             <h3>${locale}</h3>
-            <calcite-input-date-picker lang="${locale}" open value="2020-12-12"></calcite-input-date-picker>
+            <calcite-input-date-picker
+              lang="${locale}"
+              open
+              placement="bottom-start"
+              value="2020-12-12"
+            ></calcite-input-date-picker>
           </div>`,
       )}
     </div>

--- a/packages/components/src/components/input-date-picker/input-date-picker.stories.ts
+++ b/packages/components/src/components/input-date-picker/input-date-picker.stories.ts
@@ -133,27 +133,6 @@ export const flipPlacements_TestOnly = (): string => html`
   </script>
 `;
 
-export const chineseLang_TestOnly = (): string => html`
-  <style>
-    .container {
-      width: 1000px;
-      height: 400px;
-    }
-  </style>
-  <div class="container">
-    <calcite-input-date-picker
-      open
-      value="1-1-1"
-      lang="zh-CN"
-      scale="l"
-      min="2020-12-12"
-      max="2020-12-16"
-      range
-      layout="horizontal"
-    ></calcite-input-date-picker>
-  </div>
-`;
-
 export const readOnlyHasNoDropdownAffordance_TestOnly = (): string => html`
   <calcite-input-date-picker read-only value="2020-12-12"></calcite-input-date-picker>
 `;
@@ -384,7 +363,27 @@ export const Focus = (): string =>
       })();
     </script>`;
 
-export const localeFormatting = (): string => html`
-  <calcite-input-date-picker value="2020-12-12" lang="bs"></calcite-input-date-picker>
-  <calcite-input-date-picker value="2020-12-12" lang="it-CH"></calcite-input-date-picker>
-`;
+export const localized = (): string => {
+  const locales = ["ar", "bs", "fr-CA", "it-CH", "zh-CN"];
+
+  return html`
+    <style>
+      .use-cases {
+        display: flex;
+        gap: 40px;
+      }
+      calcite-input-date-picker {
+        width: 300px;
+      }
+    </style>
+    <div class="use-cases">
+      ${locales.map(
+        (locale) =>
+          html`<div>
+            <h3>${locale}</h3>
+            <calcite-input-date-picker lang="${locale}" open value="2020-12-12"></calcite-input-date-picker>
+          </div>`,
+      )}
+    </div>
+  `;
+};


### PR DESCRIPTION
**Related Issue:** #12739 

## Summary

Adds calendar support for `fr-CA`.

### Noteworthy changes

* consolidates localized `date-picker`/`input-date-picker` stories
  * `input-date-picker`'s `chineseLang_TestOnly` story was significantly simplified – this seemed safe as the [previous version](https://github.com/Esri/calcite-design-system/pull/8402/commits/ddf6fb4abf14ddbf9c9f8addfcab3dc0ab01ca37#diff-7f7f554f952d5de6f34edd99045e2b733eb94356893329e036739cc9bec594d2L117) focused on using medium icon when using "l" scale, which is covered by the [`defaultAllScales`](https://esri.github.io/calcite-design-system/?path=/story/components-controls-inputdatepicker--default-all-scales) and [`rangeSmallAndLargeScales`](https://esri.github.io/calcite-design-system/?path=/story/components-controls-inputdatepicker--range-small-and-large-scales) stories. cc @anveshmekala 