### PR TITLE
refactor: update vitest import

### DIFF
--- a/packages/components/src/tests/commonTests/browser/disabled.ts
+++ b/packages/components/src/tests/commonTests/browser/disabled.ts
@@ -1,6 +1,6 @@
 import { SetFieldType } from "type-fest";
 import { expect, it, vi } from "vitest";
-import { page, userEvent } from "@vitest/browser/context";
+import { page, userEvent } from "vitest/browser";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import { waitForAnimationFrame, waitForNextTick } from "../../utils/timing";
 import { IntrinsicElementsWithProp } from "../../utils/interfaces";


### PR DESCRIPTION
**monday.com sync:** #12164338208

**Related Issue:** N/A

## Summary

Updates `@vitest/browser/context` import to `vitest/browser` per [Vitest v4 doc](https://vitest.dev/guide/migration.html#vitest-4:~:text=WARNING,a%20future%20release.):

> With this change, the `@vitest/browser` package is no longer needed, and you can remove it from your dependencies. To support the context import, you should update the `@vitest/browser/context` to `vitest/browser`

> Both `@vitest/browser/context` and `@vitest/browser/utils` work at runtime during the transition period, but they will be removed in a future release.