### PR TITLE
feat(accordion-item): update action slot spacing

### DIFF
--- a/packages/components/src/components/accordion-item/accordion-item.scss
+++ b/packages/components/src/components/accordion-item/accordion-item.scss
@@ -166,16 +166,15 @@
       ease-in-out;
     @include includes.word-break();
   }
-  .actions-start,
-  .actions-end {
+  .has-actions {
     gap: var(--calcite-internal-accordion-item-action-slot-spacing);
   }
-  .actions-start {
+  .actions-start.has-actions {
     padding-block: var(--calcite-internal-accordion-item-action-slot-spacing)
       var(--calcite-internal-accordion-item-action-slot-spacing);
     padding-inline: var(--calcite-internal-accordion-item-action-slot-spacing) 0;
   }
-  .actions-end {
+  .actions-end.has-actions {
     padding-block: var(--calcite-internal-accordion-item-action-slot-spacing)
       var(--calcite-internal-accordion-item-action-slot-spacing);
     padding-inline: 0 var(--calcite-internal-accordion-item-action-slot-spacing);

--- a/packages/components/src/components/accordion-item/accordion-item.scss
+++ b/packages/components/src/components/accordion-item/accordion-item.scss
@@ -169,7 +169,16 @@
   .actions-start,
   .actions-end {
     gap: var(--calcite-internal-accordion-item-action-slot-spacing);
-    padding: var(--calcite-internal-accordion-item-action-slot-spacing);
+  }
+  .actions-start {
+    padding-block: var(--calcite-internal-accordion-item-action-slot-spacing)
+      var(--calcite-internal-accordion-item-action-slot-spacing);
+    padding-inline: var(--calcite-internal-accordion-item-action-slot-spacing) 0;
+  }
+  .actions-end {
+    padding-block: var(--calcite-internal-accordion-item-action-slot-spacing)
+      var(--calcite-internal-accordion-item-action-slot-spacing);
+    padding-inline: 0 var(--calcite-internal-accordion-item-action-slot-spacing);
   }
 }
 
@@ -232,13 +241,6 @@
 
 :host([scale="l"]) .heading {
   font-size: var(--calcite-font-size-0);
-}
-
-.actions-start,
-.actions-end {
-  ::slotted(calcite-action) {
-    @apply self-stretch;
-  }
 }
 
 .icon {

--- a/packages/components/src/components/accordion-item/accordion-item.scss
+++ b/packages/components/src/components/accordion-item/accordion-item.scss
@@ -168,15 +168,12 @@
   }
   .has-actions {
     gap: var(--calcite-internal-accordion-item-action-slot-spacing);
+    padding-block: var(--calcite-internal-accordion-item-action-slot-spacing);
   }
   .actions-start.has-actions {
-    padding-block: var(--calcite-internal-accordion-item-action-slot-spacing)
-      var(--calcite-internal-accordion-item-action-slot-spacing);
     padding-inline: var(--calcite-internal-accordion-item-action-slot-spacing) 0;
   }
   .actions-end.has-actions {
-    padding-block: var(--calcite-internal-accordion-item-action-slot-spacing)
-      var(--calcite-internal-accordion-item-action-slot-spacing);
     padding-inline: 0 var(--calcite-internal-accordion-item-action-slot-spacing);
   }
 }

--- a/packages/components/src/components/accordion-item/accordion-item.scss
+++ b/packages/components/src/components/accordion-item/accordion-item.scss
@@ -27,6 +27,7 @@
 //
 // Internal CSS custom properties for component use only. Overwriting is not recommended.
 //
+// --calcite-internal-accordion-item-action-slot-spacing
 // --calcite-internal-accordion-item-active-icon-rotation
 // --calcite-internal-accordion-item-active-icon-rotation-rtl
 // --calcite-internal-accordion-item-flex-direction
@@ -45,6 +46,16 @@
   --calcite-internal-accordion-item-active-icon-rotation: theme("rotate.0");
   --calcite-internal-accordion-item-icon-rotation-rtl: theme("rotate.90");
   --calcite-internal-accordion-item-active-icon-rotation-rtl: theme("rotate.0");
+}
+
+:host([scale="s"]) {
+  --calcite-internal-accordion-item-action-slot-spacing: var(--calcite-spacing-xxs);
+}
+:host([scale="m"]) {
+  --calcite-internal-accordion-item-action-slot-spacing: var(--calcite-spacing-xxs);
+}
+:host([scale="l"]) {
+  --calcite-internal-accordion-item-action-slot-spacing: var(--calcite-spacing-xs);
 }
 
 :host {
@@ -154,6 +165,11 @@
       items-center
       ease-in-out;
     @include includes.word-break();
+  }
+  .actions-start,
+  .actions-end {
+    gap: var(--calcite-internal-accordion-item-action-slot-spacing);
+    padding: var(--calcite-internal-accordion-item-action-slot-spacing);
   }
 }
 

--- a/packages/components/src/components/accordion-item/accordion-item.tsx
+++ b/packages/components/src/components/accordion-item/accordion-item.tsx
@@ -298,16 +298,24 @@ export class AccordionItem extends LitElement {
   //#region Rendering
 
   private renderActionsStart(): JsxNode {
+    const { hasActionsStart } = this;
     return (
-      <div class={CSS.actionsStart} hidden={!this.hasActionsStart}>
+      <div
+        class={{ [CSS.actionsStart]: true, [CSS.hasActions]: hasActionsStart }}
+        hidden={!hasActionsStart}
+      >
         <slot name={SLOTS.actionsStart} onSlotChange={this.handleActionsStartSlotChange} />
       </div>
     );
   }
 
   private renderActionsEnd(): JsxNode {
+    const { hasActionsEnd } = this;
     return (
-      <div class={CSS.actionsEnd} hidden={!this.hasActionsEnd}>
+      <div
+        class={{ [CSS.actionsEnd]: true, [CSS.hasActions]: hasActionsEnd }}
+        hidden={!hasActionsEnd}
+      >
         <slot name={SLOTS.actionsEnd} onSlotChange={this.handleActionsEndSlotChange} />
       </div>
     );

--- a/packages/components/src/components/accordion-item/resources.ts
+++ b/packages/components/src/components/accordion-item/resources.ts
@@ -14,6 +14,7 @@ export const CSS = {
   content: "content",
   description: "description",
   expandIcon: "expand-icon",
+  hasActions: "has-actions",
   header: "header",
   headerContainer: "header-container",
   headerContent: "header-content",

--- a/packages/components/src/components/accordion/accordion.stories.ts
+++ b/packages/components/src/components/accordion/accordion.stories.ts
@@ -103,7 +103,7 @@ export const withActions = (): string => html`
       <calcite-action scale="s" icon="banana" label="Banana" slot="actions-end"></calcite-action>
       <calcite-action scale="s" icon="sound" label="Volume" slot="actions-end"></calcite-action>
     </calcite-accordion-item>
-    <calcite-accordion-item scale="m" heading="Accordion Item 2Accordion Item 2Accordion Item 2Accordion Item 2" expanded>
+    <calcite-accordion-item scale="m" heading="Accordion Item 2" expanded>
       <calcite-action scale="s" icon="brush-tip" label="Paint" slot="actions-start"></calcite-action
       >${accordionItemContent}
       <calcite-action scale="s" icon="banana" label="Banana" slot="actions-start"></calcite-action>

--- a/packages/components/src/components/accordion/accordion.stories.ts
+++ b/packages/components/src/components/accordion/accordion.stories.ts
@@ -103,7 +103,7 @@ export const withActions = (): string => html`
       <calcite-action scale="s" icon="banana" label="Banana" slot="actions-end"></calcite-action>
       <calcite-action scale="s" icon="sound" label="Volume" slot="actions-end"></calcite-action>
     </calcite-accordion-item>
-    <calcite-accordion-item scale="m" heading="Accordion Item 2" expanded>
+    <calcite-accordion-item scale="m" heading="Accordion Item 2Accordion Item 2Accordion Item 2Accordion Item 2" expanded>
       <calcite-action scale="s" icon="brush-tip" label="Paint" slot="actions-start"></calcite-action
       >${accordionItemContent}
       <calcite-action scale="s" icon="banana" label="Banana" slot="actions-start"></calcite-action>


### PR DESCRIPTION
**Related Issue:** #10777 

## Summary

This PR updates `accordion-item`'s action slot spacing to use the new Action 5.0 design spacing.