### PR TITLE
deprecate(input-message): deprecate component

### DIFF
--- a/packages/components/src/components/input-message/input-message.tsx
+++ b/packages/components/src/components/input-message/input-message.tsx
@@ -24,9 +24,8 @@ declare global {
 
 /**
  * @deprecated in v5.0.0, removal target v6.0.0 - Use the `calcite-notice` component with `appearance="transparent"` instead.
+ * @slot - A slot for adding text.
  */
-
-/** @slot - A slot for adding text. */
 export class InputMessage extends LitElement {
   //#region Static Members
 

--- a/packages/components/src/components/input-message/input-message.tsx
+++ b/packages/components/src/components/input-message/input-message.tsx
@@ -22,6 +22,10 @@ declare global {
   }
 }
 
+/**
+ * @deprecated in v5.0.0, removal target v6.0.0 - Use the `calcite-notice` component with `appearance="transparent"` instead.
+ */
+
 /** @slot - A slot for adding text. */
 export class InputMessage extends LitElement {
   //#region Static Members


### PR DESCRIPTION
**Related Issue:** #10477 

## Summary

Deprecates `input-message` component. Use `notice` component with `appearance="transparent"` instead.