### PR TITLE
feat(dropdown-item): reduce height in small & medium scale.

### DIFF
--- a/packages/components/src/components/dropdown-item/dropdown-item.scss
+++ b/packages/components/src/components/dropdown-item/dropdown-item.scss
@@ -43,7 +43,7 @@
 }
 
 .dropdown-item-content {
-  @apply flex-auto py-0.5;
+  @apply flex-auto;
 }
 
 // item icon

--- a/packages/components/src/components/dropdown-item/dropdown-item.scss
+++ b/packages/components/src/components/dropdown-item/dropdown-item.scss
@@ -28,14 +28,13 @@
   @apply relative
     flex
     flex-grow
-    focus-base
-    items-center;
-  outline: none;
+    items-center
+    outline-none;
 }
 
 .container {
   @include item-styling;
-  @apply focus-base text-start;
+  @apply text-start;
 
   & a {
     outline: none;

--- a/packages/components/src/components/dropdown-item/dropdown-item.scss
+++ b/packages/components/src/components/dropdown-item/dropdown-item.scss
@@ -30,6 +30,7 @@
     flex-grow
     focus-base
     items-center;
+  outline: none;
 }
 
 .container {


### PR DESCRIPTION
**Related Issue:** #10782

## Summary

- Reduce height of dropdown-item for `s` & `m` scales.

Other fixes:

- Remove semi-translucent outline when focusing with keyboard. 