### PR TITLE
docs(action): revert deprecation notice for action's solid appearance

### DIFF
--- a/packages/components/src/components/action/action.tsx
+++ b/packages/components/src/components/action/action.tsx
@@ -96,11 +96,7 @@ export class Action extends LitElement implements FormOwner {
   /** Specifies the horizontal alignment of button elements with text content. */
   @property({ reflect: true }) alignment: Alignment;
 
-  /**
-   * Specifies the appearance of the component.
-   *
-   * @deprecated in v5.0.0, removal target v6.0.0 - No longer necessary.
-   */
+  /** Specifies the appearance of the component. */
   @property({ reflect: true }) appearance: Extract<"solid" | "transparent", Appearance> =
     "transparent";
 


### PR DESCRIPTION
**Related Issue:** #10759

## Summary

This PR reverts the deprecation notice for calcite-action's solid appearance property value.

This is based on the use case brought up here for solid action buttons: https://github.com/Esri/calcite-design-system/issues/10759#issuecomment-3628234230