### PR TITLE
fix: remove remaining references to legacy cdn output dir

### DIFF
--- a/examples/components/angular/README.md
+++ b/examples/components/angular/README.md
@@ -38,13 +38,6 @@ import "@esri/calcite-components/components/calcite-loader";
 import "@esri/calcite-components/components/calcite-slider";
 ```
 
-Then, import the global Calcite components stylesheet (only do this once):
-
-```css
-/* src/styles.css */
-@import "@esri/calcite-components/calcite/calcite.css";
-```
-
 To use Calcite components in Angular, you **must** add CUSTOM_ELEMENTS_SCHEMA to the `schemas` property:
 
 ```ts
@@ -79,5 +72,5 @@ Calcite components can now be used in your application like any other Angular co
 Calcite components' assets need to be copied to the `./public` directory when [using assets](https://developers.arcgis.com/calcite-design-system/get-started/#load-the-assets) locally. This example has a `copy` npm script, which will automatically run after installing dependencies. For example:
 
 ```sh
-cp -r node_modules/@esri/calcite-components/dist/calcite/assets/ ./public
+cp -r node_modules/@esri/calcite-components/dist/cdn/assets/ ./public
 ```

--- a/examples/components/angular/package.json
+++ b/examples/components/angular/package.json
@@ -14,7 +14,7 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
-    "copy": "ncp ./node_modules/@esri/calcite-components/dist/calcite/assets ./public/assets",
+    "copy": "ncp ./node_modules/@esri/calcite-components/dist/cdn/assets ./public/assets",
     "postinstall": "npm run copy"
   },
   "dependencies": {

--- a/examples/components/angular/src/styles.css
+++ b/examples/components/angular/src/styles.css
@@ -1,5 +1,3 @@
-@import "@esri/calcite-components/calcite/calcite.css";
-
 html,
 body {
   height: 100%;

--- a/examples/components/preact/README.md
+++ b/examples/components/preact/README.md
@@ -28,13 +28,6 @@ import { defineCustomElements } from "@esri/calcite-components/dist/loader";
 defineCustomElements(window);
 ```
 
-Next, import the global Calcite components stylesheet (only do this once):
-
-```ts
-// src/index.ts
-import "@esri/calcite-components/dist/calcite/calcite.css";
-```
-
 Now you can use Calcite components in your application:
 
 ```tsx

--- a/examples/components/preact/src/index.ts
+++ b/examples/components/preact/src/index.ts
@@ -1,6 +1,5 @@
 import "./style/index.css";
 import App from "./components/app";
-import "@esri/calcite-components/calcite/calcite.css";
 import { setAssetPath } from "@esri/calcite-components";
 import { defineCustomElements } from "@esri/calcite-components/loader";
 

--- a/examples/components/react/README.md
+++ b/examples/components/react/README.md
@@ -32,7 +32,7 @@ import { setAssetPath } from "@esri/calcite-components/dist/components";
 setAssetPath(window.location.href);
 
 // CDN hosted assets
-// setAssetPath("https://unpkg.com/@esri/calcite-components/dist/calcite/assets");
+// setAssetPath("https://unpkg.com/@esri/calcite-components/dist/cdn/assets");
 ```
 
 Next, import the components used in your application:
@@ -47,18 +47,12 @@ import "@esri/calcite-components/dist/components/calcite-slider";
 import { CalciteButton, CalciteIcon, CalciteSlider } from "@esri/calcite-components-react";
 ```
 
-Lastly, import the global Calcite components stylesheet (only do this once):
-
-```ts
-import "@esri/calcite-components/dist/calcite/calcite.css";
-```
-
 ### Copy the assets
 
 Calcite components' assets need to be copied from `node_modules` to your application (unless you use a CDN). This example leverages the [`vite-plugin-static-copy`](https://github.com/sapphi-red/vite-plugin-static-copy) package. Alternatively, you could use a CLI tool to copy the assets on `postinstall`. For example:
 
 ```sh
-cp -r node_modules/@esri/calcite-components/dist/calcite/assets/* ./public
+cp -r node_modules/@esri/calcite-components/dist/cdn/assets/* ./public
 ```
 
 ## Why not use the web components directly?

--- a/examples/components/react/src/main.tsx
+++ b/examples/components/react/src/main.tsx
@@ -2,8 +2,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
-import "@esri/calcite-components/dist/calcite/calcite.css";
-import { setAssetPath } from "@esri/calcite-components/dist/components";
+import { setAssetPath } from "@esri/calcite-components";
 
 setAssetPath(window.location.href);
 

--- a/examples/components/react/src/main.tsx
+++ b/examples/components/react/src/main.tsx
@@ -2,7 +2,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
-import { setAssetPath } from "@esri/calcite-components";
+import { setAssetPath } from "@esri/calcite-components/dist/components";
 
 setAssetPath(window.location.href);
 

--- a/examples/components/rollup/README.md
+++ b/examples/components/rollup/README.md
@@ -37,12 +37,6 @@ import "@esri/calcite-components/dist/components/calcite-icon";
 import "@esri/calcite-components/dist/components/calcite-date-picker";
 ```
 
-Lastly, import the global Calcite components stylesheet (only do this once):
-
-```js
-import "@esri/calcite-components/dist/calcite/calcite.css";
-```
-
 ### Configure Rollup
 
 There are a few more steps required so that rollup can successfully bundle our application:
@@ -95,7 +89,7 @@ plugins: [
   copy({
     targets: [
       {
-        src: path.resolve(__dirname, 'node_modules/@esri/calcite-components/dist/calcite/assets'),
+        src: path.resolve(__dirname, 'node_modules/@esri/calcite-components/dist/cdn/assets'),
         dest: path.resolve(__dirname, 'public')
       },
     ],

--- a/examples/components/rollup/rollup.config.js
+++ b/examples/components/rollup/rollup.config.js
@@ -26,7 +26,7 @@ export default defineConfig({
       // copy over the calcite-components assets
       targets: [
         {
-          src: "./node_modules/@esri/calcite-components/dist/calcite/assets",
+          src: "./node_modules/@esri/calcite-components/dist/cdn/assets",
           dest: "./public",
         },
       ],

--- a/examples/components/rollup/src/main.js
+++ b/examples/components/rollup/src/main.js
@@ -1,4 +1,4 @@
-import { setAssetPath } from "@esri/calcite-components";
+import { setAssetPath } from "@esri/calcite-components/dist/components";
 import "@esri/calcite-components/dist/components/calcite-button";
 import "@esri/calcite-components/dist/components/calcite-icon";
 import "@esri/calcite-components/dist/components/calcite-date-picker";

--- a/examples/components/rollup/src/main.js
+++ b/examples/components/rollup/src/main.js
@@ -1,7 +1,6 @@
-import { setAssetPath } from "@esri/calcite-components/dist/components";
+import { setAssetPath } from "@esri/calcite-components";
 import "@esri/calcite-components/dist/components/calcite-button";
 import "@esri/calcite-components/dist/components/calcite-icon";
 import "@esri/calcite-components/dist/components/calcite-date-picker";
-import "@esri/calcite-components/dist/calcite/calcite.css";
 
 setAssetPath(document.currentScript.src);

--- a/examples/components/vite/README.md
+++ b/examples/components/vite/README.md
@@ -38,13 +38,6 @@ import "@esri/calcite-components/dist/components/calcite-date-picker";
 import "@esri/calcite-components/dist/components/calcite-loader";
 ```
 
-Lastly, import the global Calcite components stylesheet (only do this once):
-
-```js
-// main.ts
-import "@esri/calcite-components/dist/calcite/calcite.css";
-```
-
 ### Copy the assets
 
 You can use the `vite-plugin-static-copy` package to copy Calcite components' assets to your application:

--- a/examples/components/vite/main.ts
+++ b/examples/components/vite/main.ts
@@ -3,13 +3,12 @@
  * Refer to the documentation if switching to the Distribution build:
  * https://developers.arcgis.com/calcite-design-system/get-started/#choose-a-build
  **/
-import { setAssetPath } from "@esri/calcite-components/dist/components";
+import { setAssetPath } from "@esri/calcite-components";
 import "@esri/calcite-components/dist/components/calcite-button";
 import "@esri/calcite-components/dist/components/calcite-icon";
 import "@esri/calcite-components/dist/components/calcite-date-picker";
 import "@esri/calcite-components/dist/components/calcite-loader";
 
-import "@esri/calcite-components/dist/calcite/calcite.css";
 import "./style.css";
 
 setAssetPath(location.href);

--- a/examples/components/vite/main.ts
+++ b/examples/components/vite/main.ts
@@ -3,7 +3,7 @@
  * Refer to the documentation if switching to the Distribution build:
  * https://developers.arcgis.com/calcite-design-system/get-started/#choose-a-build
  **/
-import { setAssetPath } from "@esri/calcite-components";
+import { setAssetPath } from "@esri/calcite-components/dist/components";
 import "@esri/calcite-components/dist/components/calcite-button";
 import "@esri/calcite-components/dist/components/calcite-icon";
 import "@esri/calcite-components/dist/components/calcite-date-picker";

--- a/examples/components/vue/README.md
+++ b/examples/components/vue/README.md
@@ -37,13 +37,6 @@ import "@esri/calcite-components/dist/components/calcite-icon";
 import "@esri/calcite-components/dist/components/calcite-date-picker";
 ```
 
-Lastly, add the global Calcite components stylesheet (only do this once):
-
-```html
-<!-- src/components/HelloWorld.vue -->
-<style src="@esri/calcite-components/dist/calcite/calcite.css"></style>
-```
-
 ### Copy the assets
 
 Static assets must be copied over to the public folder manually. A `copy` script has been created to make this process easier:

--- a/examples/components/vue/package.json
+++ b/examples/components/vue/package.json
@@ -13,7 +13,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "postinstall": "npm run copy",
-    "copy": "ncp ./node_modules/@esri/calcite-components/dist/calcite/assets/ ./public/assets/"
+    "copy": "ncp ./node_modules/@esri/calcite-components/dist/cdn/assets/ ./public/assets/"
   },
   "dependencies": {
     "@esri/calcite-components": "3.3.3",

--- a/examples/components/vue/src/components/HelloWorld.vue
+++ b/examples/components/vue/src/components/HelloWorld.vue
@@ -34,8 +34,6 @@ export default {
 };
 </script>
 
-<style src="@esri/calcite-components/dist/calcite/calcite.css"></style>
-
 <template>
   <div class="hello">
     <h1>{{ msg }} <calcite-icon icon="banana"></calcite-icon></h1>

--- a/examples/components/web-dev-server/components/flow.html
+++ b/examples/components/web-dev-server/components/flow.html
@@ -4,12 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
     <title>Flow</title>
-    <script type="module" src="../../node_modules/@esri/calcite-components/dist/calcite/calcite.esm.js"></script>
-    <link
-      rel="stylesheet"
-      type="text/css"
-      href="../../node_modules/@esri/calcite-components/dist/calcite/calcite.css"
-    />
+    <script type="module" src="../../node_modules/@esri/calcite-components/dist/index.js"></script>
 
     <style>
       body,

--- a/examples/components/web-dev-server/components/slider.html
+++ b/examples/components/web-dev-server/components/slider.html
@@ -4,12 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
     <title>Slider</title>
-    <script type="module" src="../../node_modules/@esri/calcite-components/dist/calcite/calcite.esm.js"></script>
-    <link
-      rel="stylesheet"
-      type="text/css"
-      href="../../node_modules/@esri/calcite-components/dist/calcite/calcite.css"
-    />
+    <script type="module" src="../../node_modules/@esri/calcite-components/dist/index.js"></script>
     <style>
       body,
       html,

--- a/examples/components/web-dev-server/index.html
+++ b/examples/components/web-dev-server/index.html
@@ -3,8 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
-    <script type="module" src="./node_modules/@esri/calcite-components/dist/calcite/calcite.esm.js"></script>
-    <link rel="stylesheet" type="text/css" href="./node_modules/@esri/calcite-components/dist/calcite/calcite.css" />
+    <script type="module" src="./node_modules/@esri/calcite-components/dist/index.js"></script>
     <link rel="stylesheet" href="./index.css" />
     <title>Calcite common workflow patterns</title>
   </head>

--- a/examples/components/webpack/README.md
+++ b/examples/components/webpack/README.md
@@ -68,7 +68,7 @@ This will ensure the library is available to your application.
 
 #### Add CSS loader
 
-While we imported CSS file above, we need to output a CSS file in the final bundle. To do this, you can leverage [mini-css-extract-plugin](https://webpack.js.org/plugins/mini-css-extract-plugin/).
+To output a CSS file in the final bundle, you can leverage [mini-css-extract-plugin](https://webpack.js.org/plugins/mini-css-extract-plugin/).
 
 First, install the required plugin and loader packages:
 

--- a/examples/components/webpack/README.md
+++ b/examples/components/webpack/README.md
@@ -36,15 +36,6 @@ import "@esri/calcite-components/dist/components/calcite-icon";
 import "@esri/calcite-components/dist/components/calcite-date-picker";
 ```
 
-Lastly, import the global Calcite components stylesheet (only do this once):
-
-```js
-import "@esri/calcite-components/dist/calcite/calcite.css";
-```
-
-> [!NOTE]
-> This requires setting up a CSS loader in your Webpack config (see [below](#add-css-loader))
-
 ### Configure Webpack
 
 Calcite components need to be copied to your output directory so they can be loaded from the client. The easiest way to do this is with [copy-webpack-plugin](https://webpack.js.org/plugins/copy-webpack-plugin/). First, install the package:
@@ -64,7 +55,7 @@ module.exports = {
       patterns: [
         {
           from: "**",
-          context: "node_modules/@esri/calcite-components/dist/calcite/",
+          context: "node_modules/@esri/calcite-components/dist/cdn/",
           to: "./",
         },
       ],

--- a/examples/components/webpack/src/index.js
+++ b/examples/components/webpack/src/index.js
@@ -1,7 +1,7 @@
 import "@esri/calcite-components/dist/components/calcite-button";
 import "@esri/calcite-components/dist/components/calcite-icon";
 import "@esri/calcite-components/dist/components/calcite-date-picker";
-import { setAssetPath } from "@esri/calcite-components";
+import { setAssetPath } from "@esri/calcite-components/dist/components";
 
 setAssetPath(location.href);
 

--- a/examples/components/webpack/src/index.js
+++ b/examples/components/webpack/src/index.js
@@ -1,8 +1,7 @@
 import "@esri/calcite-components/dist/components/calcite-button";
 import "@esri/calcite-components/dist/components/calcite-icon";
 import "@esri/calcite-components/dist/components/calcite-date-picker";
-import "@esri/calcite-components/dist/calcite/calcite.css";
-import { setAssetPath } from "@esri/calcite-components/dist/components";
+import { setAssetPath } from "@esri/calcite-components";
 
 setAssetPath(location.href);
 

--- a/examples/components/webpack/webpack.config.js
+++ b/examples/components/webpack/webpack.config.js
@@ -31,7 +31,7 @@ module.exports = {
       patterns: [
         {
           from: "**",
-          context: "node_modules/@esri/calcite-components/dist/calcite/",
+          context: "node_modules/@esri/calcite-components/dist/cdn/",
           to: "./",
         },
       ],

--- a/packages/components-react/README.md
+++ b/packages/components-react/README.md
@@ -49,20 +49,12 @@ Since you manually defined the custom elements on the window, you only need to i
 import { CalciteButton, CalciteIcon, CalciteSlider } from "@esri/calcite-components-react";
 ```
 
-## Import stylesheet
-
-Import the global stylesheet into your app (only do this once):
-
-```js
-import "@esri/calcite-components/dist/calcite/calcite.css";
-```
-
 ## Copy Assets
 
 Some components (icon, date-picker) rely on assets being available at a particular path. If using assets locally, you'll need to copy these over to your public folder. Something like:
 
 ```sh
-cp -r node_modules/@esri/calcite-components/dist/calcite/assets/* ./public/assets/
+cp -r node_modules/@esri/calcite-components/dist/cdn/assets/* ./public/assets/
 ```
 
 ## Why not just use the web components directly?

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -15,10 +15,7 @@ The most common approach for loading Calcite components is to use the version ho
 <!-- x-release-please-start-version -->
 
 ```html
-<script
-  type="module"
-  src="https://cdn.jsdelivr.net/npm/@esri/calcite-components@3.3.3/dist/calcite/calcite.esm.js"
-></script>
+<script type="module" src="https://cdn.jsdelivr.net/npm/@esri/calcite-components@5.0.0/dist/index.js"></script>
 ```
 
 <!-- x-release-please-end -->

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -25,8 +25,8 @@
     "./main.css": "./dist/cdn/main.css"
   },
   "main": "dist/index.js",
-  "jsdelivr": "dist/calcite/calcite.js",
-  "unpkg": "dist/calcite/calcite.js",
+  "jsdelivr": "dist/index.js",
+  "unpkg": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [


### PR DESCRIPTION
**Related Issue:** #13266

## Summary

This updates references that were missed in https://github.com/Esri/calcite-design-system/pull/12546 and https://github.com/Esri/calcite-design-system/pull/13401/.

### Notable changes:

* updates package exports for CDN hosts
* updates path used for copying assets
* removes unnecessary stylesheet imports in doc and examples

**Note**: examples use latest version of `calcite-components` (not `next`), so URLs will be broken unless manually installing prerelease versions