### PR TITLE
feat(combobox-item)!: remove textLabel prop and update heading and value properties

### DIFF
--- a/packages/components/src/components/combobox-item/combobox-item.browser.e2e.tsx
+++ b/packages/components/src/components/combobox-item/combobox-item.browser.e2e.tsx
@@ -25,7 +25,6 @@ describe("calcite-combobox-item", () => {
         { propertyName: "label", defaultValue: undefined },
         { propertyName: "selected", defaultValue: false },
         { propertyName: "shortHeading", defaultValue: undefined },
-        { propertyName: "textLabel", defaultValue: undefined },
         { propertyName: "value", defaultValue: undefined },
       ],
     );

--- a/packages/components/src/components/combobox-item/combobox-item.tsx
+++ b/packages/components/src/components/combobox-item/combobox-item.tsx
@@ -5,7 +5,7 @@ import { guid } from "../../utils/guid";
 import { ComboboxChildElement } from "../combobox/interfaces";
 import { getAncestors, getDepth, isSingleLike } from "../combobox/utils";
 import { Scale, SelectionMode } from "../interfaces";
-import { getIconScale, warnIfMissingRequiredProp } from "../../utils/component";
+import { getIconScale } from "../../utils/component";
 import { IconName } from "../icon/interfaces";
 import { slotChangeHasContent } from "../../utils/dom";
 import { highlightText } from "../../utils/text";
@@ -72,7 +72,11 @@ export class ComboboxItem extends LitElement {
   /** The `id` attribute of the component. When omitted, a globally unique identifier is used. */
   @property({ reflect: true }) guid = guid();
 
-  /** The component's text. */
+  /**
+   * The component's text.
+   *
+   * @required
+   */
   @property() heading: string;
 
   /** Specifies an icon to display. */
@@ -135,18 +139,7 @@ export class ComboboxItem extends LitElement {
    */
   @property() shortHeading: string;
 
-  /**
-   * The component's text.
-   *
-   * @deprecated in v2.12.0, removal target v5.0.0 - Use the `heading` property instead.
-   */
-  @property({ reflect: true }) textLabel: string;
-
-  /**
-   * The component's value.
-   *
-   * @required
-   */
+  /** The component's value. */
   @property() value: any;
 
   /**
@@ -206,17 +199,10 @@ export class ComboboxItem extends LitElement {
     this.ancestors = getAncestors(this.el);
   }
 
-  load(): void {
-    warnIfMissingRequiredProp(this, "value", "textLabel");
-  }
-
   override willUpdate(changes: PropertyValues<this>): void {
     if (
       this.hasUpdated &&
-      (changes.has("disabled") ||
-        changes.has("heading") ||
-        changes.has("label") ||
-        changes.has("textLabel"))
+      (changes.has("disabled") || changes.has("heading") || changes.has("label"))
     ) {
       this.emitItemChange();
     }
@@ -279,16 +265,8 @@ export class ComboboxItem extends LitElement {
   }
 
   override render(): JsxNode {
-    const {
-      disabled,
-      heading,
-      label,
-      textLabel,
-      value,
-      filterTextMatchPattern,
-      description,
-      shortHeading,
-    } = this;
+    const { disabled, heading, label, value, filterTextMatchPattern, description, shortHeading } =
+      this;
     const isSingleSelect = isSingleLike(this.selectionMode);
     const icon = disabled || isSingleSelect ? undefined : ICONS.checked;
     const selectionIcon = isSingleSelect
@@ -300,7 +278,6 @@ export class ComboboxItem extends LitElement {
         : this.selected
           ? ICONS.checked
           : ICONS.unchecked;
-    const headingText = heading || textLabel;
     const itemLabel = label || value;
 
     const classes = {
@@ -331,7 +308,7 @@ export class ComboboxItem extends LitElement {
             <div class={CSS.centerContent}>
               <div class={CSS.heading}>
                 {highlightText({
-                  text: headingText,
+                  text: heading,
                   pattern: filterTextMatchPattern,
                 })}
               </div>

--- a/packages/components/src/components/combobox/combobox.browser.e2e.tsx
+++ b/packages/components/src/components/combobox/combobox.browser.e2e.tsx
@@ -144,9 +144,9 @@ describe("calcite-combobox", () => {
       () =>
         mount(
           <calcite-combobox>
-            <calcite-combobox-item icon="banana" id="one" text-label="One" value="one" />
-            <calcite-combobox-item icon="beaker" id="two" selected text-label="Two" value="two" />
-            <calcite-combobox-item id="three" text-label="Three" value="three" />
+            <calcite-combobox-item heading="One" icon="banana" id="one" value="one" />
+            <calcite-combobox-item heading="Two" icon="beaker" id="two" selected value="two" />
+            <calcite-combobox-item heading="Three" id="three" value="three" />
           </calcite-combobox>,
         ),
       "open",

--- a/packages/components/src/components/combobox/combobox.e2e.ts
+++ b/packages/components/src/components/combobox/combobox.e2e.ts
@@ -28,8 +28,8 @@ describe("calcite-combobox", () => {
   describe("focusable", () => {
     focusable(html`
       <calcite-combobox label="Trees" value="Trees">
-        <calcite-combobox-item value="Pine" text-label="Pine"></calcite-combobox-item>
-        <calcite-combobox-item value="Spruce" text-label="Spruce"></calcite-combobox-item>
+        <calcite-combobox-item value="Pine" heading="Pine"></calcite-combobox-item>
+        <calcite-combobox-item value="Spruce" heading="Spruce"></calcite-combobox-item>
       </calcite-combobox>
     `);
   });
@@ -37,7 +37,7 @@ describe("calcite-combobox", () => {
   describe("accessible", () => {
     accessible(html`
       <calcite-combobox label="Trees" value="Trees">
-        <calcite-combobox-item value="Pine" text-label="Pine"></calcite-combobox-item>
+        <calcite-combobox-item value="Pine" heading="Pine"></calcite-combobox-item>
       </calcite-combobox>
     `);
   });
@@ -46,7 +46,7 @@ describe("calcite-combobox", () => {
     accessible(html`
       <calcite-combobox label="Trees" value="Trees">
         <calcite-combobox-item-group label="Conifers">
-          <calcite-combobox-item value="Pine" text-label="Pine"></calcite-combobox-item>
+          <calcite-combobox-item value="Pine" heading="Pine"></calcite-combobox-item>
         </calcite-combobox-item-group>
       </calcite-combobox>
     `);
@@ -56,8 +56,8 @@ describe("calcite-combobox", () => {
     accessible(html`
       <calcite-combobox open label="Trees" value="Trees">
         <calcite-combobox-item-group label="Conifers">
-          <calcite-combobox-item selected value="Pine" text-label="Pine"></calcite-combobox-item>
-          <calcite-combobox-item selected value="Spruce" text-label="Spruce"></calcite-combobox-item>
+          <calcite-combobox-item selected value="Pine" heading="Pine"></calcite-combobox-item>
+          <calcite-combobox-item selected value="Spruce" heading="Spruce"></calcite-combobox-item>
         </calcite-combobox-item-group>
       </calcite-combobox>
     `);
@@ -69,10 +69,10 @@ describe("calcite-combobox", () => {
 
   const simpleComboboxHTML = html`
     <calcite-combobox id="myCombobox">
-      <calcite-combobox-item value="Raising Arizona" text-label="Raising Arizona"></calcite-combobox-item>
-      <calcite-combobox-item value="Miller's Crossing" text-label="Miller's Crossing"></calcite-combobox-item>
-      <calcite-combobox-item value="The Hudsucker Proxy" text-label="The Hudsucker Proxy"></calcite-combobox-item>
-      <calcite-combobox-item value="Inside Llewyn Davis" text-label="Inside Llewyn Davis"></calcite-combobox-item>
+      <calcite-combobox-item value="Raising Arizona" heading="Raising Arizona"></calcite-combobox-item>
+      <calcite-combobox-item value="Miller's Crossing" heading="Miller's Crossing"></calcite-combobox-item>
+      <calcite-combobox-item value="The Hudsucker Proxy" heading="The Hudsucker Proxy"></calcite-combobox-item>
+      <calcite-combobox-item value="Inside Llewyn Davis" heading="Inside Llewyn Davis"></calcite-combobox-item>
     </calcite-combobox>
   `;
 
@@ -86,25 +86,25 @@ describe("calcite-combobox", () => {
       await page.setContent(html`
         <calcite-combobox>
           <calcite-combobox-item
-            text-label="text-label-1"
+            heading="text-heading-1"
             description="description-1"
             value="value-1"
             short-heading="short-heading-1"
           ></calcite-combobox-item>
           <calcite-combobox-item
-            text-label="text-label-2"
+            heading="text-heading-2"
             description="description-2"
             value="value-2"
             short-heading="short-heading-2"
           ></calcite-combobox-item>
           <calcite-combobox-item
-            text-label="text-label-3"
+            heading="text-heading-3"
             description="description-3"
             value="value-3"
             short-heading="short-heading-3"
           ></calcite-combobox-item>
           <calcite-combobox-item
-            text-label="text-label-4"
+            heading="text-heading-4"
             description="description-4"
             value="value-4"
             short-heading="short-heading-4"
@@ -115,14 +115,14 @@ describe("calcite-combobox", () => {
       const combobox = await page.find("calcite-combobox");
       const filterEventSpy = await combobox.spyOnEvent("calciteComboboxFilterChange");
 
-      await clearAndType(combobox, "text-label-1");
+      await clearAndType(combobox, "text-heading-1");
 
       let items = await findAll(page, "calcite-combobox-item");
       expect(await items[0].isVisible()).toBe(true);
       expect(await items[1].isVisible()).toBe(false);
       expect(await items[2].isVisible()).toBe(false);
       expect(await items[3].isVisible()).toBe(false);
-      expect(await combobox.getProperty("filterText")).toBe("text-label-1");
+      expect(await combobox.getProperty("filterText")).toBe("text-heading-1");
       expect((await combobox.getProperty("filteredItems")).length).toBe(1);
       expect(filterEventSpy).toHaveReceivedEventTimes(1);
 
@@ -186,10 +186,10 @@ describe("calcite-combobox", () => {
 
       await page.setContent(html`
         <calcite-combobox id="myCombobox">
-          <calcite-combobox-item value="Raising Arizona" text-label="Raising Arizona"></calcite-combobox-item>
-          <calcite-combobox-item value="Miller's Crossing" text-label="Miller's Crossing"></calcite-combobox-item>
-          <calcite-combobox-item value="The Hudsucker Proxy" text-label="The Hudsucker Proxy"></calcite-combobox-item>
-          <calcite-combobox-item value="Inside Llewyn Davis" text-label="Inside Llewyn Davis"></calcite-combobox-item>
+          <calcite-combobox-item value="Raising Arizona" heading="Raising Arizona"></calcite-combobox-item>
+          <calcite-combobox-item value="Miller's Crossing" heading="Miller's Crossing"></calcite-combobox-item>
+          <calcite-combobox-item value="The Hudsucker Proxy" heading="The Hudsucker Proxy"></calcite-combobox-item>
+          <calcite-combobox-item value="Inside Llewyn Davis" heading="Inside Llewyn Davis"></calcite-combobox-item>
         </calcite-combobox>
       `);
 
@@ -220,10 +220,10 @@ describe("calcite-combobox", () => {
 
       await page.setContent(html`
         <calcite-combobox id="myCombobox">
-          <calcite-combobox-item value="Raising Arizona" text-label="Raising Arizona"></calcite-combobox-item>
-          <calcite-combobox-item value="Miller's Crossing" text-label="Miller's Crossing"></calcite-combobox-item>
-          <calcite-combobox-item value="The Hudsucker Proxy" text-label="The Hudsucker Proxy"></calcite-combobox-item>
-          <calcite-combobox-item value="Inside Llewyn Davis" text-label="Inside Llewyn Davis"></calcite-combobox-item>
+          <calcite-combobox-item value="Raising Arizona" heading="Raising Arizona"></calcite-combobox-item>
+          <calcite-combobox-item value="Miller's Crossing" heading="Miller's Crossing"></calcite-combobox-item>
+          <calcite-combobox-item value="The Hudsucker Proxy" heading="The Hudsucker Proxy"></calcite-combobox-item>
+          <calcite-combobox-item value="Inside Llewyn Davis" heading="Inside Llewyn Davis"></calcite-combobox-item>
         </calcite-combobox>
       `);
 
@@ -245,10 +245,10 @@ describe("calcite-combobox", () => {
 
       await page.setContent(html`
         <calcite-combobox id="myCombobox">
-          <calcite-combobox-item value="Raising Arizona" text-label="Raising Arizona"></calcite-combobox-item>
-          <calcite-combobox-item value="Miller's Crossing" text-label="Miller's Crossing"></calcite-combobox-item>
-          <calcite-combobox-item value="The Hudsucker Proxy" text-label="The Hudsucker Proxy"></calcite-combobox-item>
-          <calcite-combobox-item value="Inside Llewyn Davis" text-label="Inside Llewyn Davis"></calcite-combobox-item>
+          <calcite-combobox-item value="Raising Arizona" heading="Raising Arizona"></calcite-combobox-item>
+          <calcite-combobox-item value="Miller's Crossing" heading="Miller's Crossing"></calcite-combobox-item>
+          <calcite-combobox-item value="The Hudsucker Proxy" heading="The Hudsucker Proxy"></calcite-combobox-item>
+          <calcite-combobox-item value="Inside Llewyn Davis" heading="Inside Llewyn Davis"></calcite-combobox-item>
         </calcite-combobox>
       `);
 
@@ -272,14 +272,14 @@ describe("calcite-combobox", () => {
       const page = await newE2EPage();
       await page.setContent(html`
         <calcite-combobox clear-disabled="true" selection-mode="single-persist" placeholder="Select a field">
-          <calcite-combobox-item id="item-1" value="France/Germany" text-label="France/Germany"></calcite-combobox-item>
-          <calcite-combobox-item id="item-2" value="Spain/Portugal" text-label="Spain/Portugal"></calcite-combobox-item>
+          <calcite-combobox-item id="item-1" value="France/Germany" heading="France/Germany"></calcite-combobox-item>
+          <calcite-combobox-item id="item-2" value="Spain/Portugal" heading="Spain/Portugal"></calcite-combobox-item>
           <calcite-combobox-item
             id="item-3"
             value="Indonesia/Malaysia"
-            text-label="Indonesia/Malaysia"
+            heading="Indonesia/Malaysia"
           ></calcite-combobox-item>
-          <calcite-combobox-item id="item-4" value="Libya/Algeria" text-label="Libya/Algeria"></calcite-combobox-item>
+          <calcite-combobox-item id="item-4" value="Libya/Algeria" heading="Libya/Algeria"></calcite-combobox-item>
         </calcite-combobox>
       `);
 
@@ -305,9 +305,9 @@ describe("calcite-combobox", () => {
       const page = await newE2EPage();
       await page.setContent(`
       <calcite-combobox selection-mode="single">
-        <calcite-combobox-item id="one" value="one" text-label="One"></calcite-combobox-item>
-        <calcite-combobox-item id="two" value="two" text-label="Two" ></calcite-combobox-item>
-        <calcite-combobox-item id="three" value="three" text-label="Three" filter-disabled></calcite-combobox-item>
+        <calcite-combobox-item id="one" value="one" heading="One"></calcite-combobox-item>
+        <calcite-combobox-item id="two" value="two" heading="Two" ></calcite-combobox-item>
+        <calcite-combobox-item id="three" value="three" heading="Three" filter-disabled></calcite-combobox-item>
       </calcite-combobox>
     `);
 
@@ -328,25 +328,25 @@ describe("calcite-combobox", () => {
 
     const nestedComboboxChildren = html`
       <calcite-combobox-item-group id="group-1" label="group 1">
-        <calcite-combobox-item id="item-1-1" value="a" text-label="item 1.1"></calcite-combobox-item>
-        <calcite-combobox-item id="item-1-2" value="b" text-label="item 1.2"></calcite-combobox-item>
+        <calcite-combobox-item id="item-1-1" value="a" heading="item 1.1"></calcite-combobox-item>
+        <calcite-combobox-item id="item-1-2" value="b" heading="item 1.2"></calcite-combobox-item>
 
         <calcite-combobox-item-group id="subgroup-1-1" label="subgroup 1.1">
-          <calcite-combobox-item id="item-1-1-1" value="c" text-label="item 1.1.1"></calcite-combobox-item>
+          <calcite-combobox-item id="item-1-1-1" value="c" heading="item 1.1.1"></calcite-combobox-item>
           <calcite-combobox-item-group id="subgroup-1-1-1" label="subgroup 1.1.1 (empty)"></calcite-combobox-item-group>
 
           <calcite-combobox-item-group id="subgroup-1-1-2" label="subgroup 1.1.2">
-            <calcite-combobox-item id="item-1-1-2-1" value="d" text-label="item 1.1.2.1">
-              <calcite-combobox-item id="item-1-1-2-2" value="e" text-label="subitem 1.1.2.2"></calcite-combobox-item>
+            <calcite-combobox-item id="item-1-1-2-1" value="d" heading="item 1.1.2.1">
+              <calcite-combobox-item id="item-1-1-2-2" value="e" heading="subitem 1.1.2.2"></calcite-combobox-item>
             </calcite-combobox-item>
           </calcite-combobox-item-group>
         </calcite-combobox-item-group>
       </calcite-combobox-item-group>
 
       <calcite-combobox-item-group id="group-2" label="group 2">
-        <calcite-combobox-item id="item-2-1" value="f" text-label="item 2.1">
-          <calcite-combobox-item id="item-2-1-1" value="g" text-label="subitem 2.1.1"></calcite-combobox-item>
-          <calcite-combobox-item id="item-2-1-2" value="h" text-label="subitem 2.1.2"></calcite-combobox-item>
+        <calcite-combobox-item id="item-2-1" value="f" heading="item 2.1">
+          <calcite-combobox-item id="item-2-1-1" value="g" heading="subitem 2.1.1"></calcite-combobox-item>
+          <calcite-combobox-item id="item-2-1-2" value="h" heading="subitem 2.1.2"></calcite-combobox-item>
         </calcite-combobox-item>
       </calcite-combobox-item-group>
     `;
@@ -440,13 +440,13 @@ describe("calcite-combobox", () => {
 
         const item1 = document.createElement("calcite-combobox-item");
         item1.value = "1";
-        item1.textLabel = "One";
+        item1.heading = "One";
         item1.metadata = { foo: "foo" };
         combobox.append(item1);
 
         const item2 = document.createElement("calcite-combobox-item");
         item2.value = "2";
-        item2.textLabel = "Two";
+        item2.heading = "Two";
         item2.metadata = { bar: "bar" };
         combobox.append(item2);
 
@@ -473,14 +473,14 @@ describe("calcite-combobox", () => {
       await page.setContent(
         html` <calcite-combobox placeholder="typing 'group1' or 'group2' should show group with all items">
           <calcite-combobox-item-group id="group1" label="group1">
-            <calcite-combobox-item id="value1" value="value1" text-label="value1"></calcite-combobox-item>
-            <calcite-combobox-item id="value2" value="value2" text-label="value2"></calcite-combobox-item>
-            <calcite-combobox-item id="value3" value="value3" text-label="value3"></calcite-combobox-item>
+            <calcite-combobox-item id="value1" value="value1" heading="value1"></calcite-combobox-item>
+            <calcite-combobox-item id="value2" value="value2" heading="value2"></calcite-combobox-item>
+            <calcite-combobox-item id="value3" value="value3" heading="value3"></calcite-combobox-item>
           </calcite-combobox-item-group>
           <calcite-combobox-item-group id="group2" label="group2">
-            <calcite-combobox-item id="value4" value="value4" text-label="value4"></calcite-combobox-item>
-            <calcite-combobox-item id="value5" value="value5" text-label="value5"></calcite-combobox-item>
-            <calcite-combobox-item id="value6" value="value6" text-label="value6"></calcite-combobox-item>
+            <calcite-combobox-item id="value4" value="value4" heading="value4"></calcite-combobox-item>
+            <calcite-combobox-item id="value5" value="value5" heading="value5"></calcite-combobox-item>
+            <calcite-combobox-item id="value6" value="value6" heading="value6"></calcite-combobox-item>
           </calcite-combobox-item-group>
         </calcite-combobox>`,
       );
@@ -531,11 +531,11 @@ describe("calcite-combobox", () => {
           <calcite-combobox-item
             id="one"
             value="Natural Resources"
-            text-label="Natural Resources"
+            heading="Natural Resources"
             selected
           ></calcite-combobox-item>
-          <calcite-combobox-item id="two" value="Agriculture" text-label="Agriculture"></calcite-combobox-item>
-          <calcite-combobox-item id="three" value="Transportation" text-label="Transportation"></calcite-combobox-item>
+          <calcite-combobox-item id="two" value="Agriculture" heading="Agriculture"></calcite-combobox-item>
+          <calcite-combobox-item id="three" value="Transportation" heading="Transportation"></calcite-combobox-item>
         </calcite-combobox>
       `);
 
@@ -572,36 +572,36 @@ describe("calcite-combobox", () => {
       await page.setContent(html`
         <calcite-combobox filter-text="match">
           <calcite-combobox-item
-            id="text-label-match"
-            text-label="match"
+            id="text-heading-match"
+            heading="match"
             description="description-1"
             value="value-1"
             short-heading="short-heading-1"
           ></calcite-combobox-item>
           <calcite-combobox-item
             id="description-match"
-            text-label="text-label-2"
+            heading="text-heading-2"
             description="match"
             value="value-2"
             short-heading="short-heading-2"
           ></calcite-combobox-item>
           <calcite-combobox-item
             id="value-match"
-            text-label="text-label-3"
+            heading="text-heading-3"
             description="description-3"
             value="match"
             short-heading="short-heading-3"
           ></calcite-combobox-item>
           <calcite-combobox-item
             id="short-heading-match"
-            text-label="text-label-4"
+            heading="text-heading-4"
             description="description-4"
             value="value-4"
             short-heading="match"
           ></calcite-combobox-item>
           <calcite-combobox-item
             id="no-match"
-            text-label="text-label-5"
+            heading="text-heading-5"
             description="description-5"
             value="value-5"
             short-heading="short-heading-5"
@@ -611,15 +611,15 @@ describe("calcite-combobox", () => {
 
       await page.waitForChanges();
       const combobox = await page.find("calcite-combobox");
-      combobox.setProperty("filterProps", ["textLabel", "description"]);
+      combobox.setProperty("filterProps", ["description"]);
       await page.waitForChanges();
       await page.waitForTimeout(DEBOUNCE.filter);
 
-      expect(await combobox.getProperty("filteredItems")).toHaveLength(2);
+      expect(await combobox.getProperty("filteredItems")).toHaveLength(1);
 
       const visibleItems = await findAll(page, "calcite-combobox-item:not([hidden]):not([item-hidden])");
 
-      expect(visibleItems.map((item) => item.id)).toEqual(["text-label-match", "description-match"]);
+      expect(visibleItems.map((item) => item.id)).toEqual(["description-match"]);
     });
   });
 
@@ -655,14 +655,6 @@ describe("calcite-combobox", () => {
 
     expect(await a11yItem.getProperty("ariaLabel")).toBe(label);
 
-    const textLabel = "textLabel";
-    item.setProperty("textLabel", textLabel);
-    await page.waitForChanges();
-    await page.waitForTimeout(DEBOUNCE.nextTick);
-    a11yItem = await page.find(`calcite-combobox >>> ul.${CSS.screenReadersOnly} li`);
-
-    expect(await a11yItem.getProperty("textContent")).toBe(textLabel);
-
     const heading = "heading";
     item.setProperty("heading", heading);
     await page.waitForChanges();
@@ -684,18 +676,18 @@ describe("calcite-combobox", () => {
     const page = await newE2EPage();
     await page.setContent(`
       <calcite-combobox max-items="${maxItems}">
-        <calcite-combobox-item id="item-0" value="item-0" text-label="item-0">
-          <calcite-combobox-item id="item-1" value="item-1" text-label="item-1"></calcite-combobox-item>
-          <calcite-combobox-item id="item-2" value="item-2" text-label="item-2"></calcite-combobox-item>
-          <calcite-combobox-item id="item-3" value="item-3" text-label="item-3"></calcite-combobox-item>
-          <calcite-combobox-item id="item-4" value="item-4" text-label="item-4"></calcite-combobox-item>
-          <calcite-combobox-item id="item-5" value="item-5" text-label="item-5"></calcite-combobox-item>
+        <calcite-combobox-item id="item-0" value="item-0" heading="item-0">
+          <calcite-combobox-item id="item-1" value="item-1" heading="item-1"></calcite-combobox-item>
+          <calcite-combobox-item id="item-2" value="item-2" heading="item-2"></calcite-combobox-item>
+          <calcite-combobox-item id="item-3" value="item-3" heading="item-3"></calcite-combobox-item>
+          <calcite-combobox-item id="item-4" value="item-4" heading="item-4"></calcite-combobox-item>
+          <calcite-combobox-item id="item-5" value="item-5" heading="item-5"></calcite-combobox-item>
         </calcite-combobox-item>
-        <calcite-combobox-item id="item-6" value="item-6" text-label="item-6">
-          <calcite-combobox-item id="item-7" value="item-7" text-label="item-7"></calcite-combobox-item>
-          <calcite-combobox-item id="item-8" value="item-8" text-label="item-8"></calcite-combobox-item>
-          <calcite-combobox-item id="item-9" value="item-9" text-label="item-9"></calcite-combobox-item>
-          <calcite-combobox-item id="item-10" value="item-10" text-label="item-10"></calcite-combobox-item>
+        <calcite-combobox-item id="item-6" value="item-6" heading="item-6">
+          <calcite-combobox-item id="item-7" value="item-7" heading="item-7"></calcite-combobox-item>
+          <calcite-combobox-item id="item-8" value="item-8" heading="item-8"></calcite-combobox-item>
+          <calcite-combobox-item id="item-9" value="item-9" heading="item-9"></calcite-combobox-item>
+          <calcite-combobox-item id="item-10" value="item-10" heading="item-10"></calcite-combobox-item>
         </calcite-combobox-item>
       </calcite-combobox>
     `);
@@ -726,18 +718,18 @@ describe("calcite-combobox", () => {
 
     await page.setContent(`
       <calcite-combobox max-items="${maxItems}">
-        <calcite-combobox-item id="item-0" value="item-0" text-label="item-0">
-          <calcite-combobox-item id="item-1" value="item-1" text-label="item-1"></calcite-combobox-item>
-          <calcite-combobox-item id="item-2" value="item-2" text-label="item-2"></calcite-combobox-item>
-          <calcite-combobox-item id="item-3" value="item-3" text-label="item-3"></calcite-combobox-item>
-          <calcite-combobox-item id="item-4" value="item-4" text-label="item-4"></calcite-combobox-item>
-          <calcite-combobox-item id="item-5" value="item-5" text-label="item-5"></calcite-combobox-item>
+        <calcite-combobox-item id="item-0" value="item-0" heading="item-0">
+          <calcite-combobox-item id="item-1" value="item-1" heading="item-1"></calcite-combobox-item>
+          <calcite-combobox-item id="item-2" value="item-2" heading="item-2"></calcite-combobox-item>
+          <calcite-combobox-item id="item-3" value="item-3" heading="item-3"></calcite-combobox-item>
+          <calcite-combobox-item id="item-4" value="item-4" heading="item-4"></calcite-combobox-item>
+          <calcite-combobox-item id="item-5" value="item-5" heading="item-5"></calcite-combobox-item>
         </calcite-combobox-item>
         <calcite-combobox-item-group id="item-6" label="item-6">
-          <calcite-combobox-item id="item-7" value="item-7" text-label="item-7"></calcite-combobox-item>
-          <calcite-combobox-item id="item-8" value="item-8" text-label="item-8"></calcite-combobox-item>
-          <calcite-combobox-item id="item-9" value="item-9" text-label="item-9"></calcite-combobox-item>
-          <calcite-combobox-item id="item-10" value="item-10" text-label="item-10"></calcite-combobox-item>
+          <calcite-combobox-item id="item-7" value="item-7" heading="item-7"></calcite-combobox-item>
+          <calcite-combobox-item id="item-8" value="item-8" heading="item-8"></calcite-combobox-item>
+          <calcite-combobox-item id="item-9" value="item-9" heading="item-9"></calcite-combobox-item>
+          <calcite-combobox-item id="item-10" value="item-10" heading="item-10"></calcite-combobox-item>
         </calcite-combobox-item-group>
       </calcite-combobox>
     `);
@@ -769,26 +761,26 @@ describe("calcite-combobox", () => {
 
     await page.setContent(`
     <calcite-combobox label="custom values" allow-custom-values placeholder="placeholder" max-items="6">
-      <calcite-combobox-item value="Trees" text-label="Trees" selected>
-        <calcite-combobox-item value="Pine" text-label="Pine">
-          <calcite-combobox-item value="Pine Nested" text-label="Pine Nested"></calcite-combobox-item>
+      <calcite-combobox-item value="Trees" heading="Trees" selected>
+        <calcite-combobox-item value="Pine" heading="Pine">
+          <calcite-combobox-item value="Pine Nested" heading="Pine Nested"></calcite-combobox-item>
         </calcite-combobox-item>
-        <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia"></calcite-combobox-item>
-        <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir"></calcite-combobox-item>
+        <calcite-combobox-item value="Sequoia" disabled heading="Sequoia"></calcite-combobox-item>
+        <calcite-combobox-item value="Douglas Fir" heading="Douglas Fir"></calcite-combobox-item>
       </calcite-combobox-item>
-      <calcite-combobox-item value="Flowers" text-label="Flowers">
-        <calcite-combobox-item value="Daffodil" text-label="Daffodil"></calcite-combobox-item>
-        <calcite-combobox-item value="Black Eyed Susan" text-label="Black Eyed Susan"></calcite-combobox-item>
-        <calcite-combobox-item value="Nasturtium" text-label="Nasturtium"></calcite-combobox-item>
+      <calcite-combobox-item value="Flowers" heading="Flowers">
+        <calcite-combobox-item value="Daffodil" heading="Daffodil"></calcite-combobox-item>
+        <calcite-combobox-item value="Black Eyed Susan" heading="Black Eyed Susan"></calcite-combobox-item>
+        <calcite-combobox-item value="Nasturtium" heading="Nasturtium"></calcite-combobox-item>
       </calcite-combobox-item>
-      <calcite-combobox-item value="Animals" text-label="Animals">
-        <calcite-combobox-item value="Birds" text-label="Birds"></calcite-combobox-item>
-        <calcite-combobox-item value="Reptiles" text-label="Reptiles"></calcite-combobox-item>
-        <calcite-combobox-item value="Amphibians" text-label="Amphibians"></calcite-combobox-item>
+      <calcite-combobox-item value="Animals" heading="Animals">
+        <calcite-combobox-item value="Birds" heading="Birds"></calcite-combobox-item>
+        <calcite-combobox-item value="Reptiles" heading="Reptiles"></calcite-combobox-item>
+        <calcite-combobox-item value="Amphibians" heading="Amphibians"></calcite-combobox-item>
       </calcite-combobox-item>
-      <calcite-combobox-item value="Rocks" text-label="Rocks"></calcite-combobox-item>
-      <calcite-combobox-item value="Insects" text-label="Insects"></calcite-combobox-item>
-      <calcite-combobox-item value="Rivers" text-label="Rivers"></calcite-combobox-item>
+      <calcite-combobox-item value="Rocks" heading="Rocks"></calcite-combobox-item>
+      <calcite-combobox-item value="Insects" heading="Insects"></calcite-combobox-item>
+      <calcite-combobox-item value="Rivers" heading="Rivers"></calcite-combobox-item>
     </calcite-combobox>
     `);
     await page.waitForChanges();
@@ -815,14 +807,14 @@ describe("calcite-combobox", () => {
     const page = await newE2EPage();
     await page.setContent(html`
       <calcite-combobox label="custom values" allow-custom-values placeholder="placeholder" max-items="6">
-        <calcite-combobox-item value="Trees" text-label="Trees" selected>
-          <calcite-combobox-item value="Pine" text-label="Pine">
-            <calcite-combobox-item value="Pine Nested" text-label="Pine Nested"></calcite-combobox-item>
+        <calcite-combobox-item value="Trees" heading="Trees" selected>
+          <calcite-combobox-item value="Pine" heading="Pine">
+            <calcite-combobox-item value="Pine Nested" heading="Pine Nested"></calcite-combobox-item>
           </calcite-combobox-item>
-          <calcite-combobox-item value="Sequoia" hidden text-label="Sequoia"></calcite-combobox-item>
-          <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir"></calcite-combobox-item>
+          <calcite-combobox-item value="Sequoia" hidden heading="Sequoia"></calcite-combobox-item>
+          <calcite-combobox-item value="Douglas Fir" heading="Douglas Fir"></calcite-combobox-item>
         </calcite-combobox-item>
-        <calcite-combobox-item value="Rocks" text-label="Rocks"></calcite-combobox-item>
+        <calcite-combobox-item value="Rocks" heading="Rocks"></calcite-combobox-item>
       </calcite-combobox>
     `);
     await page.waitForChanges();
@@ -840,14 +832,14 @@ describe("calcite-combobox", () => {
     const page = await newE2EPage();
     await page.setContent(html`
       <calcite-combobox label="custom values" allow-custom-values placeholder="placeholder" max-items="6">
-        <calcite-combobox-item value="Trees" text-label="Trees" hidden>
-          <calcite-combobox-item value="Pine" text-label="Pine">
-            <calcite-combobox-item value="Pine Nested" text-label="Pine Nested"></calcite-combobox-item>
+        <calcite-combobox-item value="Trees" heading="Trees" hidden>
+          <calcite-combobox-item value="Pine" heading="Pine">
+            <calcite-combobox-item value="Pine Nested" heading="Pine Nested"></calcite-combobox-item>
           </calcite-combobox-item>
-          <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia"></calcite-combobox-item>
-          <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir"></calcite-combobox-item>
+          <calcite-combobox-item value="Sequoia" disabled heading="Sequoia"></calcite-combobox-item>
+          <calcite-combobox-item value="Douglas Fir" heading="Douglas Fir"></calcite-combobox-item>
         </calcite-combobox-item>
-        <calcite-combobox-item value="Rocks" text-label="Rocks"></calcite-combobox-item>
+        <calcite-combobox-item value="Rocks" heading="Rocks"></calcite-combobox-item>
       </calcite-combobox>
     `);
     await page.waitForChanges();
@@ -866,17 +858,17 @@ describe("calcite-combobox", () => {
     const maxItems = 6;
     await page.setContent(html`
       <calcite-combobox label="custom values" allow-custom-values placeholder="placeholder" max-items="6">
-        <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia"></calcite-combobox-item>
-        <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir"></calcite-combobox-item>
-        <calcite-combobox-item value="Daffodil" text-label="Daffodil"></calcite-combobox-item>
-        <calcite-combobox-item value="Black Eyed Susan" text-label="Black Eyed Susan"></calcite-combobox-item>
-        <calcite-combobox-item value="Nasturtium" text-label="Nasturtium"></calcite-combobox-item>
-        <calcite-combobox-item value="Birds" text-label="Birds"></calcite-combobox-item>
-        <calcite-combobox-item value="Reptiles" text-label="Reptiles"></calcite-combobox-item>
-        <calcite-combobox-item value="Amphibians" text-label="Amphibians"></calcite-combobox-item>
-        <calcite-combobox-item value="Rocks" text-label="Rocks"></calcite-combobox-item>
-        <calcite-combobox-item value="Insects" text-label="Insects"></calcite-combobox-item>
-        <calcite-combobox-item value="Rivers" text-label="Rivers"></calcite-combobox-item>
+        <calcite-combobox-item value="Sequoia" disabled heading="Sequoia"></calcite-combobox-item>
+        <calcite-combobox-item value="Douglas Fir" heading="Douglas Fir"></calcite-combobox-item>
+        <calcite-combobox-item value="Daffodil" heading="Daffodil"></calcite-combobox-item>
+        <calcite-combobox-item value="Black Eyed Susan" heading="Black Eyed Susan"></calcite-combobox-item>
+        <calcite-combobox-item value="Nasturtium" heading="Nasturtium"></calcite-combobox-item>
+        <calcite-combobox-item value="Birds" heading="Birds"></calcite-combobox-item>
+        <calcite-combobox-item value="Reptiles" heading="Reptiles"></calcite-combobox-item>
+        <calcite-combobox-item value="Amphibians" heading="Amphibians"></calcite-combobox-item>
+        <calcite-combobox-item value="Rocks" heading="Rocks"></calcite-combobox-item>
+        <calcite-combobox-item value="Insects" heading="Insects"></calcite-combobox-item>
+        <calcite-combobox-item value="Rivers" heading="Rivers"></calcite-combobox-item>
       </calcite-combobox>
     `);
     const element = await page.find("calcite-combobox");
@@ -916,8 +908,8 @@ describe("calcite-combobox", () => {
           const page = await newE2EPage();
           await page.setContent(html`
             <calcite-combobox selection-mode="single">
-              <calcite-combobox-item value="one" text-label="one"></calcite-combobox-item>
-              <calcite-combobox-item value="two" text-label="two"></calcite-combobox-item>
+              <calcite-combobox-item value="one" heading="one"></calcite-combobox-item>
+              <calcite-combobox-item value="two" heading="two"></calcite-combobox-item>
             </calcite-combobox>
           `);
           const combobox = await page.find("calcite-combobox");
@@ -944,8 +936,8 @@ describe("calcite-combobox", () => {
           const page = await newE2EPage();
           await page.setContent(html`
             <calcite-combobox selection-mode="single-persist">
-              <calcite-combobox-item value="one" text-label="one"></calcite-combobox-item>
-              <calcite-combobox-item value="two" text-label="two"></calcite-combobox-item>
+              <calcite-combobox-item value="one" heading="one"></calcite-combobox-item>
+              <calcite-combobox-item value="two" heading="two"></calcite-combobox-item>
             </calcite-combobox>
           `);
           const combobox = await page.find("calcite-combobox");
@@ -1013,8 +1005,8 @@ describe("calcite-combobox", () => {
           const page = await newE2EPage();
           await page.setContent(html`
             <calcite-combobox selection-mode="multiple">
-              <calcite-combobox-item value="one" text-label="one"></calcite-combobox-item>
-              <calcite-combobox-item value="two" text-label="two"></calcite-combobox-item>
+              <calcite-combobox-item value="one" heading="one"></calcite-combobox-item>
+              <calcite-combobox-item value="two" heading="two"></calcite-combobox-item>
             </calcite-combobox>
           `);
           const combobox = await page.find("calcite-combobox");
@@ -1042,9 +1034,9 @@ describe("calcite-combobox", () => {
           const page = await newE2EPage();
           await page.setContent(html`
             <calcite-combobox selection-mode="ancestors">
-              <calcite-combobox-item value="one" text-label="parent">
-                <calcite-combobox-item value="two" text-label="child1"></calcite-combobox-item>
-                <calcite-combobox-item value="three" text-label="child2"></calcite-combobox-item>
+              <calcite-combobox-item value="one" heading="parent">
+                <calcite-combobox-item value="two" heading="child1"></calcite-combobox-item>
+                <calcite-combobox-item value="three" heading="child2"></calcite-combobox-item>
               </calcite-combobox-item>
             </calcite-combobox>
           `);
@@ -1075,8 +1067,8 @@ describe("calcite-combobox", () => {
       const page = await newE2EPage();
       await page.setContent(html`
         <calcite-combobox selection-mode="ancestors">
-          <calcite-combobox-item value="one" text-label="one">
-            <calcite-combobox-item value="child1" text-label="child1"></calcite-combobox-item>
+          <calcite-combobox-item value="one" heading="one">
+            <calcite-combobox-item value="child1" heading="child1"></calcite-combobox-item>
           </calcite-combobox-item>
         </calcite-combobox>
       `);
@@ -1100,9 +1092,9 @@ describe("calcite-combobox", () => {
       const page = await newE2EPage();
       await page.setContent(html`
         <calcite-combobox selection-mode="ancestors">
-          <calcite-combobox-item value="parent" text-label="parent">
-            <calcite-combobox-item value="child1" text-label="child1"></calcite-combobox-item>
-            <calcite-combobox-item value="child2" text-label="child2"></calcite-combobox-item>
+          <calcite-combobox-item value="parent" heading="parent">
+            <calcite-combobox-item value="child1" heading="child1"></calcite-combobox-item>
+            <calcite-combobox-item value="child2" heading="child2"></calcite-combobox-item>
           </calcite-combobox-item>
         </calcite-combobox>
       `);
@@ -1133,8 +1125,8 @@ describe("calcite-combobox", () => {
       const page = await newE2EPage();
       await page.setContent(html`
         <calcite-combobox>
-          <calcite-combobox-item value="one" text-label="one"></calcite-combobox-item>
-          <calcite-combobox-item value="two" text-label="two"></calcite-combobox-item>
+          <calcite-combobox-item value="one" heading="one"></calcite-combobox-item>
+          <calcite-combobox-item value="two" heading="two"></calcite-combobox-item>
         </calcite-combobox>
       `);
       const combobox = await page.find("calcite-combobox");
@@ -1166,7 +1158,7 @@ describe("calcite-combobox", () => {
       const page = await newE2EPage();
       await page.setContent(
         html`<calcite-combobox>
-          <calcite-combobox-item value="one" selected text-label="one"></calcite-combobox-item>
+          <calcite-combobox-item value="one" selected heading="one"></calcite-combobox-item>
         </calcite-combobox>`,
       );
       const eventSpy = await page.spyOnEvent("calciteComboboxChipClose");
@@ -1183,9 +1175,9 @@ describe("calcite-combobox", () => {
       const page = await newE2EPage();
       await page.setContent(html`
         <calcite-combobox allow-custom-values selection-mode="single">
-          <calcite-combobox-item id="one" value="one" text-label="one"></calcite-combobox-item>
-          <calcite-combobox-item id="two" value="two" text-label="two"></calcite-combobox-item>
-          <calcite-combobox-item id="three" value="three" text-label="three"></calcite-combobox-item>
+          <calcite-combobox-item id="one" value="one" heading="one"></calcite-combobox-item>
+          <calcite-combobox-item id="two" value="two" heading="two"></calcite-combobox-item>
+          <calcite-combobox-item id="three" value="three" heading="three"></calcite-combobox-item>
         </calcite-combobox>
       `);
       const input = await page.find("calcite-combobox >>> input");
@@ -1210,9 +1202,9 @@ describe("calcite-combobox", () => {
       const page = await newE2EPage();
       await page.setContent(html`
         <calcite-combobox allow-custom-values selection-mode="single">
-          <calcite-combobox-item selected id="one" value="one" text-label="one"></calcite-combobox-item>
-          <calcite-combobox-item id="two" value="two" text-label="two"></calcite-combobox-item>
-          <calcite-combobox-item id="three" value="three" text-label="three"></calcite-combobox-item>
+          <calcite-combobox-item selected id="one" value="one" heading="one"></calcite-combobox-item>
+          <calcite-combobox-item id="two" value="two" heading="two"></calcite-combobox-item>
+          <calcite-combobox-item id="three" value="three" heading="three"></calcite-combobox-item>
         </calcite-combobox>
       `);
       await skipAnimations(page);
@@ -1240,9 +1232,9 @@ describe("calcite-combobox", () => {
       const page = await newE2EPage();
       await page.setContent(html`
         <calcite-combobox allow-custom-values>
-          <calcite-combobox-item selected id="one" value="one" text-label="one"></calcite-combobox-item>
-          <calcite-combobox-item selected id="two" value="two" text-label="two"></calcite-combobox-item>
-          <calcite-combobox-item id="three" value="three" text-label="three"></calcite-combobox-item>
+          <calcite-combobox-item selected id="one" value="one" heading="one"></calcite-combobox-item>
+          <calcite-combobox-item selected id="two" value="two" heading="two"></calcite-combobox-item>
+          <calcite-combobox-item id="three" value="three" heading="three"></calcite-combobox-item>
         </calcite-combobox>
       `);
       const combobox = await page.find("calcite-combobox");
@@ -1272,9 +1264,9 @@ describe("calcite-combobox", () => {
       const page = await newE2EPage();
       await page.setContent(html`
         <calcite-combobox selection-mode="single">
-          <calcite-combobox-item value="1" text-label="first"></calcite-combobox-item>
-          <calcite-combobox-item value="2" text-label="second"></calcite-combobox-item>
-          <calcite-combobox-item value="3" text-label="third"></calcite-combobox-item>
+          <calcite-combobox-item value="1" heading="first"></calcite-combobox-item>
+          <calcite-combobox-item value="2" heading="second"></calcite-combobox-item>
+          <calcite-combobox-item value="3" heading="third"></calcite-combobox-item>
         </calcite-combobox>
       `);
 
@@ -1296,9 +1288,9 @@ describe("calcite-combobox", () => {
           selectionMode: "single",
           html: html`
             <calcite-combobox selection-mode="single">
-              <calcite-combobox-item selected id="one" value="one" text-label="one"></calcite-combobox-item>
-              <calcite-combobox-item id="two" value="two" text-label="two"></calcite-combobox-item>
-              <calcite-combobox-item id="three" value="three" text-label="three"></calcite-combobox-item>
+              <calcite-combobox-item selected id="one" value="one" heading="one"></calcite-combobox-item>
+              <calcite-combobox-item id="two" value="two" heading="two"></calcite-combobox-item>
+              <calcite-combobox-item id="three" value="three" heading="three"></calcite-combobox-item>
             </calcite-combobox>
           `,
         },
@@ -1306,9 +1298,9 @@ describe("calcite-combobox", () => {
           selectionMode: "single-persist",
           html: html`
             <calcite-combobox selection-mode="single-persist">
-              <calcite-combobox-item selected id="one" value="one" text-label="one"></calcite-combobox-item>
-              <calcite-combobox-item id="two" value="two" text-label="two"></calcite-combobox-item>
-              <calcite-combobox-item id="three" value="three" text-label="three"></calcite-combobox-item>
+              <calcite-combobox-item selected id="one" value="one" heading="one"></calcite-combobox-item>
+              <calcite-combobox-item id="two" value="two" heading="two"></calcite-combobox-item>
+              <calcite-combobox-item id="three" value="three" heading="three"></calcite-combobox-item>
             </calcite-combobox>
           `,
         },
@@ -1316,9 +1308,9 @@ describe("calcite-combobox", () => {
           selectionMode: "multiple",
           html: html`
             <calcite-combobox selection-mode="multiple">
-              <calcite-combobox-item selected id="one" value="one" text-label="one"></calcite-combobox-item>
-              <calcite-combobox-item selected id="two" value="two" text-label="two"></calcite-combobox-item>
-              <calcite-combobox-item selected id="three" value="three" text-label="three"></calcite-combobox-item>
+              <calcite-combobox-item selected id="one" value="one" heading="one"></calcite-combobox-item>
+              <calcite-combobox-item selected id="two" value="two" heading="two"></calcite-combobox-item>
+              <calcite-combobox-item selected id="three" value="three" heading="three"></calcite-combobox-item>
             </calcite-combobox>
           `,
         },
@@ -1326,9 +1318,9 @@ describe("calcite-combobox", () => {
           selectionMode: "ancestors",
           html: html`
             <calcite-combobox selection-mode="ancestors">
-              <calcite-combobox-item value="parent" text-label="parent">
-                <calcite-combobox-item value="child1" text-label="child1"></calcite-combobox-item>
-                <calcite-combobox-item selected value="child2" text-label="child2"></calcite-combobox-item>
+              <calcite-combobox-item value="parent" heading="parent">
+                <calcite-combobox-item value="child1" heading="child1"></calcite-combobox-item>
+                <calcite-combobox-item selected value="child2" heading="child2"></calcite-combobox-item>
               </calcite-combobox-item>
             </calcite-combobox>
           `,
@@ -1366,9 +1358,9 @@ describe("calcite-combobox", () => {
           selectionMode: "single",
           html: html`
             <calcite-combobox clear-disabled selection-mode="single">
-              <calcite-combobox-item selected id="one" value="one" text-label="one"></calcite-combobox-item>
-              <calcite-combobox-item id="two" value="two" text-label="two"></calcite-combobox-item>
-              <calcite-combobox-item id="three" value="three" text-label="three"></calcite-combobox-item>
+              <calcite-combobox-item selected id="one" value="one" heading="one"></calcite-combobox-item>
+              <calcite-combobox-item id="two" value="two" heading="two"></calcite-combobox-item>
+              <calcite-combobox-item id="three" value="three" heading="three"></calcite-combobox-item>
             </calcite-combobox>
           `,
         },
@@ -1376,9 +1368,9 @@ describe("calcite-combobox", () => {
           selectionMode: "single-persist",
           html: html`
             <calcite-combobox clear-disabled selection-mode="single-persist">
-              <calcite-combobox-item selected id="one" value="one" text-label="one"></calcite-combobox-item>
-              <calcite-combobox-item id="two" value="two" text-label="two"></calcite-combobox-item>
-              <calcite-combobox-item id="three" value="three" text-label="three"></calcite-combobox-item>
+              <calcite-combobox-item selected id="one" value="one" heading="one"></calcite-combobox-item>
+              <calcite-combobox-item id="two" value="two" heading="two"></calcite-combobox-item>
+              <calcite-combobox-item id="three" value="three" heading="three"></calcite-combobox-item>
             </calcite-combobox>
           `,
         },
@@ -1386,9 +1378,9 @@ describe("calcite-combobox", () => {
           selectionMode: "multiple",
           html: html`
             <calcite-combobox clear-disabled selection-mode="multiple">
-              <calcite-combobox-item selected id="one" value="one" text-label="one"></calcite-combobox-item>
-              <calcite-combobox-item selected id="two" value="two" text-label="two"></calcite-combobox-item>
-              <calcite-combobox-item selected id="three" value="three" text-label="three"></calcite-combobox-item>
+              <calcite-combobox-item selected id="one" value="one" heading="one"></calcite-combobox-item>
+              <calcite-combobox-item selected id="two" value="two" heading="two"></calcite-combobox-item>
+              <calcite-combobox-item selected id="three" value="three" heading="three"></calcite-combobox-item>
             </calcite-combobox>
           `,
         },
@@ -1396,9 +1388,9 @@ describe("calcite-combobox", () => {
           selectionMode: "ancestors",
           html: html`
             <calcite-combobox clear-disabled selection-mode="ancestors">
-              <calcite-combobox-item value="parent" text-label="parent">
-                <calcite-combobox-item value="child1" text-label="child1"></calcite-combobox-item>
-                <calcite-combobox-item selected value="child2" text-label="child2"></calcite-combobox-item>
+              <calcite-combobox-item value="parent" heading="parent">
+                <calcite-combobox-item value="child1" heading="child1"></calcite-combobox-item>
+                <calcite-combobox-item selected value="child2" heading="child2"></calcite-combobox-item>
               </calcite-combobox-item>
             </calcite-combobox>
           `,
@@ -1457,14 +1449,14 @@ describe("calcite-combobox", () => {
       page = await newE2EPage();
       await page.setContent(html`
         <calcite-combobox id="myCombobox" placeholder="Select a field">
-          <calcite-combobox-item value="Natural Resources" text-label="Natural Resources"></calcite-combobox-item>
-          <calcite-combobox-item value="Agriculture" text-label="Agriculture"></calcite-combobox-item>
-          <calcite-combobox-item value="Forestry" text-label="Forestry"></calcite-combobox-item>
-          <calcite-combobox-item selected value="Mining" text-label="Mining"></calcite-combobox-item>
-          <calcite-combobox-item value="Business" text-label="Business"></calcite-combobox-item>
-          <calcite-combobox-item selected value="Education" text-label="Education"></calcite-combobox-item>
-          <calcite-combobox-item selected value="Utilities" text-label="Utilities"></calcite-combobox-item>
-          <calcite-combobox-item value="Transportation" text-label="Transportation"></calcite-combobox-item>
+          <calcite-combobox-item value="Natural Resources" heading="Natural Resources"></calcite-combobox-item>
+          <calcite-combobox-item value="Agriculture" heading="Agriculture"></calcite-combobox-item>
+          <calcite-combobox-item value="Forestry" heading="Forestry"></calcite-combobox-item>
+          <calcite-combobox-item selected value="Mining" heading="Mining"></calcite-combobox-item>
+          <calcite-combobox-item value="Business" heading="Business"></calcite-combobox-item>
+          <calcite-combobox-item selected value="Education" heading="Education"></calcite-combobox-item>
+          <calcite-combobox-item selected value="Utilities" heading="Utilities"></calcite-combobox-item>
+          <calcite-combobox-item value="Transportation" heading="Transportation"></calcite-combobox-item>
         </calcite-combobox>
       `);
     });
@@ -1582,10 +1574,10 @@ describe("calcite-combobox", () => {
       page = await newE2EPage();
       await page.setContent(html`
         <calcite-combobox id="myCombobox">
-          <calcite-combobox-item id="one" value="one" text-label="one"></calcite-combobox-item>
-          <calcite-combobox-item id="two" value="two" text-label="two"></calcite-combobox-item>
-          <calcite-combobox-item-group text-label="Last Item">
-            <calcite-combobox-item id="three" value="three" text-label="three"></calcite-combobox-item>
+          <calcite-combobox-item id="one" value="one" heading="one"></calcite-combobox-item>
+          <calcite-combobox-item id="two" value="two" heading="two"></calcite-combobox-item>
+          <calcite-combobox-item-group heading="Last Item">
+            <calcite-combobox-item id="three" value="three" heading="three"></calcite-combobox-item>
           </calcite-combobox-item-group>
         </calcite-combobox>
       `);
@@ -1862,10 +1854,10 @@ describe("calcite-combobox", () => {
       const page = await newE2EPage();
       await page.setContent(html`
         <calcite-combobox selection-display="fit" style="width:350px">
-          <calcite-combobox-item id="one" value="one" text-label="one"></calcite-combobox-item>
-          <calcite-combobox-item id="two" value="two" text-label="two"></calcite-combobox-item>
-          <calcite-combobox-item-group text-label="Last Item">
-            <calcite-combobox-item id="three" value="three" text-label="three"></calcite-combobox-item>
+          <calcite-combobox-item id="one" value="one" heading="one"></calcite-combobox-item>
+          <calcite-combobox-item id="two" value="two" heading="two"></calcite-combobox-item>
+          <calcite-combobox-item-group heading="Last Item">
+            <calcite-combobox-item id="three" value="three" heading="three"></calcite-combobox-item>
           </calcite-combobox-item-group>
         </calcite-combobox>
       `);
@@ -1889,10 +1881,10 @@ describe("calcite-combobox", () => {
       const page = await newE2EPage();
       await page.setContent(html`
         <calcite-combobox selection-display="fit" style="width:450px">
-          <calcite-combobox-item id="one" value="one" text-label="one"></calcite-combobox-item>
-          <calcite-combobox-item id="two" value="two" text-label="two"></calcite-combobox-item>
-          <calcite-combobox-item-group text-label="Last Item">
-            <calcite-combobox-item id="three" value="three" text-label="three"></calcite-combobox-item>
+          <calcite-combobox-item id="one" value="one" heading="one"></calcite-combobox-item>
+          <calcite-combobox-item id="two" value="two" heading="two"></calcite-combobox-item>
+          <calcite-combobox-item-group heading="Last Item">
+            <calcite-combobox-item id="three" value="three" heading="three"></calcite-combobox-item>
           </calcite-combobox-item-group>
         </calcite-combobox>
       `);
@@ -1918,9 +1910,9 @@ describe("calcite-combobox", () => {
       const page = await newE2EPage();
       await page.setContent(html`
         <calcite-combobox selection-mode="single">
-          <calcite-combobox-item id="one" value="one" text-label="one" selected></calcite-combobox-item>
-          <calcite-combobox-item id="two" value="two" text-label="two"></calcite-combobox-item>
-          <calcite-combobox-item id="three" value="three" text-label="three"></calcite-combobox-item>
+          <calcite-combobox-item id="one" value="one" heading="one" selected></calcite-combobox-item>
+          <calcite-combobox-item id="two" value="two" heading="two"></calcite-combobox-item>
+          <calcite-combobox-item id="three" value="three" heading="three"></calcite-combobox-item>
         </calcite-combobox>
       `);
 
@@ -1945,9 +1937,9 @@ describe("calcite-combobox", () => {
       const page = await newE2EPage();
       await page.setContent(html`
         <calcite-combobox selection-mode="multiple">
-          <calcite-combobox-item id="one" value="one" text-label="one" selected></calcite-combobox-item>
-          <calcite-combobox-item id="two" value="two" text-label="two"></calcite-combobox-item>
-          <calcite-combobox-item id="three" value="three" text-label="three"></calcite-combobox-item>
+          <calcite-combobox-item id="one" value="one" heading="one" selected></calcite-combobox-item>
+          <calcite-combobox-item id="two" value="two" heading="two"></calcite-combobox-item>
+          <calcite-combobox-item id="three" value="three" heading="three"></calcite-combobox-item>
         </calcite-combobox>
       `);
       await page.waitForChanges();
@@ -1969,9 +1961,9 @@ describe("calcite-combobox", () => {
       const page = await newE2EPage();
       await page.setContent(
         html`<calcite-combobox selection-mode="single">
-          <calcite-combobox-item id="one" value="one" text-label="one" selected></calcite-combobox-item>
-          <calcite-combobox-item id="two" value="two" text-label="two"></calcite-combobox-item>
-          <calcite-combobox-item id="three" value="three" text-label="three"></calcite-combobox-item>
+          <calcite-combobox-item id="one" value="one" heading="one" selected></calcite-combobox-item>
+          <calcite-combobox-item id="two" value="two" heading="two"></calcite-combobox-item>
+          <calcite-combobox-item id="three" value="three" heading="three"></calcite-combobox-item>
         </calcite-combobox>`,
       );
       await page.waitForChanges();
@@ -2058,9 +2050,9 @@ describe("calcite-combobox", () => {
       const page = await newE2EPage();
       await page.setContent(html`
         <calcite-combobox allow-custom-values>
-          <calcite-combobox-item id="one" value="one" text-label="one"></calcite-combobox-item>
-          <calcite-combobox-item id="two" value="two" text-label="two"></calcite-combobox-item>
-          <calcite-combobox-item id="three" value="three" text-label="three"></calcite-combobox-item>
+          <calcite-combobox-item id="one" value="one" heading="one"></calcite-combobox-item>
+          <calcite-combobox-item id="two" value="two" heading="two"></calcite-combobox-item>
+          <calcite-combobox-item id="three" value="three" heading="three"></calcite-combobox-item>
         </calcite-combobox>
       `);
       const eventSpy = await page.spyOnEvent("calciteComboboxChange");
@@ -2091,9 +2083,9 @@ describe("calcite-combobox", () => {
       const page = await newE2EPage();
       await page.setContent(html`
         <calcite-combobox allow-custom-values>
-          <calcite-combobox-item id="one" value="one" text-label="one"></calcite-combobox-item>
-          <calcite-combobox-item id="two" value="two" text-label="two"></calcite-combobox-item>
-          <calcite-combobox-item id="three" value="three" text-label="three"></calcite-combobox-item>
+          <calcite-combobox-item id="one" value="one" heading="one"></calcite-combobox-item>
+          <calcite-combobox-item id="two" value="two" heading="two"></calcite-combobox-item>
+          <calcite-combobox-item id="three" value="three" heading="three"></calcite-combobox-item>
         </calcite-combobox>
       `);
       const eventSpy = await page.spyOnEvent("calciteComboboxChange");
@@ -2137,9 +2129,9 @@ describe("calcite-combobox", () => {
       await page.setContent(html`
         <div class="child" style="display: flex; flex-direction: row">
           <calcite-combobox allow-custom-values>
-            <calcite-combobox-item id="one" value="one" text-label="one"></calcite-combobox-item>
-            <calcite-combobox-item id="two" value="two" text-label="two"></calcite-combobox-item>
-            <calcite-combobox-item id="three" value="three" text-label="three"></calcite-combobox-item>
+            <calcite-combobox-item id="one" value="one" heading="one"></calcite-combobox-item>
+            <calcite-combobox-item id="two" value="two" heading="two"></calcite-combobox-item>
+            <calcite-combobox-item id="three" value="three" heading="three"></calcite-combobox-item>
           </calcite-combobox>
           <button>OK</button>
           <div></div>
@@ -2184,9 +2176,9 @@ describe("calcite-combobox", () => {
       const page = await newE2EPage();
       await page.setContent(html`
         <calcite-combobox allow-custom-values>
-          <calcite-combobox-item id="one" value="one" text-label="one"></calcite-combobox-item>
-          <calcite-combobox-item id="two" value="two" text-label="two"></calcite-combobox-item>
-          <calcite-combobox-item id="three" value="three" text-label="three"></calcite-combobox-item>
+          <calcite-combobox-item id="one" value="one" heading="one"></calcite-combobox-item>
+          <calcite-combobox-item id="two" value="two" heading="two"></calcite-combobox-item>
+          <calcite-combobox-item id="three" value="three" heading="three"></calcite-combobox-item>
         </calcite-combobox>
       `);
       let chip = await page.find("calcite-combobox >>> calcite-chip");
@@ -2215,9 +2207,9 @@ describe("calcite-combobox", () => {
       const page = await newE2EPage();
       await page.setContent(html`
         <calcite-combobox selection-mode="single">
-          <calcite-combobox-item id="one" value="one" text-label="One"></calcite-combobox-item>
-          <calcite-combobox-item id="two" value="two" text-label="Two"></calcite-combobox-item>
-          <calcite-combobox-item id="three" value="three" text-label="Three"></calcite-combobox-item>
+          <calcite-combobox-item id="one" value="one" heading="One"></calcite-combobox-item>
+          <calcite-combobox-item id="two" value="two" heading="Two"></calcite-combobox-item>
+          <calcite-combobox-item id="three" value="three" heading="Three"></calcite-combobox-item>
         </calcite-combobox>
       `);
       const chip = await page.find("calcite-combobox >>> calcite-chip");
@@ -2255,9 +2247,9 @@ describe("calcite-combobox", () => {
       const page = await newE2EPage();
       await page.setContent(html`
         <calcite-combobox>
-          <calcite-combobox-item id="one" icon="banana" value="one" text-label="One"></calcite-combobox-item>
-          <calcite-combobox-item id="two" icon="beaker" value="two" text-label="Two"></calcite-combobox-item>
-          <calcite-combobox-item id="three" value="three" text-label="Three"></calcite-combobox-item>
+          <calcite-combobox-item id="one" icon="banana" value="one" heading="One"></calcite-combobox-item>
+          <calcite-combobox-item id="two" icon="beaker" value="two" heading="Two"></calcite-combobox-item>
+          <calcite-combobox-item id="three" value="three" heading="Three"></calcite-combobox-item>
         </calcite-combobox>
       `);
       const chip = await page.find("calcite-combobox >>> calcite-chip");
@@ -2288,9 +2280,9 @@ describe("calcite-combobox", () => {
       const page = await newE2EPage();
       await page.setContent(html`
         <calcite-combobox selection-mode="single">
-          <calcite-combobox-item id="one" icon="banana" value="one" text-label="One"></calcite-combobox-item>
-          <calcite-combobox-item id="two" icon="beaker" value="two" text-label="Two"></calcite-combobox-item>
-          <calcite-combobox-item id="three" value="three" text-label="Three"></calcite-combobox-item>
+          <calcite-combobox-item id="one" icon="banana" value="one" heading="One"></calcite-combobox-item>
+          <calcite-combobox-item id="two" icon="beaker" value="two" heading="Two"></calcite-combobox-item>
+          <calcite-combobox-item id="three" value="three" heading="Three"></calcite-combobox-item>
         </calcite-combobox>
       `);
       const element = await page.find("calcite-combobox");
@@ -2334,9 +2326,9 @@ describe("calcite-combobox", () => {
       <div></div>
       <template>
         <calcite-combobox selection-mode="single">
-          <calcite-combobox-item id="one" icon="banana" value="one" text-label="One"></calcite-combobox-item>
-          <calcite-combobox-item id="two" icon="beaker" value="two" text-label="Two"></calcite-combobox-item>
-          <calcite-combobox-item id="three" value="three" text-label="Three"></calcite-combobox-item>
+          <calcite-combobox-item id="one" icon="banana" value="one" heading="One"></calcite-combobox-item>
+          <calcite-combobox-item id="two" icon="beaker" value="two" heading="Two"></calcite-combobox-item>
+          <calcite-combobox-item id="three" value="three" heading="Three"></calcite-combobox-item>
         </calcite-combobox>
       </template>
       <script>
@@ -2358,9 +2350,9 @@ describe("calcite-combobox", () => {
   describe("is form-associated", () => {
     formAssociated(
       html`<calcite-combobox selection-mode="single">
-        <calcite-combobox-item id="one" icon="banana" value="one" text-label="One"></calcite-combobox-item>
-        <calcite-combobox-item id="two" icon="beaker" value="two" text-label="Two" selected></calcite-combobox-item>
-        <calcite-combobox-item id="three" value="three" text-label="Three"></calcite-combobox-item>
+        <calcite-combobox-item id="one" icon="banana" value="one" heading="One"></calcite-combobox-item>
+        <calcite-combobox-item id="two" icon="beaker" value="two" heading="Two" selected></calcite-combobox-item>
+        <calcite-combobox-item id="three" value="three" heading="Three"></calcite-combobox-item>
       </calcite-combobox>`,
       { testValue: "two", submitsOnEnter: true, validation: true, changeValueKeys: ["Space", "Enter"] },
     );
@@ -2370,10 +2362,9 @@ describe("calcite-combobox", () => {
     const page = await newE2EPage();
     await page.setContent(
       html` <calcite-combobox placeholder="What's scarier than 5G?" selection-mode="single" placeholder-icon="car">
-        <calcite-combobox-item value="Bluetooth" text-label="Bluetooth" icon="bluetooth"> </calcite-combobox-item>
-        <calcite-combobox-item value="Exercise" text-label="Exercise"> </calcite-combobox-item>
-        <calcite-combobox-item value="Space Lasers" text-label="Space Lasers" icon="satellite-3">
-        </calcite-combobox-item>
+        <calcite-combobox-item value="Bluetooth" heading="Bluetooth" icon="bluetooth"> </calcite-combobox-item>
+        <calcite-combobox-item value="Exercise" heading="Exercise"> </calcite-combobox-item>
+        <calcite-combobox-item value="Space Lasers" heading="Space Lasers" icon="satellite-3"> </calcite-combobox-item>
       </calcite-combobox>`,
     );
 
@@ -2393,7 +2384,7 @@ describe("calcite-combobox", () => {
     const page = await newE2EPage();
     await page.setContent(
       html` <calcite-combobox>
-        <calcite-combobox-item value="Bluetooth" text-label="Bluetooth"> </calcite-combobox-item>
+        <calcite-combobox-item value="Bluetooth" heading="Bluetooth"> </calcite-combobox-item>
       </calcite-combobox>`,
     );
 
@@ -2411,7 +2402,7 @@ describe("calcite-combobox", () => {
     const page = await newE2EPage();
     await page.setContent(
       html` <calcite-combobox open id="demoId">
-        <calcite-combobox-item value="test-value" text-label="test"> </calcite-combobox-item>
+        <calcite-combobox-item value="test-value" heading="test"> </calcite-combobox-item>
       </calcite-combobox>`,
     );
     const item = await page.find("calcite-combobox-item");
@@ -2431,7 +2422,7 @@ describe("calcite-combobox", () => {
     const page = await newE2EPage();
     await page.setContent(
       html` <calcite-combobox open id="demoId">
-        <calcite-combobox-item value="test-value" text-label="test"> </calcite-combobox-item>
+        <calcite-combobox-item value="test-value" heading="test"> </calcite-combobox-item>
       </calcite-combobox>`,
     );
     await skipAnimations(page);
@@ -2450,7 +2441,7 @@ describe("calcite-combobox", () => {
     const page = await newE2EPage();
     await page.setContent(
       html` <calcite-combobox id="demoId">
-        <calcite-combobox-item value="test-value" text-label="test"> </calcite-combobox-item>
+        <calcite-combobox-item value="test-value" heading="test"> </calcite-combobox-item>
       </calcite-combobox>`,
     );
     await skipAnimations(page);
@@ -2480,8 +2471,8 @@ describe("calcite-combobox", () => {
       it("shows the first item as active if there is no previous selection", async () =>
         assertActiveItem(
           html`<calcite-combobox selection-mode="single">
-            <calcite-combobox-item value="item1" text-label="item1"></calcite-combobox-item>
-            <calcite-combobox-item value="item2" text-label="item2"></calcite-combobox-item>
+            <calcite-combobox-item value="item1" heading="item1"></calcite-combobox-item>
+            <calcite-combobox-item value="item2" heading="item2"></calcite-combobox-item>
           </calcite-combobox>`,
           "item1",
         ));
@@ -2489,9 +2480,9 @@ describe("calcite-combobox", () => {
       it("shows the selected item as active when opened", async () =>
         assertActiveItem(
           html`<calcite-combobox selection-mode="single">
-            <calcite-combobox-item value="item1" text-label="item1"></calcite-combobox-item>
-            <calcite-combobox-item value="item2" text-label="item2"></calcite-combobox-item>
-            <calcite-combobox-item value="item3" text-label="item3" selected></calcite-combobox-item>
+            <calcite-combobox-item value="item1" heading="item1"></calcite-combobox-item>
+            <calcite-combobox-item value="item2" heading="item2"></calcite-combobox-item>
+            <calcite-combobox-item value="item3" heading="item3" selected></calcite-combobox-item>
           </calcite-combobox>`,
           "item3",
         ));
@@ -2501,30 +2492,30 @@ describe("calcite-combobox", () => {
 
         await page.setContent(
           html`<calcite-combobox open max-items="6" selection-mode="single">
-            <calcite-combobox-item value="Trees" text-label="Trees">
-              <calcite-combobox-item value="Pine" text-label="Pine">
-                <calcite-combobox-item value="Pine Nested" text-label="Pine Nested"></calcite-combobox-item>
+            <calcite-combobox-item value="Trees" heading="Trees">
+              <calcite-combobox-item value="Pine" heading="Pine">
+                <calcite-combobox-item value="Pine Nested" heading="Pine Nested"></calcite-combobox-item>
               </calcite-combobox-item>
-              <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia"></calcite-combobox-item>
-              <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir"></calcite-combobox-item>
+              <calcite-combobox-item value="Sequoia" disabled heading="Sequoia"></calcite-combobox-item>
+              <calcite-combobox-item value="Douglas Fir" heading="Douglas Fir"></calcite-combobox-item>
             </calcite-combobox-item>
-            <calcite-combobox-item value="Flowers" text-label="Flowers">
-              <calcite-combobox-item value="Daffodil" text-label="Daffodil"></calcite-combobox-item>
+            <calcite-combobox-item value="Flowers" heading="Flowers">
+              <calcite-combobox-item value="Daffodil" heading="Daffodil"></calcite-combobox-item>
               <calcite-combobox-item
                 value="Black Eyed Susan"
-                text-label="Black Eyed Susan"
+                heading="Black Eyed Susan"
                 selected
               ></calcite-combobox-item>
-              <calcite-combobox-item value="Nasturtium" text-label="Nasturtium"></calcite-combobox-item>
+              <calcite-combobox-item value="Nasturtium" heading="Nasturtium"></calcite-combobox-item>
             </calcite-combobox-item>
-            <calcite-combobox-item value="Animals" text-label="Animals">
-              <calcite-combobox-item value="Birds" text-label="Birds"></calcite-combobox-item>
-              <calcite-combobox-item value="Reptiles" text-label="Reptiles"></calcite-combobox-item>
-              <calcite-combobox-item value="Amphibians" text-label="Amphibians"></calcite-combobox-item>
+            <calcite-combobox-item value="Animals" heading="Animals">
+              <calcite-combobox-item value="Birds" heading="Birds"></calcite-combobox-item>
+              <calcite-combobox-item value="Reptiles" heading="Reptiles"></calcite-combobox-item>
+              <calcite-combobox-item value="Amphibians" heading="Amphibians"></calcite-combobox-item>
             </calcite-combobox-item>
-            <calcite-combobox-item value="Rocks" text-label="Rocks"></calcite-combobox-item>
-            <calcite-combobox-item value="Insects" text-label="Insects"></calcite-combobox-item>
-            <calcite-combobox-item value="Rivers" text-label="Rivers"></calcite-combobox-item>
+            <calcite-combobox-item value="Rocks" heading="Rocks"></calcite-combobox-item>
+            <calcite-combobox-item value="Insects" heading="Insects"></calcite-combobox-item>
+            <calcite-combobox-item value="Rivers" heading="Rivers"></calcite-combobox-item>
           </calcite-combobox>`,
         );
         await page.waitForChanges();
@@ -2540,9 +2531,9 @@ describe("calcite-combobox", () => {
       it("shows the first item as active if there is no previous selection", async () =>
         assertActiveItem(
           html` <calcite-combobox selection-mode="multiple">
-            <calcite-combobox-item value="item1" text-label="item1"></calcite-combobox-item>
-            <calcite-combobox-item value="item2" text-label="item2"></calcite-combobox-item>
-            <calcite-combobox-item value="item3" text-label="item3"></calcite-combobox-item>
+            <calcite-combobox-item value="item1" heading="item1"></calcite-combobox-item>
+            <calcite-combobox-item value="item2" heading="item2"></calcite-combobox-item>
+            <calcite-combobox-item value="item3" heading="item3"></calcite-combobox-item>
           </calcite-combobox>`,
           "item1",
         ));
@@ -2550,9 +2541,9 @@ describe("calcite-combobox", () => {
       it("shows the last selected item as active", async () =>
         assertActiveItem(
           html` <calcite-combobox selection-mode="multiple">
-            <calcite-combobox-item selected value="item1" text-label="item1"></calcite-combobox-item>
-            <calcite-combobox-item value="item2" text-label="item2" selected></calcite-combobox-item>
-            <calcite-combobox-item selected value="item3" text-label="item3"></calcite-combobox-item>
+            <calcite-combobox-item selected value="item1" heading="item1"></calcite-combobox-item>
+            <calcite-combobox-item value="item2" heading="item2" selected></calcite-combobox-item>
+            <calcite-combobox-item selected value="item3" heading="item3"></calcite-combobox-item>
           </calcite-combobox>`,
           "item3",
         ));
@@ -2562,30 +2553,30 @@ describe("calcite-combobox", () => {
 
         await page.setContent(
           html`<calcite-combobox open max-items="6" selection-mode="multiple">
-            <calcite-combobox-item value="Trees" text-label="Trees">
-              <calcite-combobox-item value="Pine" text-label="Pine">
-                <calcite-combobox-item value="Pine Nested" text-label="Pine Nested"></calcite-combobox-item>
+            <calcite-combobox-item value="Trees" heading="Trees">
+              <calcite-combobox-item value="Pine" heading="Pine">
+                <calcite-combobox-item value="Pine Nested" heading="Pine Nested"></calcite-combobox-item>
               </calcite-combobox-item>
-              <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia"></calcite-combobox-item>
-              <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir"></calcite-combobox-item>
+              <calcite-combobox-item value="Sequoia" disabled heading="Sequoia"></calcite-combobox-item>
+              <calcite-combobox-item value="Douglas Fir" heading="Douglas Fir"></calcite-combobox-item>
             </calcite-combobox-item>
-            <calcite-combobox-item value="Flowers" text-label="Flowers">
-              <calcite-combobox-item value="Daffodil" text-label="Daffodil"></calcite-combobox-item>
+            <calcite-combobox-item value="Flowers" heading="Flowers">
+              <calcite-combobox-item value="Daffodil" heading="Daffodil"></calcite-combobox-item>
               <calcite-combobox-item
                 value="Black Eyed Susan"
-                text-label="Black Eyed Susan"
+                heading="Black Eyed Susan"
                 selected
               ></calcite-combobox-item>
-              <calcite-combobox-item value="Nasturtium" text-label="Nasturtium"></calcite-combobox-item>
+              <calcite-combobox-item value="Nasturtium" heading="Nasturtium"></calcite-combobox-item>
             </calcite-combobox-item>
-            <calcite-combobox-item value="Animals" text-label="Animals">
-              <calcite-combobox-item value="Birds" text-label="Birds"></calcite-combobox-item>
-              <calcite-combobox-item value="Reptiles" text-label="Reptiles"></calcite-combobox-item>
-              <calcite-combobox-item value="Amphibians" text-label="Amphibians"></calcite-combobox-item>
+            <calcite-combobox-item value="Animals" heading="Animals">
+              <calcite-combobox-item value="Birds" heading="Birds"></calcite-combobox-item>
+              <calcite-combobox-item value="Reptiles" heading="Reptiles"></calcite-combobox-item>
+              <calcite-combobox-item value="Amphibians" heading="Amphibians"></calcite-combobox-item>
             </calcite-combobox-item>
-            <calcite-combobox-item value="Rocks" text-label="Rocks" selected></calcite-combobox-item>
-            <calcite-combobox-item value="Insects" text-label="Insects"></calcite-combobox-item>
-            <calcite-combobox-item value="Rivers" text-label="Rivers"></calcite-combobox-item>
+            <calcite-combobox-item value="Rocks" heading="Rocks" selected></calcite-combobox-item>
+            <calcite-combobox-item value="Insects" heading="Insects"></calcite-combobox-item>
+            <calcite-combobox-item value="Rivers" heading="Rivers"></calcite-combobox-item>
           </calcite-combobox>`,
         );
         await page.waitForChanges();
@@ -2604,11 +2595,11 @@ describe("calcite-combobox", () => {
       it("shows the first item as active if there is no previous selection", async () =>
         assertActiveItem(
           html` <calcite-combobox selection-mode="ancestors">
-            <calcite-combobox-item value="item1" text-label="parent">
-              <calcite-combobox-item value="item1_1" text-label="item1_1"></calcite-combobox-item>
+            <calcite-combobox-item value="item1" heading="parent">
+              <calcite-combobox-item value="item1_1" heading="item1_1"></calcite-combobox-item>
             </calcite-combobox-item>
-            <calcite-combobox-item value="item2" text-label="item2"></calcite-combobox-item>
-            <calcite-combobox-item value="item3" text-label="item3"></calcite-combobox-item>
+            <calcite-combobox-item value="item2" heading="item2"></calcite-combobox-item>
+            <calcite-combobox-item value="item3" heading="item3"></calcite-combobox-item>
           </calcite-combobox>`,
           "item1",
         ));
@@ -2616,11 +2607,11 @@ describe("calcite-combobox", () => {
       it("shows the last selected item as active", async () =>
         assertActiveItem(
           html` <calcite-combobox selection-mode="ancestors">
-            <calcite-combobox-item value="item1" text-label="parent" selected>
-              <calcite-combobox-item value="item1_1" text-label="item1_1"></calcite-combobox-item>
+            <calcite-combobox-item value="item1" heading="parent" selected>
+              <calcite-combobox-item value="item1_1" heading="item1_1"></calcite-combobox-item>
             </calcite-combobox-item>
-            <calcite-combobox-item value="item2" text-label="item2"></calcite-combobox-item>
-            <calcite-combobox-item value="item3" text-label="item3" selected></calcite-combobox-item>
+            <calcite-combobox-item value="item2" heading="item2"></calcite-combobox-item>
+            <calcite-combobox-item value="item3" heading="item3" selected></calcite-combobox-item>
           </calcite-combobox>`,
           "item3",
         ));
@@ -2632,9 +2623,9 @@ describe("calcite-combobox", () => {
     await page.setContent(html`
       <calcite-combobox label="Trees" value="Trees" scale="l" selection-mode="single">
         <calcite-combobox-item-group label="Conifers">
-          <calcite-combobox-item value="Pine" text-label="Pine"></calcite-combobox-item>
+          <calcite-combobox-item value="Pine" heading="Pine"></calcite-combobox-item>
         </calcite-combobox-item-group>
-        <calcite-combobox-item value="DisabledItem" text-label="DisabledItem" disabled></calcite-combobox-item>
+        <calcite-combobox-item value="DisabledItem" heading="DisabledItem" disabled></calcite-combobox-item>
       </calcite-combobox>
     `);
     const comboboxItems = await findAll(page, "calcite-combobox-item");
@@ -2652,8 +2643,8 @@ describe("calcite-combobox", () => {
       page = await newE2EPage();
       await page.setContent(html`
         <calcite-combobox id="myCombobox">
-          <calcite-combobox-item id="one" value="one" text-label="one"></calcite-combobox-item>
-          <calcite-combobox-item id="two" value="two" text-label="two"></calcite-combobox-item>
+          <calcite-combobox-item id="one" value="one" heading="one"></calcite-combobox-item>
+          <calcite-combobox-item id="two" value="two" heading="two"></calcite-combobox-item>
         </calcite-combobox>
       `);
     });
@@ -2704,8 +2695,8 @@ describe("calcite-combobox", () => {
       page = await newE2EPage();
       await page.setContent(html`
         <calcite-combobox id="myCombobox">
-          <calcite-combobox-item id="one" value="one" text-label="one"></calcite-combobox-item>
-          <calcite-combobox-item id="two" value="two" text-label="two"></calcite-combobox-item>
+          <calcite-combobox-item id="one" value="one" heading="one"></calcite-combobox-item>
+          <calcite-combobox-item id="two" value="two" heading="two"></calcite-combobox-item>
         </calcite-combobox>
       `);
     });
@@ -2745,15 +2736,15 @@ describe("calcite-combobox", () => {
     await page.setContent(html`
       <calcite-combobox label="test" placeholder="placeholder" max-items="10" scale="m">
         <calcite-combobox-item-group label="Pokemon">
-          <calcite-combobox-item value="Pikachu" text-label="Pikachu"></calcite-combobox-item>
-          <calcite-combobox-item value="Venusaur" text-label="Venusaur"></calcite-combobox-item>
-          <calcite-combobox-item value="Charizard" text-label="Charizard"></calcite-combobox-item>
+          <calcite-combobox-item value="Pikachu" heading="Pikachu"></calcite-combobox-item>
+          <calcite-combobox-item value="Venusaur" heading="Venusaur"></calcite-combobox-item>
+          <calcite-combobox-item value="Charizard" heading="Charizard"></calcite-combobox-item>
           <calcite-combobox-item-group label="Cutest Pokemon">
-            <calcite-combobox-item value="Bulbasaur" text-label="Bulbasaur"></calcite-combobox-item>
-            <calcite-combobox-item value="Squirtle1" text-label="Squirtle1">
-              <calcite-combobox-item value="Squirtle2" text-label="Squirtle2">
-                <calcite-combobox-item value="Squirtle3" text-label="Squirtle3">
-                  <calcite-combobox-item value="Squirtle4" text-label="Squirtle4"></calcite-combobox-item>
+            <calcite-combobox-item value="Bulbasaur" heading="Bulbasaur"></calcite-combobox-item>
+            <calcite-combobox-item value="Squirtle1" heading="Squirtle1">
+              <calcite-combobox-item value="Squirtle2" heading="Squirtle2">
+                <calcite-combobox-item value="Squirtle3" heading="Squirtle3">
+                  <calcite-combobox-item value="Squirtle4" heading="Squirtle4"></calcite-combobox-item>
                 </calcite-combobox-item>
               </calcite-combobox-item>
             </calcite-combobox-item>
@@ -2792,13 +2783,13 @@ describe("calcite-combobox", () => {
     await page.setContent(html`
       <calcite-combobox label="test" placeholder="placeholder" max-items="10" scale="m">
         <calcite-combobox-item-group label="Pokemon">
-          <calcite-combobox-item value="Pikachu" text-label="Pikachu"></calcite-combobox-item>
-          <calcite-combobox-item value="Venusaur" text-label="Venusaur"></calcite-combobox-item>
-          <calcite-combobox-item value="Charizard" text-label="Charizard"></calcite-combobox-item>
+          <calcite-combobox-item value="Pikachu" heading="Pikachu"></calcite-combobox-item>
+          <calcite-combobox-item value="Venusaur" heading="Venusaur"></calcite-combobox-item>
+          <calcite-combobox-item value="Charizard" heading="Charizard"></calcite-combobox-item>
           <calcite-combobox-item-group label="Cutest Pokemon">
-            <calcite-combobox-item value="Bulbasaur" text-label="Bulbasaur"></calcite-combobox-item>
-            <calcite-combobox-item value="Squirtle1" text-label="Squirtle1">
-              <calcite-combobox-item value="Squirtle2" text-label="Squirtle2"> </calcite-combobox-item>
+            <calcite-combobox-item value="Bulbasaur" heading="Bulbasaur"></calcite-combobox-item>
+            <calcite-combobox-item value="Squirtle1" heading="Squirtle1">
+              <calcite-combobox-item value="Squirtle2" heading="Squirtle2"> </calcite-combobox-item>
             </calcite-combobox-item>
           </calcite-combobox-item-group>
         </calcite-combobox-item-group>
@@ -2828,10 +2819,10 @@ describe("calcite-combobox", () => {
     const page = await newE2EPage();
     await page.setContent(html`
       <calcite-combobox id="myCombobox" read-only>
-        <calcite-combobox-item value="Raising Arizona" text-label="Raising Arizona"></calcite-combobox-item>
-        <calcite-combobox-item value="Miller's Crossing" text-label="Miller's Crossing"></calcite-combobox-item>
-        <calcite-combobox-item value="The Hudsucker Proxy" text-label="The Hudsucker Proxy"></calcite-combobox-item>
-        <calcite-combobox-item value="Inside Llewyn Davis" text-label="Inside Llewyn Davis"></calcite-combobox-item>
+        <calcite-combobox-item value="Raising Arizona" heading="Raising Arizona"></calcite-combobox-item>
+        <calcite-combobox-item value="Miller's Crossing" heading="Miller's Crossing"></calcite-combobox-item>
+        <calcite-combobox-item value="The Hudsucker Proxy" heading="The Hudsucker Proxy"></calcite-combobox-item>
+        <calcite-combobox-item value="Inside Llewyn Davis" heading="Inside Llewyn Davis"></calcite-combobox-item>
       </calcite-combobox>
     `);
 
@@ -2856,9 +2847,9 @@ describe("calcite-combobox", () => {
     const page = await newE2EPage();
     await page.setContent(html`
       <calcite-combobox>
-        <calcite-combobox-item text-label="Item 1" value="one"></calcite-combobox-item>
-        <calcite-combobox-item text-label="Item 2" value="two"></calcite-combobox-item>
-        <calcite-combobox-item id="tres" text-label="Item 3" value="three" disabled></calcite-combobox-item>
+        <calcite-combobox-item heading="Item 1" value="one"></calcite-combobox-item>
+        <calcite-combobox-item heading="Item 2" value="two"></calcite-combobox-item>
+        <calcite-combobox-item id="tres" heading="Item 3" value="three" disabled></calcite-combobox-item>
       </calcite-combobox>
     `);
     const combobox = await page.find("calcite-combobox");
@@ -2881,9 +2872,9 @@ describe("calcite-combobox", () => {
     const page = await newE2EPage();
     await page.setContent(
       html`<calcite-combobox selection-mode="single">
-        <calcite-combobox-item id="one" value="one" text-label="one" selected></calcite-combobox-item>
-        <calcite-combobox-item id="two" value="two" text-label="two"></calcite-combobox-item>
-        <calcite-combobox-item id="three" value="three" text-label="three"></calcite-combobox-item>
+        <calcite-combobox-item id="one" value="one" heading="one" selected></calcite-combobox-item>
+        <calcite-combobox-item id="two" value="two" heading="two"></calcite-combobox-item>
+        <calcite-combobox-item id="three" value="three" heading="three"></calcite-combobox-item>
       </calcite-combobox>`,
     );
     await page.waitForChanges();
@@ -2902,9 +2893,9 @@ describe("calcite-combobox", () => {
     const page = await newE2EPage();
     await page.setContent(
       html`<calcite-combobox selection-mode="single" select-all-enabled read-only>
-        <calcite-combobox-item value="one" text-label="one" selected=""></calcite-combobox-item>
-        <calcite-combobox-item value="two" text-label="two"></calcite-combobox-item>
-        <calcite-combobox-item value="three" text-label="three"></calcite-combobox-item>
+        <calcite-combobox-item value="one" heading="one" selected=""></calcite-combobox-item>
+        <calcite-combobox-item value="two" heading="two"></calcite-combobox-item>
+        <calcite-combobox-item value="three" heading="three"></calcite-combobox-item>
       </calcite-combobox>`,
     );
     const input = await page.find("calcite-combobox >>> input");
@@ -2918,15 +2909,15 @@ describe("calcite-combobox", () => {
       page = await newE2EPage();
       await page.setContent(
         html`<calcite-combobox selection-mode="multiple" select-all-enabled>
-          <calcite-combobox-item value="Trees" text-label="Trees">
-            <calcite-combobox-item value="Pine" text-label="Pine">
-              <calcite-combobox-item value="Pine Nested" text-label="Pine Nested"></calcite-combobox-item>
+          <calcite-combobox-item value="Trees" heading="Trees">
+            <calcite-combobox-item value="Pine" heading="Pine">
+              <calcite-combobox-item value="Pine Nested" heading="Pine Nested"></calcite-combobox-item>
             </calcite-combobox-item>
-            <calcite-combobox-item value="Sequoia" text-label="Sequoia"></calcite-combobox-item>
+            <calcite-combobox-item value="Sequoia" heading="Sequoia"></calcite-combobox-item>
           </calcite-combobox-item>
-          <calcite-combobox-item value="Flowers" text-label="Flowers">
-            <calcite-combobox-item value="Daffodil" text-label="Daffodil"></calcite-combobox-item>
-            <calcite-combobox-item value="Nasturtium" text-label="Nasturtium"></calcite-combobox-item>
+          <calcite-combobox-item value="Flowers" heading="Flowers">
+            <calcite-combobox-item value="Daffodil" heading="Daffodil"></calcite-combobox-item>
+            <calcite-combobox-item value="Nasturtium" heading="Nasturtium"></calcite-combobox-item>
           </calcite-combobox-item>
         </calcite-combobox>`,
       );
@@ -3057,8 +3048,8 @@ describe("calcite-combobox", () => {
       page = await newE2EPage();
       await page.setContent(
         html`<calcite-combobox selection-mode="multiple" select-all-enabled>
-          <calcite-combobox-item value="Trees" text-label="Trees" selected>
-            <calcite-combobox-item value="Pine" text-label="Pine" />
+          <calcite-combobox-item value="Trees" heading="Trees" selected>
+            <calcite-combobox-item value="Pine" heading="Pine" />
           </calcite-combobox-item>
         </calcite-combobox>`,
       );
@@ -3070,8 +3061,8 @@ describe("calcite-combobox", () => {
       page = await newE2EPage();
       await page.setContent(
         html`<calcite-combobox selection-mode="multiple" select-all-enabled>
-          <calcite-combobox-item value="Trees" text-label="Trees" selected>
-            <calcite-combobox-item value="Pine" text-label="Pine" selected />
+          <calcite-combobox-item value="Trees" heading="Trees" selected>
+            <calcite-combobox-item value="Pine" heading="Pine" selected />
           </calcite-combobox-item>
         </calcite-combobox>`,
       );
@@ -3084,9 +3075,9 @@ describe("calcite-combobox", () => {
       page = await newE2EPage();
       await page.setContent(
         html`<calcite-combobox selection-mode="multiple" select-all-enabled>
-          <calcite-combobox-item value="Trees" text-label="Trees" selected>
-            <calcite-combobox-item value="Pine" text-label="Maple" selected />
-            <calcite-combobox-item value="Pine" text-label="Pine" selected />
+          <calcite-combobox-item value="Trees" heading="Trees" selected>
+            <calcite-combobox-item value="Pine" heading="Maple" selected />
+            <calcite-combobox-item value="Pine" heading="Pine" selected />
           </calcite-combobox-item>
         </calcite-combobox>`,
       );
@@ -3131,12 +3122,12 @@ describe("calcite-combobox", () => {
     describe("default", () => {
       const comboboxHTML = html`<calcite-combobox label="test" max-items="6" open>
         <calcite-combobox-item-group value="Trees" label="Trees">
-          <calcite-combobox-item value="Pine" text-label="Pine">
-            <calcite-combobox-item value="Pine Nested" text-label="Pine Nested"></calcite-combobox-item>
+          <calcite-combobox-item value="Pine" heading="Pine">
+            <calcite-combobox-item value="Pine Nested" heading="Pine Nested"></calcite-combobox-item>
           </calcite-combobox-item>
         </calcite-combobox-item-group>
-        <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia"></calcite-combobox-item>
-        <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir" selected></calcite-combobox-item>
+        <calcite-combobox-item value="Sequoia" disabled heading="Sequoia"></calcite-combobox-item>
+        <calcite-combobox-item value="Douglas Fir" heading="Douglas Fir" selected></calcite-combobox-item>
       </calcite-combobox>`;
 
       const comboboxTokens: ComponentTestTokens = {
@@ -3191,9 +3182,9 @@ describe("calcite-combobox", () => {
         placeholder="select element"
         placeholder-icon="layers"
       >
-        <calcite-combobox-item value="Trees" text-label="Trees"></calcite-combobox-item>
-        <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia"></calcite-combobox-item>
-        <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir"></calcite-combobox-item>
+        <calcite-combobox-item value="Trees" heading="Trees"></calcite-combobox-item>
+        <calcite-combobox-item value="Sequoia" disabled heading="Sequoia"></calcite-combobox-item>
+        <calcite-combobox-item value="Douglas Fir" heading="Douglas Fir"></calcite-combobox-item>
       </calcite-combobox>`;
 
       const comboboxTokens: ComponentTestTokens = {
@@ -3208,9 +3199,9 @@ describe("calcite-combobox", () => {
 
     describe("single select", () => {
       const singleSelectComboboxHTML = html` <calcite-combobox label="test" selection-mode="single">
-        <calcite-combobox-item value="Trees" text-label="Trees"></calcite-combobox-item>
-        <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia"></calcite-combobox-item>
-        <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir" selected></calcite-combobox-item>
+        <calcite-combobox-item value="Trees" heading="Trees"></calcite-combobox-item>
+        <calcite-combobox-item value="Sequoia" disabled heading="Sequoia"></calcite-combobox-item>
+        <calcite-combobox-item value="Douglas Fir" heading="Douglas Fir" selected></calcite-combobox-item>
       </calcite-combobox>`;
 
       const comboboxTokens: ComponentTestTokens = {
@@ -3225,8 +3216,8 @@ describe("calcite-combobox", () => {
 
     const comboboxSelectAllEnabledHTML = html`
       <calcite-combobox select-all-enabled>
-          </calcite-combobox-item value="Pine" text-label="Pine">
-          </calcite-combobox-item value="Not Pine" text-label="Not Pine">
+          </calcite-combobox-item value="Pine" heading="Pine">
+          </calcite-combobox-item value="Not Pine" heading="Not Pine">
         </calcite-combobox>
     `;
 
@@ -3254,8 +3245,8 @@ describe("calcite-combobox", () => {
           const page = await newE2EPage();
           await page.setContent(`
             <calcite-combobox open allow-custom-values>
-              <calcite-combobox-item value="Pine" text-label="Pine"></calcite-combobox-item>
-              <calcite-combobox-item value="Maple" text-label="Maple"></calcite-combobox-item>
+              <calcite-combobox-item value="Pine" heading="Pine"></calcite-combobox-item>
+              <calcite-combobox-item value="Maple" heading="Maple"></calcite-combobox-item>
             </calcite-combobox>
           `);
 
@@ -3282,13 +3273,13 @@ describe("calcite-combobox", () => {
     describe("groups", () => {
       const comboboxGroupHTML = html`<calcite-combobox label="test" placeholder="placeholder">
         <calcite-combobox-item-group label="Parent group">
-          <calcite-combobox-item value="group item 1" text-label="group item 1"></calcite-combobox-item>
-          <calcite-combobox-item value="group item 2" text-label="group item 2"></calcite-combobox-item>
-          <calcite-combobox-item value="group item 3" text-label="group item 3"></calcite-combobox-item>
+          <calcite-combobox-item value="group item 1" heading="group item 1"></calcite-combobox-item>
+          <calcite-combobox-item value="group item 2" heading="group item 2"></calcite-combobox-item>
+          <calcite-combobox-item value="group item 3" heading="group item 3"></calcite-combobox-item>
           <calcite-combobox-item-group label="Nested group">
-            <calcite-combobox-item value="group item 4" text-label="group item 4"></calcite-combobox-item>
-            <calcite-combobox-item value="group item 5" text-label="group item 5"></calcite-combobox-item>
-            <calcite-combobox-item value="group item 6" text-label="group item 6"></calcite-combobox-item>
+            <calcite-combobox-item value="group item 4" heading="group item 4"></calcite-combobox-item>
+            <calcite-combobox-item value="group item 5" heading="group item 5"></calcite-combobox-item>
+            <calcite-combobox-item value="group item 6" heading="group item 6"></calcite-combobox-item>
           </calcite-combobox-item-group>
         </calcite-combobox-item-group>
       </calcite-combobox>`;

--- a/packages/components/src/components/combobox/combobox.stories.ts
+++ b/packages/components/src/components/combobox/combobox.stories.ts
@@ -76,19 +76,19 @@ export const single = (): string => html`
       scale="m"
       status="idle"
     >
-      <calcite-combobox-item icon="altitude" value="altitude" text-label="Altitude" selected></calcite-combobox-item>
-      <calcite-combobox-item icon="article" value="article" text-label="Article"></calcite-combobox-item>
-      <calcite-combobox-item icon="attachment" value="attachment" text-label="Attachment"></calcite-combobox-item>
-      <calcite-combobox-item icon="banana" value="banana" text-label="Banana"></calcite-combobox-item>
-      <calcite-combobox-item icon="battery3" value="battery" text-label="Battery Charging"></calcite-combobox-item>
-      <calcite-combobox-item icon="beaker" value="beaker" text-label="Beaker"></calcite-combobox-item>
-      <calcite-combobox-item icon="bell" value="bell" text-label="Bell"></calcite-combobox-item>
-      <calcite-combobox-item icon="bookmark" value="bookmark" text-label="Bookmark"></calcite-combobox-item>
-      <calcite-combobox-item icon="brightness" value="brightness" text-label="Brightness"></calcite-combobox-item>
-      <calcite-combobox-item icon="calendar" value="calendar" text-label="Calendar"></calcite-combobox-item>
-      <calcite-combobox-item icon="camera" value="camera" text-label="Camera"></calcite-combobox-item>
-      <calcite-combobox-item icon="car" value="car" text-label="Car"></calcite-combobox-item>
-      <calcite-combobox-item icon="clock" value="clock" text-label="Clock"></calcite-combobox-item>
+      <calcite-combobox-item icon="altitude" value="altitude" heading="Altitude" selected></calcite-combobox-item>
+      <calcite-combobox-item icon="article" value="article" heading="Article"></calcite-combobox-item>
+      <calcite-combobox-item icon="attachment" value="attachment" heading="Attachment"></calcite-combobox-item>
+      <calcite-combobox-item icon="banana" value="banana" heading="Banana"></calcite-combobox-item>
+      <calcite-combobox-item icon="battery3" value="battery" heading="Battery Charging"></calcite-combobox-item>
+      <calcite-combobox-item icon="beaker" value="beaker" heading="Beaker"></calcite-combobox-item>
+      <calcite-combobox-item icon="bell" value="bell" heading="Bell"></calcite-combobox-item>
+      <calcite-combobox-item icon="bookmark" value="bookmark" heading="Bookmark"></calcite-combobox-item>
+      <calcite-combobox-item icon="brightness" value="brightness" heading="Brightness"></calcite-combobox-item>
+      <calcite-combobox-item icon="calendar" value="calendar" heading="Calendar"></calcite-combobox-item>
+      <calcite-combobox-item icon="camera" value="camera" heading="Camera"></calcite-combobox-item>
+      <calcite-combobox-item icon="car" value="car" heading="Car"></calcite-combobox-item>
+      <calcite-combobox-item icon="clock" value="clock" heading="Clock"></calcite-combobox-item>
     </calcite-combobox>
   </div>
 `;
@@ -104,19 +104,19 @@ export const smallViewport = (): string => html`
     scale="m"
     status="idle"
   >
-    <calcite-combobox-item icon="altitude" value="altitude" text-label="Altitude" selected></calcite-combobox-item>
-    <calcite-combobox-item icon="article" value="article" text-label="Article"></calcite-combobox-item>
-    <calcite-combobox-item icon="attachment" value="attachment" text-label="Attachment"></calcite-combobox-item>
-    <calcite-combobox-item icon="banana" value="banana" text-label="Banana"></calcite-combobox-item>
-    <calcite-combobox-item icon="battery3" value="battery" text-label="Battery Charging"></calcite-combobox-item>
-    <calcite-combobox-item icon="beaker" value="beaker" text-label="Beaker"></calcite-combobox-item>
-    <calcite-combobox-item icon="bell" value="bell" text-label="Bell"></calcite-combobox-item>
-    <calcite-combobox-item icon="bookmark" value="bookmark" text-label="Bookmark"></calcite-combobox-item>
-    <calcite-combobox-item icon="brightness" value="brightness" text-label="Brightness"></calcite-combobox-item>
-    <calcite-combobox-item icon="calendar" value="calendar" text-label="Calendar"></calcite-combobox-item>
-    <calcite-combobox-item icon="camera" value="camera" text-label="Camera"></calcite-combobox-item>
-    <calcite-combobox-item icon="car" value="car" text-label="Car"></calcite-combobox-item>
-    <calcite-combobox-item icon="clock" value="clock" text-label="Clock"></calcite-combobox-item>
+    <calcite-combobox-item icon="altitude" value="altitude" heading="Altitude" selected></calcite-combobox-item>
+    <calcite-combobox-item icon="article" value="article" heading="Article"></calcite-combobox-item>
+    <calcite-combobox-item icon="attachment" value="attachment" heading="Attachment"></calcite-combobox-item>
+    <calcite-combobox-item icon="banana" value="banana" heading="Banana"></calcite-combobox-item>
+    <calcite-combobox-item icon="battery3" value="battery" heading="Battery Charging"></calcite-combobox-item>
+    <calcite-combobox-item icon="beaker" value="beaker" heading="Beaker"></calcite-combobox-item>
+    <calcite-combobox-item icon="bell" value="bell" heading="Bell"></calcite-combobox-item>
+    <calcite-combobox-item icon="bookmark" value="bookmark" heading="Bookmark"></calcite-combobox-item>
+    <calcite-combobox-item icon="brightness" value="brightness" heading="Brightness"></calcite-combobox-item>
+    <calcite-combobox-item icon="calendar" value="calendar" heading="Calendar"></calcite-combobox-item>
+    <calcite-combobox-item icon="camera" value="camera" heading="Camera"></calcite-combobox-item>
+    <calcite-combobox-item icon="car" value="car" heading="Car"></calcite-combobox-item>
+    <calcite-combobox-item icon="clock" value="clock" heading="Clock"></calcite-combobox-item>
   </calcite-combobox>
 `;
 smallViewport.parameters = { chromatic: { viewports: [300, 300] } };
@@ -127,24 +127,24 @@ export const multiple = (): string => html`
     <calcite-label>
       Some selected
       <calcite-combobox label="test" placeholder="Select items" max-items="10" scale="m" placeholder-icon="car">
-        <calcite-combobox-item value="Trees" text-label="Trees" selected>
-          <calcite-combobox-item selected value="Pine" selected text-label="Pine">
-            <calcite-combobox-item value="Pine Nested" text-label="Pine Nested"></calcite-combobox-item>
+        <calcite-combobox-item value="Trees" heading="Trees" selected>
+          <calcite-combobox-item selected value="Pine" selected heading="Pine">
+            <calcite-combobox-item value="Pine Nested" heading="Pine Nested"></calcite-combobox-item>
           </calcite-combobox-item>
-          <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia"></calcite-combobox-item>
-          <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir"></calcite-combobox-item>
+          <calcite-combobox-item value="Sequoia" disabled heading="Sequoia"></calcite-combobox-item>
+          <calcite-combobox-item value="Douglas Fir" heading="Douglas Fir"></calcite-combobox-item>
         </calcite-combobox-item>
       </calcite-combobox>
     </calcite-label>
     <calcite-label>
       All selected
       <calcite-combobox label="test" placeholder="Select items" max-items="10" scale="m" placeholder-icon="car">
-        <calcite-combobox-item value="Trees" text-label="Trees" selected>
-          <calcite-combobox-item selected value="Pine" selected text-label="Pine">
-            <calcite-combobox-item value="Pine Nested" text-label="Pine Nested" selected></calcite-combobox-item>
+        <calcite-combobox-item value="Trees" heading="Trees" selected>
+          <calcite-combobox-item selected value="Pine" selected heading="Pine">
+            <calcite-combobox-item value="Pine Nested" heading="Pine Nested" selected></calcite-combobox-item>
           </calcite-combobox-item>
-          <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia"></calcite-combobox-item>
-          <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir" selected></calcite-combobox-item>
+          <calcite-combobox-item value="Sequoia" disabled heading="Sequoia"></calcite-combobox-item>
+          <calcite-combobox-item value="Douglas Fir" heading="Douglas Fir" selected></calcite-combobox-item>
         </calcite-combobox-item>
       </calcite-combobox>
     </calcite-label>
@@ -160,12 +160,12 @@ export const multiple = (): string => html`
         selection-display="fit"
         placeholder-icon="car"
       >
-        <calcite-combobox-item value="Trees" text-label="Trees" selected>
-          <calcite-combobox-item selected value="Pine" selected text-label="Pine">
-            <calcite-combobox-item value="Pine Nested" text-label="Pine Nested"></calcite-combobox-item>
+        <calcite-combobox-item value="Trees" heading="Trees" selected>
+          <calcite-combobox-item selected value="Pine" selected heading="Pine">
+            <calcite-combobox-item value="Pine Nested" heading="Pine Nested"></calcite-combobox-item>
           </calcite-combobox-item>
-          <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia"></calcite-combobox-item>
-          <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir"></calcite-combobox-item>
+          <calcite-combobox-item value="Sequoia" disabled heading="Sequoia"></calcite-combobox-item>
+          <calcite-combobox-item value="Douglas Fir" heading="Douglas Fir"></calcite-combobox-item>
         </calcite-combobox-item>
       </calcite-combobox>
     </calcite-label>
@@ -179,12 +179,12 @@ export const multiple = (): string => html`
         selection-display="fit"
         placeholder-icon="car"
       >
-        <calcite-combobox-item value="Trees" text-label="Trees" selected>
-          <calcite-combobox-item selected value="Pine" selected text-label="Pine">
-            <calcite-combobox-item value="Pine Nested" text-label="Pine Nested" selected></calcite-combobox-item>
+        <calcite-combobox-item value="Trees" heading="Trees" selected>
+          <calcite-combobox-item selected value="Pine" selected heading="Pine">
+            <calcite-combobox-item value="Pine Nested" heading="Pine Nested" selected></calcite-combobox-item>
           </calcite-combobox-item>
-          <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia"></calcite-combobox-item>
-          <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir"></calcite-combobox-item>
+          <calcite-combobox-item value="Sequoia" disabled heading="Sequoia"></calcite-combobox-item>
+          <calcite-combobox-item value="Douglas Fir" heading="Douglas Fir"></calcite-combobox-item>
         </calcite-combobox-item>
       </calcite-combobox>
     </calcite-label>
@@ -198,12 +198,12 @@ export const multiple = (): string => html`
         selection-display="fit"
         placeholder-icon="car"
       >
-        <calcite-combobox-item value="Trees" text-label="Trees" selected>
-          <calcite-combobox-item selected value="Pine" selected text-label="Pine">
-            <calcite-combobox-item value="Pine Nested" text-label="Pine Nested" selected></calcite-combobox-item>
+        <calcite-combobox-item value="Trees" heading="Trees" selected>
+          <calcite-combobox-item selected value="Pine" selected heading="Pine">
+            <calcite-combobox-item value="Pine Nested" heading="Pine Nested" selected></calcite-combobox-item>
           </calcite-combobox-item>
-          <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia"></calcite-combobox-item>
-          <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir" selected></calcite-combobox-item>
+          <calcite-combobox-item value="Sequoia" disabled heading="Sequoia"></calcite-combobox-item>
+          <calcite-combobox-item value="Douglas Fir" heading="Douglas Fir" selected></calcite-combobox-item>
         </calcite-combobox-item>
       </calcite-combobox>
     </calcite-label>
@@ -217,12 +217,12 @@ export const multiple = (): string => html`
         selection-display="fit"
         placeholder-icon="car"
       >
-        <calcite-combobox-item value="Trees" text-label="Trees" selected>
-          <calcite-combobox-item selected value="Pine" selected text-label="Pine">
-            <calcite-combobox-item value="Pine Nested" text-label="Pine Nested" selected></calcite-combobox-item>
+        <calcite-combobox-item value="Trees" heading="Trees" selected>
+          <calcite-combobox-item selected value="Pine" selected heading="Pine">
+            <calcite-combobox-item value="Pine Nested" heading="Pine Nested" selected></calcite-combobox-item>
           </calcite-combobox-item>
-          <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia"></calcite-combobox-item>
-          <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir"></calcite-combobox-item>
+          <calcite-combobox-item value="Sequoia" disabled heading="Sequoia"></calcite-combobox-item>
+          <calcite-combobox-item value="Douglas Fir" heading="Douglas Fir"></calcite-combobox-item>
         </calcite-combobox-item>
       </calcite-combobox>
     </calcite-label>
@@ -236,12 +236,12 @@ export const multiple = (): string => html`
         selection-display="fit"
         placeholder-icon="car"
       >
-        <calcite-combobox-item value="Trees" text-label="Trees" selected>
-          <calcite-combobox-item selected value="Pine" selected text-label="Pine">
-            <calcite-combobox-item value="Pine Nested" text-label="Pine Nested" selected></calcite-combobox-item>
+        <calcite-combobox-item value="Trees" heading="Trees" selected>
+          <calcite-combobox-item selected value="Pine" selected heading="Pine">
+            <calcite-combobox-item value="Pine Nested" heading="Pine Nested" selected></calcite-combobox-item>
           </calcite-combobox-item>
-          <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia" selected></calcite-combobox-item>
-          <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir" selected></calcite-combobox-item>
+          <calcite-combobox-item value="Sequoia" disabled heading="Sequoia" selected></calcite-combobox-item>
+          <calcite-combobox-item value="Douglas Fir" heading="Douglas Fir" selected></calcite-combobox-item>
         </calcite-combobox-item>
       </calcite-combobox>
     </calcite-label>
@@ -255,12 +255,12 @@ export const multiple = (): string => html`
         selection-display="fit"
         placeholder-icon="car"
       >
-        <calcite-combobox-item value="Trees" text-label="Trees" selected>
-          <calcite-combobox-item selected value="Pine" selected text-label="Pine">
-            <calcite-combobox-item value="Pine Nested" text-label="Pine Nested" selected></calcite-combobox-item>
+        <calcite-combobox-item value="Trees" heading="Trees" selected>
+          <calcite-combobox-item selected value="Pine" selected heading="Pine">
+            <calcite-combobox-item value="Pine Nested" heading="Pine Nested" selected></calcite-combobox-item>
           </calcite-combobox-item>
-          <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia"></calcite-combobox-item>
-          <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir"></calcite-combobox-item>
+          <calcite-combobox-item value="Sequoia" disabled heading="Sequoia"></calcite-combobox-item>
+          <calcite-combobox-item value="Douglas Fir" heading="Douglas Fir"></calcite-combobox-item>
         </calcite-combobox-item>
       </calcite-combobox>
     </calcite-label>
@@ -274,12 +274,12 @@ export const multiple = (): string => html`
         selection-display="fit"
         placeholder-icon="car"
       >
-        <calcite-combobox-item value="Trees" text-label="Trees" selected>
-          <calcite-combobox-item selected value="Pine" selected text-label="Pine">
-            <calcite-combobox-item value="Pine Nested" text-label="Pine Nested" selected></calcite-combobox-item>
+        <calcite-combobox-item value="Trees" heading="Trees" selected>
+          <calcite-combobox-item selected value="Pine" selected heading="Pine">
+            <calcite-combobox-item value="Pine Nested" heading="Pine Nested" selected></calcite-combobox-item>
           </calcite-combobox-item>
-          <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia" selected></calcite-combobox-item>
-          <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir" selected></calcite-combobox-item>
+          <calcite-combobox-item value="Sequoia" disabled heading="Sequoia" selected></calcite-combobox-item>
+          <calcite-combobox-item value="Douglas Fir" heading="Douglas Fir" selected></calcite-combobox-item>
         </calcite-combobox-item>
       </calcite-combobox>
     </calcite-label>
@@ -295,12 +295,12 @@ export const multiple = (): string => html`
         selection-display="single"
         placeholder-icon="car"
       >
-        <calcite-combobox-item value="Trees" text-label="Trees" selected>
-          <calcite-combobox-item selected value="Pine" selected text-label="Pine">
-            <calcite-combobox-item value="Pine Nested" text-label="Pine Nested"></calcite-combobox-item>
+        <calcite-combobox-item value="Trees" heading="Trees" selected>
+          <calcite-combobox-item selected value="Pine" selected heading="Pine">
+            <calcite-combobox-item value="Pine Nested" heading="Pine Nested"></calcite-combobox-item>
           </calcite-combobox-item>
-          <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia"></calcite-combobox-item>
-          <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir"></calcite-combobox-item>
+          <calcite-combobox-item value="Sequoia" disabled heading="Sequoia"></calcite-combobox-item>
+          <calcite-combobox-item value="Douglas Fir" heading="Douglas Fir"></calcite-combobox-item>
         </calcite-combobox-item>
       </calcite-combobox>
     </calcite-label>
@@ -314,12 +314,12 @@ export const multiple = (): string => html`
         selection-display="single"
         placeholder-icon="car"
       >
-        <calcite-combobox-item value="Trees" text-label="Trees" selected>
-          <calcite-combobox-item selected value="Pine" selected text-label="Pine">
-            <calcite-combobox-item value="Pine Nested" text-label="Pine Nested" selected></calcite-combobox-item>
+        <calcite-combobox-item value="Trees" heading="Trees" selected>
+          <calcite-combobox-item selected value="Pine" selected heading="Pine">
+            <calcite-combobox-item value="Pine Nested" heading="Pine Nested" selected></calcite-combobox-item>
           </calcite-combobox-item>
-          <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia"></calcite-combobox-item>
-          <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir" selected></calcite-combobox-item>
+          <calcite-combobox-item value="Sequoia" disabled heading="Sequoia"></calcite-combobox-item>
+          <calcite-combobox-item value="Douglas Fir" heading="Douglas Fir" selected></calcite-combobox-item>
         </calcite-combobox-item>
       </calcite-combobox>
     </calcite-label>
@@ -333,12 +333,12 @@ export const multiple = (): string => html`
         selection-display="single"
         placeholder-icon="car"
       >
-        <calcite-combobox-item value="Trees" text-label="Trees" selected>
-          <calcite-combobox-item selected value="Pine" selected text-label="Pine">
-            <calcite-combobox-item value="Pine Nested" text-label="Pine Nested"></calcite-combobox-item>
+        <calcite-combobox-item value="Trees" heading="Trees" selected>
+          <calcite-combobox-item selected value="Pine" selected heading="Pine">
+            <calcite-combobox-item value="Pine Nested" heading="Pine Nested"></calcite-combobox-item>
           </calcite-combobox-item>
-          <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia"></calcite-combobox-item>
-          <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir"></calcite-combobox-item>
+          <calcite-combobox-item value="Sequoia" disabled heading="Sequoia"></calcite-combobox-item>
+          <calcite-combobox-item value="Douglas Fir" heading="Douglas Fir"></calcite-combobox-item>
         </calcite-combobox-item>
       </calcite-combobox>
     </calcite-label>
@@ -352,12 +352,12 @@ export const multiple = (): string => html`
         selection-display="single"
         placeholder-icon="car"
       >
-        <calcite-combobox-item value="Trees" text-label="Trees" selected>
-          <calcite-combobox-item selected value="Pine" selected text-label="Pine">
-            <calcite-combobox-item value="Pine Nested" text-label="Pine Nested" selected></calcite-combobox-item>
+        <calcite-combobox-item value="Trees" heading="Trees" selected>
+          <calcite-combobox-item selected value="Pine" selected heading="Pine">
+            <calcite-combobox-item value="Pine Nested" heading="Pine Nested" selected></calcite-combobox-item>
           </calcite-combobox-item>
-          <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia"></calcite-combobox-item>
-          <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir" selected></calcite-combobox-item>
+          <calcite-combobox-item value="Sequoia" disabled heading="Sequoia"></calcite-combobox-item>
+          <calcite-combobox-item value="Douglas Fir" heading="Douglas Fir" selected></calcite-combobox-item>
         </calcite-combobox-item>
       </calcite-combobox>
     </calcite-label>
@@ -365,32 +365,32 @@ export const multiple = (): string => html`
 `;
 
 export const nestedItems = (): string => html`
-      <calcite-combobox-item value="ITEM-0-0" text-label="Level 1">
-        <calcite-combobox-item value="ITEM-0-1" text-label="Level 2"></calcite-combobox-item>
-        <calcite-combobox-item value="ITEM-0-2" text-label="Level 2"></calcite-combobox-item>
-        <calcite-combobox-item value="ITEM-0-3" text-label="Level 2"></calcite-combobox-item>
+      <calcite-combobox-item value="ITEM-0-0" heading="Level 1">
+        <calcite-combobox-item value="ITEM-0-1" heading="Level 2"></calcite-combobox-item>
+        <calcite-combobox-item value="ITEM-0-2" heading="Level 2"></calcite-combobox-item>
+        <calcite-combobox-item value="ITEM-0-3" heading="Level 2"></calcite-combobox-item>
       </calcite-combobox-item>
-      <calcite-combobox-item value="ITEM-1-0" text-label="Level 1">
-        <calcite-combobox-item value="ITEM-1-1" text-label="Level 2">
-          <calcite-combobox-item value="ITEM-1-1-0" text-label="Level 3"></calcite-combobox-item>
-          <calcite-combobox-item value="ITEM-1-1-1" text-label="Level 3">
-            <calcite-combobox-item value="ITEM-1-1-1-0" text-label="Level 4"></calcite-combobox-item>
-            <calcite-combobox-item value="ITEM-1-1-1-1" text-label="Level 4"></calcite-combobox-item>
+      <calcite-combobox-item value="ITEM-1-0" heading="Level 1">
+        <calcite-combobox-item value="ITEM-1-1" heading="Level 2">
+          <calcite-combobox-item value="ITEM-1-1-0" heading="Level 3"></calcite-combobox-item>
+          <calcite-combobox-item value="ITEM-1-1-1" heading="Level 3">
+            <calcite-combobox-item value="ITEM-1-1-1-0" heading="Level 4"></calcite-combobox-item>
+            <calcite-combobox-item value="ITEM-1-1-1-1" heading="Level 4"></calcite-combobox-item>
           </calcite-combobox-item>
         </calcite-combobox-item>
-        <calcite-combobox-item value="ITEM-1-2" text-label="Level 2"></calcite-combobox-item>
-        <calcite-combobox-item value="ITEM-1-3" text-label="Level 2"></calcite-combobox-item>
+        <calcite-combobox-item value="ITEM-1-2" heading="Level 2"></calcite-combobox-item>
+        <calcite-combobox-item value="ITEM-1-3" heading="Level 2"></calcite-combobox-item>
       </calcite-combobox-item>
-      <calcite-combobox-item value="ITEM-2-0" text-label="Level 1">
-        <calcite-combobox-item value="ITEM-2-1" text-label="Level 2"></calcite-combobox-item>
-        <calcite-combobox-item value="ITEM-2-2" text-label="Level 2">
-          <calcite-combobox-item value="ITEM-2-2-0" text-label="Level 3"></calcite-combobox-item>
+      <calcite-combobox-item value="ITEM-2-0" heading="Level 1">
+        <calcite-combobox-item value="ITEM-2-1" heading="Level 2"></calcite-combobox-item>
+        <calcite-combobox-item value="ITEM-2-2" heading="Level 2">
+          <calcite-combobox-item value="ITEM-2-2-0" heading="Level 3"></calcite-combobox-item>
         </calcite-combobox-item>
-        <calcite-combobox-item value="ITEM-2-3" text-label="Level 2"></calcite-combobox-item>
+        <calcite-combobox-item value="ITEM-2-3" heading="Level 2"></calcite-combobox-item>
       </calcite-combobox-item>
-      <calcite-combobox-item value="ITEM-0-4" text-label="Level 1"></calcite-combobox-item>
-      <calcite-combobox-item value="ITEM-0-5" text-label="Level 1"></calcite-combobox-item>
-      <calcite-combobox-item value="ITEM-0-6" text-label="Level 1"></calcite-combobox-item>
+      <calcite-combobox-item value="ITEM-0-4" heading="Level 1"></calcite-combobox-item>
+      <calcite-combobox-item value="ITEM-0-5" heading="Level 1"></calcite-combobox-item>
+      <calcite-combobox-item value="ITEM-0-6" heading="Level 1"></calcite-combobox-item>
     </calcite-combobox>
 `;
 
@@ -415,34 +415,34 @@ export const longItemsAllSelectionModes = (): string => html`
   <div style="display: flex; flex-direction: column;">
     <div style="display: flex; flex-direction: row; margin-block-end: 160px;">
       <calcite-combobox open selection-mode="single" style="margin-right: 20px;">
-        <calcite-combobox-item text-label="Layers">
-        <calcite-combobox-item text-label="Enriched USA Census Tract Areas Aug29"></calcite-combobox-item>
-        <calcite-combobox-item text-label="Viewer_Reservable_Equipments_Capacity_V2_WFL1"></calcite-combobox-item></calcite-combobox-item>
+        <calcite-combobox-item heading="Layers">
+        <calcite-combobox-item heading="Enriched USA Census Tract Areas Aug29"></calcite-combobox-item>
+        <calcite-combobox-item heading="Viewer_Reservable_Equipments_Capacity_V2_WFL1"></calcite-combobox-item></calcite-combobox-item>
       </calcite-combobox>
 
       <calcite-combobox open selection-mode="single-persist">
-        <calcite-combobox-item text-label="Layers">
-        <calcite-combobox-item text-label="Enriched USA Census Tract Areas Aug29"></calcite-combobox-item>
-        <calcite-combobox-item text-label="Viewer_Reservable_Equipments_Capacity_V2_WFL1"></calcite-combobox-item></calcite-combobox-item>
+        <calcite-combobox-item heading="Layers">
+        <calcite-combobox-item heading="Enriched USA Census Tract Areas Aug29"></calcite-combobox-item>
+        <calcite-combobox-item heading="Viewer_Reservable_Equipments_Capacity_V2_WFL1"></calcite-combobox-item></calcite-combobox-item>
       </calcite-combobox>
     </div>
 
     <div style="display: flex; flex-direction: row;">
       <calcite-combobox open selection-mode="multiple" style="margin-right: 20px;">
         <calcite-combobox-item-group label="First item group">
-          <calcite-combobox-item text-label="Enriched USA Census Tract Areas Aug29"></calcite-combobox-item>
+          <calcite-combobox-item heading="Enriched USA Census Tract Areas Aug29"></calcite-combobox-item>
         </calcite-combobox-item-group>
         <calcite-combobox-item-group label="Last item group">
-          <calcite-combobox-item text-label="Viewer_Reservable_Equipments_Capacity_V2_WFL1"></calcite-combobox-item></calcite-combobox-item>
+          <calcite-combobox-item heading="Viewer_Reservable_Equipments_Capacity_V2_WFL1"></calcite-combobox-item></calcite-combobox-item>
         </calcite-combobox-item-group>
       </calcite-combobox>
 
       <calcite-combobox open selection-mode="ancestors">
         <calcite-combobox-item-group label="First item group">
-          <calcite-combobox-item text-label="Enriched USA Census Tract Areas Aug29"></calcite-combobox-item>
+          <calcite-combobox-item heading="Enriched USA Census Tract Areas Aug29"></calcite-combobox-item>
         </calcite-combobox-item-group>
         <calcite-combobox-item-group label="Last item group">
-          <calcite-combobox-item text-label="Viewer_Reservable_Equipments_Capacity_V2_WFL1"></calcite-combobox-item>
+          <calcite-combobox-item heading="Viewer_Reservable_Equipments_Capacity_V2_WFL1"></calcite-combobox-item>
           </calcite-combobox-item>
         </calcite-combobox-item-group>
       </calcite-combobox>
@@ -452,15 +452,15 @@ export const longItemsAllSelectionModes = (): string => html`
 
 export const disabled_TestOnly = (): string =>
   html`<calcite-combobox disabled>
-    <calcite-combobox-item value="Trees" text-label="Trees">
-      <calcite-combobox-item value="Pine" text-label="Pine"></calcite-combobox-item>
-      <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia"></calcite-combobox-item>
-      <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir"></calcite-combobox-item>
+    <calcite-combobox-item value="Trees" heading="Trees">
+      <calcite-combobox-item value="Pine" heading="Pine"></calcite-combobox-item>
+      <calcite-combobox-item value="Sequoia" disabled heading="Sequoia"></calcite-combobox-item>
+      <calcite-combobox-item value="Douglas Fir" heading="Douglas Fir"></calcite-combobox-item>
     </calcite-combobox-item>
-    <calcite-combobox-item value="Flowers" text-label="Flowers" disabled>
-      <calcite-combobox-item value="Daffodil" text-label="Daffodil"></calcite-combobox-item>
-      <calcite-combobox-item value="Black Eyed Susan" text-label="Black Eyed Susan"></calcite-combobox-item>
-      <calcite-combobox-item value="Nasturtium" text-label="Nasturtium"></calcite-combobox-item>
+    <calcite-combobox-item value="Flowers" heading="Flowers" disabled>
+      <calcite-combobox-item value="Daffodil" heading="Daffodil"></calcite-combobox-item>
+      <calcite-combobox-item value="Black Eyed Susan" heading="Black Eyed Susan"></calcite-combobox-item>
+      <calcite-combobox-item value="Nasturtium" heading="Nasturtium"></calcite-combobox-item>
     </calcite-combobox-item>
   </calcite-combobox>`;
 
@@ -473,28 +473,28 @@ export const flipPlacements_TestOnly = (): string => html`
   </style>
   <div style="height: 100px; overflow:scroll;">
     <calcite-combobox class="my-combobox" placeholder="placeholder" open>
-      <calcite-combobox-item value="Trees" text-label="Trees" aria-hidden="true">
-        <calcite-combobox-item value="Pine" text-label="Pine" aria-hidden="true"></calcite-combobox-item>
-        <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia" aria-hidden="true"></calcite-combobox-item>
-        <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir" aria-hidden="true"></calcite-combobox-item>
+      <calcite-combobox-item value="Trees" heading="Trees" aria-hidden="true">
+        <calcite-combobox-item value="Pine" heading="Pine" aria-hidden="true"></calcite-combobox-item>
+        <calcite-combobox-item value="Sequoia" disabled heading="Sequoia" aria-hidden="true"></calcite-combobox-item>
+        <calcite-combobox-item value="Douglas Fir" heading="Douglas Fir" aria-hidden="true"></calcite-combobox-item>
       </calcite-combobox-item>
-      <calcite-combobox-item value="Flowers" text-label="Flowers" aria-hidden="true">
-        <calcite-combobox-item value="Daffodil" text-label="Daffodil" aria-hidden="true"></calcite-combobox-item>
+      <calcite-combobox-item value="Flowers" heading="Flowers" aria-hidden="true">
+        <calcite-combobox-item value="Daffodil" heading="Daffodil" aria-hidden="true"></calcite-combobox-item>
         <calcite-combobox-item
           value="Black Eyed Susan"
-          text-label="Black Eyed Susan"
+          heading="Black Eyed Susan"
           aria-hidden="true"
         ></calcite-combobox-item>
-        <calcite-combobox-item value="Nasturtium" text-label="Nasturtium" aria-hidden="true"></calcite-combobox-item>
+        <calcite-combobox-item value="Nasturtium" heading="Nasturtium" aria-hidden="true"></calcite-combobox-item>
       </calcite-combobox-item>
-      <calcite-combobox-item value="Animals" text-label="Animals" aria-hidden="true">
-        <calcite-combobox-item value="Birds" text-label="Birds" aria-hidden="true"></calcite-combobox-item>
-        <calcite-combobox-item value="Reptiles" text-label="Reptiles" aria-hidden="true"></calcite-combobox-item>
-        <calcite-combobox-item value="Amphibians" text-label="Amphibians" aria-hidden="true"></calcite-combobox-item>
+      <calcite-combobox-item value="Animals" heading="Animals" aria-hidden="true">
+        <calcite-combobox-item value="Birds" heading="Birds" aria-hidden="true"></calcite-combobox-item>
+        <calcite-combobox-item value="Reptiles" heading="Reptiles" aria-hidden="true"></calcite-combobox-item>
+        <calcite-combobox-item value="Amphibians" heading="Amphibians" aria-hidden="true"></calcite-combobox-item>
       </calcite-combobox-item>
-      <calcite-combobox-item value="Rocks" text-label="Rocks" aria-hidden="true"></calcite-combobox-item>
-      <calcite-combobox-item value="Insects" text-label="Insects" aria-hidden="true"></calcite-combobox-item>
-      <calcite-combobox-item value="Rivers" text-label="Rivers" aria-hidden="true"></calcite-combobox-item>
+      <calcite-combobox-item value="Rocks" heading="Rocks" aria-hidden="true"></calcite-combobox-item>
+      <calcite-combobox-item value="Insects" heading="Insects" aria-hidden="true"></calcite-combobox-item>
+      <calcite-combobox-item value="Rivers" heading="Rivers" aria-hidden="true"></calcite-combobox-item>
     </calcite-combobox>
   </div>
   <script>
@@ -505,24 +505,24 @@ export const flipPlacements_TestOnly = (): string => html`
 export const flipPositioning_TestOnly = (): string => html`
   <div style="position: absolute; bottom: 10px; left: 10px;">
     <calcite-combobox max-items="6" placeholder="placeholder" label="demo" selection-mode="multiple" scale="m" open>
-      <calcite-combobox-item value="Trees" text-label="Trees">
-        <calcite-combobox-item value="Pine" text-label="Pine"></calcite-combobox-item>
-        <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia"></calcite-combobox-item>
-        <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir"></calcite-combobox-item>
+      <calcite-combobox-item value="Trees" heading="Trees">
+        <calcite-combobox-item value="Pine" heading="Pine"></calcite-combobox-item>
+        <calcite-combobox-item value="Sequoia" disabled heading="Sequoia"></calcite-combobox-item>
+        <calcite-combobox-item value="Douglas Fir" heading="Douglas Fir"></calcite-combobox-item>
       </calcite-combobox-item>
-      <calcite-combobox-item value="Flowers" text-label="Flowers">
-        <calcite-combobox-item value="Daffodil" text-label="Daffodil"></calcite-combobox-item>
-        <calcite-combobox-item value="Black Eyed Susan" text-label="Black Eyed Susan"></calcite-combobox-item>
-        <calcite-combobox-item value="Nasturtium" text-label="Nasturtium"></calcite-combobox-item>
+      <calcite-combobox-item value="Flowers" heading="Flowers">
+        <calcite-combobox-item value="Daffodil" heading="Daffodil"></calcite-combobox-item>
+        <calcite-combobox-item value="Black Eyed Susan" heading="Black Eyed Susan"></calcite-combobox-item>
+        <calcite-combobox-item value="Nasturtium" heading="Nasturtium"></calcite-combobox-item>
       </calcite-combobox-item>
-      <calcite-combobox-item value="Animals" text-label="Animals">
-        <calcite-combobox-item value="Birds" text-label="Birds"></calcite-combobox-item>
-        <calcite-combobox-item value="Reptiles" text-label="Reptiles"></calcite-combobox-item>
-        <calcite-combobox-item value="Amphibians" text-label="Amphibians"></calcite-combobox-item>
+      <calcite-combobox-item value="Animals" heading="Animals">
+        <calcite-combobox-item value="Birds" heading="Birds"></calcite-combobox-item>
+        <calcite-combobox-item value="Reptiles" heading="Reptiles"></calcite-combobox-item>
+        <calcite-combobox-item value="Amphibians" heading="Amphibians"></calcite-combobox-item>
       </calcite-combobox-item>
-      <calcite-combobox-item value="Rocks" text-label="Rocks"></calcite-combobox-item>
-      <calcite-combobox-item value="Insects" text-label="Insects"></calcite-combobox-item>
-      <calcite-combobox-item value="Rivers" text-label="Rivers"></calcite-combobox-item>
+      <calcite-combobox-item value="Rocks" heading="Rocks"></calcite-combobox-item>
+      <calcite-combobox-item value="Insects" heading="Insects"></calcite-combobox-item>
+      <calcite-combobox-item value="Rivers" heading="Rivers"></calcite-combobox-item>
     </calcite-combobox>
   </div>
 `;
@@ -540,24 +540,24 @@ export const darkModeRTL_TestOnly = (): string => html`
       label="demo"
       validation-message="This should not appear because the status is not 'invalid'"
     >
-      <calcite-combobox-item value="Trees" text-label="Trees">
-        <calcite-combobox-item value="Pine" text-label="Pine"></calcite-combobox-item>
-        <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia"></calcite-combobox-item>
-        <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir"></calcite-combobox-item>
+      <calcite-combobox-item value="Trees" heading="Trees">
+        <calcite-combobox-item value="Pine" heading="Pine"></calcite-combobox-item>
+        <calcite-combobox-item value="Sequoia" disabled heading="Sequoia"></calcite-combobox-item>
+        <calcite-combobox-item value="Douglas Fir" heading="Douglas Fir"></calcite-combobox-item>
       </calcite-combobox-item>
-      <calcite-combobox-item value="Flowers" text-label="Flowers">
-        <calcite-combobox-item value="Daffodil" text-label="Daffodil"></calcite-combobox-item>
-        <calcite-combobox-item value="Black Eyed Susan" text-label="Black Eyed Susan"></calcite-combobox-item>
-        <calcite-combobox-item value="Nasturtium" text-label="Nasturtium"></calcite-combobox-item>
+      <calcite-combobox-item value="Flowers" heading="Flowers">
+        <calcite-combobox-item value="Daffodil" heading="Daffodil"></calcite-combobox-item>
+        <calcite-combobox-item value="Black Eyed Susan" heading="Black Eyed Susan"></calcite-combobox-item>
+        <calcite-combobox-item value="Nasturtium" heading="Nasturtium"></calcite-combobox-item>
       </calcite-combobox-item>
-      <calcite-combobox-item value="Animals" text-label="Animals">
-        <calcite-combobox-item value="Birds" text-label="Birds"></calcite-combobox-item>
-        <calcite-combobox-item value="Reptiles" text-label="Reptiles"></calcite-combobox-item>
-        <calcite-combobox-item value="Amphibians" text-label="Amphibians"></calcite-combobox-item>
+      <calcite-combobox-item value="Animals" heading="Animals">
+        <calcite-combobox-item value="Birds" heading="Birds"></calcite-combobox-item>
+        <calcite-combobox-item value="Reptiles" heading="Reptiles"></calcite-combobox-item>
+        <calcite-combobox-item value="Amphibians" heading="Amphibians"></calcite-combobox-item>
       </calcite-combobox-item>
-      <calcite-combobox-item value="Rocks" text-label="Rocks"></calcite-combobox-item>
-      <calcite-combobox-item value="Insects" text-label="Insects"></calcite-combobox-item>
-      <calcite-combobox-item value="Rivers" text-label="Rivers"></calcite-combobox-item>
+      <calcite-combobox-item value="Rocks" heading="Rocks"></calcite-combobox-item>
+      <calcite-combobox-item value="Insects" heading="Insects"></calcite-combobox-item>
+      <calcite-combobox-item value="Rivers" heading="Rivers"></calcite-combobox-item>
     </calcite-combobox>
   </div>
 `;
@@ -565,15 +565,15 @@ darkModeRTL_TestOnly.parameters = { themes: modesDarkDefault };
 
 export const singleLongLabel_TestOnly = (): string => html`
   <calcite-combobox open selection-mode="single" allow-custom-values>
-    <calcite-combobox-item value="Trees" text-label="Trees">
+    <calcite-combobox-item value="Trees" heading="Trees">
       <calcite-combobox-item
         value="CommercialDamageAssessment - Damage to Commercial Buildings"
-        text-label="CommercialDamageAssessment - Damage to Commercial Buildings &  Damage to Residential Buildings "
+        heading="CommercialDamageAssessment - Damage to Commercial Buildings &  Damage to Residential Buildings "
       ></calcite-combobox-item>
-      <calcite-combobox-item value="Sequoia" text-label="Sequoia"></calcite-combobox-item>
-      <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir"></calcite-combobox-item>
+      <calcite-combobox-item value="Sequoia" heading="Sequoia"></calcite-combobox-item>
+      <calcite-combobox-item value="Douglas Fir" heading="Douglas Fir"></calcite-combobox-item>
     </calcite-combobox-item>
-    <calcite-combobox-item value="Rivers" text-label="Rivers"></calcite-combobox-item>
+    <calcite-combobox-item value="Rivers" heading="Rivers"></calcite-combobox-item>
   </calcite-combobox>
 `;
 
@@ -587,59 +587,59 @@ export const withPlaceholderIcon_TestOnly = (): string =>
     selection-mode="single"
     scale="s"
   >
-    <calcite-combobox-item value="root" text-label="username" icon="home"></calcite-combobox-item>
-    <calcite-combobox-item value="1" text-label="Folder 1" icon="folder"></calcite-combobox-item>
-    <calcite-combobox-item value="2" text-label="Folder 2" icon="folder"></calcite-combobox-item>
+    <calcite-combobox-item value="root" heading="username" icon="home"></calcite-combobox-item>
+    <calcite-combobox-item value="1" heading="Folder 1" icon="folder"></calcite-combobox-item>
+    <calcite-combobox-item value="2" heading="Folder 2" icon="folder"></calcite-combobox-item>
   </calcite-combobox>`;
 
 export const withoutPlaceholderIcon_TestOnly = (): string =>
   html` <div style="width:400px;max-width:100%;background-color:white;padding:100px">
     <calcite-combobox placeholder="select folder" selection-mode="multiple" open>
-      <calcite-combobox-item value="root" text-label="username" icon="home" selected></calcite-combobox-item>
-      <calcite-combobox-item value="1" text-label="Folder 1" icon="folder"></calcite-combobox-item>
-      <calcite-combobox-item value="2" text-label="Folder 2" icon="folder"></calcite-combobox-item>
+      <calcite-combobox-item value="root" heading="username" icon="home" selected></calcite-combobox-item>
+      <calcite-combobox-item value="1" heading="Folder 1" icon="folder"></calcite-combobox-item>
+      <calcite-combobox-item value="2" heading="Folder 2" icon="folder"></calcite-combobox-item>
     </calcite-combobox>
   </div>`;
 
 export const scrollingWithoutMaxItems_TestOnly = (): string => html`
   <div style="width:400px;max-width:100%;background-color:white;padding:100px">
     <calcite-combobox label="demo combobox" open>
-      <calcite-combobox-item value="Trees" text-label="Trees" selected>
-        <calcite-combobox-item value="Pine" text-label="Pine"></calcite-combobox-item>
-        <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia"></calcite-combobox-item>
-        <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir"></calcite-combobox-item>
+      <calcite-combobox-item value="Trees" heading="Trees" selected>
+        <calcite-combobox-item value="Pine" heading="Pine"></calcite-combobox-item>
+        <calcite-combobox-item value="Sequoia" disabled heading="Sequoia"></calcite-combobox-item>
+        <calcite-combobox-item value="Douglas Fir" heading="Douglas Fir"></calcite-combobox-item>
       </calcite-combobox-item>
-      <calcite-combobox-item value="Flowers" text-label="Flowers">
-        <calcite-combobox-item value="Daffodil" text-label="Daffodil"></calcite-combobox-item>
-        <calcite-combobox-item value="Black Eyed Susan" text-label="Black Eyed Susan"></calcite-combobox-item>
-        <calcite-combobox-item value="Nasturtium" text-label="Nasturtium"></calcite-combobox-item>
+      <calcite-combobox-item value="Flowers" heading="Flowers">
+        <calcite-combobox-item value="Daffodil" heading="Daffodil"></calcite-combobox-item>
+        <calcite-combobox-item value="Black Eyed Susan" heading="Black Eyed Susan"></calcite-combobox-item>
+        <calcite-combobox-item value="Nasturtium" heading="Nasturtium"></calcite-combobox-item>
       </calcite-combobox-item>
-      <calcite-combobox-item value="Animals" text-label="Animals">
-        <calcite-combobox-item value="Birds" text-label="Birds"></calcite-combobox-item>
-        <calcite-combobox-item value="Reptiles" text-label="Reptiles"></calcite-combobox-item>
-        <calcite-combobox-item value="Amphibians" text-label="Amphibians"></calcite-combobox-item>
+      <calcite-combobox-item value="Animals" heading="Animals">
+        <calcite-combobox-item value="Birds" heading="Birds"></calcite-combobox-item>
+        <calcite-combobox-item value="Reptiles" heading="Reptiles"></calcite-combobox-item>
+        <calcite-combobox-item value="Amphibians" heading="Amphibians"></calcite-combobox-item>
       </calcite-combobox-item>
-      <calcite-combobox-item value="Rocks" text-label="Rocks"></calcite-combobox-item>
-      <calcite-combobox-item value="Insects" text-label="Insects"></calcite-combobox-item>
-      <calcite-combobox-item value="Rivers" text-label="Rivers"></calcite-combobox-item>
-      <calcite-combobox-item value="Trees" text-label="Trees" selected>
-        <calcite-combobox-item value="Pine" text-label="Pine"></calcite-combobox-item>
-        <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia"></calcite-combobox-item>
-        <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir"></calcite-combobox-item>
+      <calcite-combobox-item value="Rocks" heading="Rocks"></calcite-combobox-item>
+      <calcite-combobox-item value="Insects" heading="Insects"></calcite-combobox-item>
+      <calcite-combobox-item value="Rivers" heading="Rivers"></calcite-combobox-item>
+      <calcite-combobox-item value="Trees" heading="Trees" selected>
+        <calcite-combobox-item value="Pine" heading="Pine"></calcite-combobox-item>
+        <calcite-combobox-item value="Sequoia" disabled heading="Sequoia"></calcite-combobox-item>
+        <calcite-combobox-item value="Douglas Fir" heading="Douglas Fir"></calcite-combobox-item>
       </calcite-combobox-item>
-      <calcite-combobox-item value="Flowers" text-label="Flowers">
-        <calcite-combobox-item value="Daffodil" text-label="Daffodil"></calcite-combobox-item>
-        <calcite-combobox-item value="Black Eyed Susan" text-label="Black Eyed Susan"></calcite-combobox-item>
-        <calcite-combobox-item value="Nasturtium" text-label="Nasturtium"></calcite-combobox-item>
+      <calcite-combobox-item value="Flowers" heading="Flowers">
+        <calcite-combobox-item value="Daffodil" heading="Daffodil"></calcite-combobox-item>
+        <calcite-combobox-item value="Black Eyed Susan" heading="Black Eyed Susan"></calcite-combobox-item>
+        <calcite-combobox-item value="Nasturtium" heading="Nasturtium"></calcite-combobox-item>
       </calcite-combobox-item>
-      <calcite-combobox-item value="Animals" text-label="Animals">
-        <calcite-combobox-item value="Birds" text-label="Birds"></calcite-combobox-item>
-        <calcite-combobox-item value="Reptiles" text-label="Reptiles"></calcite-combobox-item>
-        <calcite-combobox-item value="Amphibians" text-label="Amphibians"></calcite-combobox-item>
+      <calcite-combobox-item value="Animals" heading="Animals">
+        <calcite-combobox-item value="Birds" heading="Birds"></calcite-combobox-item>
+        <calcite-combobox-item value="Reptiles" heading="Reptiles"></calcite-combobox-item>
+        <calcite-combobox-item value="Amphibians" heading="Amphibians"></calcite-combobox-item>
       </calcite-combobox-item>
-      <calcite-combobox-item value="Rocks" text-label="Rocks"></calcite-combobox-item>
-      <calcite-combobox-item value="Insects" text-label="Insects"></calcite-combobox-item>
-      <calcite-combobox-item value="Rivers" text-label="Rivers"></calcite-combobox-item>
+      <calcite-combobox-item value="Rocks" heading="Rocks"></calcite-combobox-item>
+      <calcite-combobox-item value="Insects" heading="Insects"></calcite-combobox-item>
+      <calcite-combobox-item value="Rivers" heading="Rivers"></calcite-combobox-item>
     </calcite-combobox>
   </div>
 `;
@@ -658,28 +658,28 @@ export const optionListMinWidthMatchesInputWhenOverlayPositioningIsFixed_TestOnl
   </style>
   <div class="wrapper">
     <calcite-combobox placeholder="placeholder" overlay-positioning="fixed" placement="bottom" open>
-      <calcite-combobox-item value="Trees" text-label="Trees" aria-hidden="true">
-        <calcite-combobox-item value="Pine" text-label="Pine" aria-hidden="true"></calcite-combobox-item>
-        <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia" aria-hidden="true"></calcite-combobox-item>
-        <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir" aria-hidden="true"></calcite-combobox-item>
+      <calcite-combobox-item value="Trees" heading="Trees" aria-hidden="true">
+        <calcite-combobox-item value="Pine" heading="Pine" aria-hidden="true"></calcite-combobox-item>
+        <calcite-combobox-item value="Sequoia" disabled heading="Sequoia" aria-hidden="true"></calcite-combobox-item>
+        <calcite-combobox-item value="Douglas Fir" heading="Douglas Fir" aria-hidden="true"></calcite-combobox-item>
       </calcite-combobox-item>
-      <calcite-combobox-item value="Flowers" text-label="Flowers" aria-hidden="true">
-        <calcite-combobox-item value="Daffodil" text-label="Daffodil" aria-hidden="true"></calcite-combobox-item>
+      <calcite-combobox-item value="Flowers" heading="Flowers" aria-hidden="true">
+        <calcite-combobox-item value="Daffodil" heading="Daffodil" aria-hidden="true"></calcite-combobox-item>
         <calcite-combobox-item
           value="Black Eyed Susan"
-          text-label="Black Eyed Susan"
+          heading="Black Eyed Susan"
           aria-hidden="true"
         ></calcite-combobox-item>
-        <calcite-combobox-item value="Nasturtium" text-label="Nasturtium" aria-hidden="true"></calcite-combobox-item>
+        <calcite-combobox-item value="Nasturtium" heading="Nasturtium" aria-hidden="true"></calcite-combobox-item>
       </calcite-combobox-item>
-      <calcite-combobox-item value="Animals" text-label="Animals" aria-hidden="true">
-        <calcite-combobox-item value="Birds" text-label="Birds" aria-hidden="true"></calcite-combobox-item>
-        <calcite-combobox-item value="Reptiles" text-label="Reptiles" aria-hidden="true"></calcite-combobox-item>
-        <calcite-combobox-item value="Amphibians" text-label="Amphibians" aria-hidden="true"></calcite-combobox-item>
+      <calcite-combobox-item value="Animals" heading="Animals" aria-hidden="true">
+        <calcite-combobox-item value="Birds" heading="Birds" aria-hidden="true"></calcite-combobox-item>
+        <calcite-combobox-item value="Reptiles" heading="Reptiles" aria-hidden="true"></calcite-combobox-item>
+        <calcite-combobox-item value="Amphibians" heading="Amphibians" aria-hidden="true"></calcite-combobox-item>
       </calcite-combobox-item>
-      <calcite-combobox-item value="Rocks" text-label="Rocks" aria-hidden="true"></calcite-combobox-item>
-      <calcite-combobox-item value="Insects" text-label="Insects" aria-hidden="true"></calcite-combobox-item>
-      <calcite-combobox-item value="Rivers" text-label="Rivers" aria-hidden="true"></calcite-combobox-item>
+      <calcite-combobox-item value="Rocks" heading="Rocks" aria-hidden="true"></calcite-combobox-item>
+      <calcite-combobox-item value="Insects" heading="Insects" aria-hidden="true"></calcite-combobox-item>
+      <calcite-combobox-item value="Rivers" heading="Rivers" aria-hidden="true"></calcite-combobox-item>
     </calcite-combobox>
   </div>
 `;
@@ -689,28 +689,28 @@ export const mediumIconForLargeComboboxItem_TestOnly = (): string => html`
     <calcite-combobox-item
       icon="altitude"
       value="altitude"
-      text-label="Altitude"
+      heading="Altitude"
       selected
       scale="l"
     ></calcite-combobox-item>
-    <calcite-combobox-item icon="article" value="article" text-label="Article" scale="l"></calcite-combobox-item>
-    <calcite-combobox-item value="altitude" text-label="Altitude" scale="l"></calcite-combobox-item>
-    <calcite-combobox-item value="article" text-label="Article" scale="l"></calcite-combobox-item>
+    <calcite-combobox-item icon="article" value="article" heading="Article" scale="l"></calcite-combobox-item>
+    <calcite-combobox-item value="altitude" heading="Altitude" scale="l"></calcite-combobox-item>
+    <calcite-combobox-item value="article" heading="Article" scale="l"></calcite-combobox-item>
   </calcite-combobox>
 `;
 
 export const withSelectorIndicatorAndIcons_TestOnly = (): string => html`
-  <calcite-combobox-item text-label="Folder 1" icon="folder" selected>
-    <calcite-combobox-item text-label="Sub Folder 1" icon="folder" selected>
-      <calcite-combobox-item text-label="Sub Folder 2 " icon="folder" selected></calcite-combobox-item>
+  <calcite-combobox-item heading="Folder 1" icon="folder" selected>
+    <calcite-combobox-item heading="Sub Folder 1" icon="folder" selected>
+      <calcite-combobox-item heading="Sub Folder 2 " icon="folder" selected></calcite-combobox-item>
     </calcite-combobox-item>
   </calcite-combobox-item>
-  <calcite-combobox-item text-label="Folder 2" icon="folder"></calcite-combobox-item>
-  <calcite-combobox-item text-label="Folder 3" icon="folder"></calcite-combobox-item>
-  <calcite-combobox-item text-label="Folder 4"></calcite-combobox-item>
+  <calcite-combobox-item heading="Folder 2" icon="folder"></calcite-combobox-item>
+  <calcite-combobox-item heading="Folder 3" icon="folder"></calcite-combobox-item>
+  <calcite-combobox-item heading="Folder 4"></calcite-combobox-item>
   <calcite-combobox-item-group label="Files">
-    <calcite-combobox-item text-label="File 1" icon="file" selected>
-      <calcite-combobox-item text-label="file 2" icon="file" selected></calcite-combobox-item>
+    <calcite-combobox-item heading="File 1" icon="file" selected>
+      <calcite-combobox-item heading="file 2" icon="file" selected></calcite-combobox-item>
     </calcite-combobox-item>
   </calcite-combobox-item-group>
 `;
@@ -722,24 +722,24 @@ withSelectorIndicatorAndIcons_TestOnly.decorators = [allScaleComboboxBuilder];
 
 export const nestedGroups_TestOnly = (): string => html`
   <calcite-combobox-item-group label="First item group">
-    <calcite-combobox-item value="Pikachu" text-label="Pikachu"></calcite-combobox-item>
-    <calcite-combobox-item value="Charizard" text-label="Charizard"></calcite-combobox-item>
+    <calcite-combobox-item value="Pikachu" heading="Pikachu"></calcite-combobox-item>
+    <calcite-combobox-item value="Charizard" heading="Charizard"></calcite-combobox-item>
 
     <calcite-combobox-item-group label="Cutest Pokémon">
-      <calcite-combobox-item value="Bulbasaur" text-label="Bulbasaur"></calcite-combobox-item>
+      <calcite-combobox-item value="Bulbasaur" heading="Bulbasaur"></calcite-combobox-item>
       <calcite-combobox-item-group label="No Pokémon 🙃"></calcite-combobox-item-group>
 
       <calcite-combobox-item-group label="Cutest Pokémon">
-        <calcite-combobox-item value="Squirtle" text-label="Squirtle">
-          <calcite-combobox-item value="Charizard" text-label="Charizard"></calcite-combobox-item>
+        <calcite-combobox-item value="Squirtle" heading="Squirtle">
+          <calcite-combobox-item value="Charizard" heading="Charizard"></calcite-combobox-item>
         </calcite-combobox-item>
       </calcite-combobox-item-group>
     </calcite-combobox-item-group>
   </calcite-combobox-item-group>
 
   <calcite-combobox-item-group label="Last item group">
-    <calcite-combobox-item value="Squirtle" text-label="Squirtle">
-      <calcite-combobox-item value="Charizard" text-label="Charizard"></calcite-combobox-item>
+    <calcite-combobox-item value="Squirtle" heading="Squirtle">
+      <calcite-combobox-item value="Charizard" heading="Charizard"></calcite-combobox-item>
     </calcite-combobox-item>
   </calcite-combobox-item-group>
 `;
@@ -751,21 +751,21 @@ nestedGroups_TestOnly.decorators = [allScaleComboboxBuilder];
 
 export const clearDisabled_TestOnly = (): string => html`
   <calcite-combobox clear-disabled selection-mode="single" style="width:400px">
-    <calcite-combobox-item selected id="one" value="one" text-label="one"></calcite-combobox-item>
-    <calcite-combobox-item id="two" value="two" text-label="two"></calcite-combobox-item>
-    <calcite-combobox-item id="three" value="three" text-label="three"></calcite-combobox-item>
+    <calcite-combobox-item selected id="one" value="one" heading="one"></calcite-combobox-item>
+    <calcite-combobox-item id="two" value="two" heading="two"></calcite-combobox-item>
+    <calcite-combobox-item id="three" value="three" heading="three"></calcite-combobox-item>
   </calcite-combobox>
   <br />
   <calcite-combobox clear-disabled selection-mode="multiple" style="width:400px">
-    <calcite-combobox-item selected id="one" value="one" text-label="one"></calcite-combobox-item>
-    <calcite-combobox-item selected id="two" value="two" text-label="two"></calcite-combobox-item>
-    <calcite-combobox-item selected id="three" value="three" text-label="three"></calcite-combobox-item>
+    <calcite-combobox-item selected id="one" value="one" heading="one"></calcite-combobox-item>
+    <calcite-combobox-item selected id="two" value="two" heading="two"></calcite-combobox-item>
+    <calcite-combobox-item selected id="three" value="three" heading="three"></calcite-combobox-item>
   </calcite-combobox>
   <br />
   <calcite-combobox clear-disabled selection-mode="ancestors" style="width:400px">
-    <calcite-combobox-item value="parent" text-label="parent">
-      <calcite-combobox-item value="child1" text-label="child1"></calcite-combobox-item>
-      <calcite-combobox-item selected value="child2" text-label="child2"></calcite-combobox-item>
+    <calcite-combobox-item value="parent" heading="parent">
+      <calcite-combobox-item value="child1" heading="child1"></calcite-combobox-item>
+      <calcite-combobox-item selected value="child2" heading="child2"></calcite-combobox-item>
     </calcite-combobox-item>
   </calcite-combobox>
 `;
@@ -773,21 +773,21 @@ export const clearDisabled_TestOnly = (): string => html`
 export const openInAllScales_TestOnly = (): string => html`
   <div style="display: flex">
     <calcite-combobox open placeholder="choose a number" scale="s">
-      <calcite-combobox-item value="one" text-label="one"></calcite-combobox-item>
-      <calcite-combobox-item value="two" text-label="two"></calcite-combobox-item>
-      <calcite-combobox-item value="three" text-label="three"></calcite-combobox-item>
+      <calcite-combobox-item value="one" heading="one"></calcite-combobox-item>
+      <calcite-combobox-item value="two" heading="two"></calcite-combobox-item>
+      <calcite-combobox-item value="three" heading="three"></calcite-combobox-item>
     </calcite-combobox>
     <br />
     <calcite-combobox open placeholder="choose a number" scale="m">
-      <calcite-combobox-item value="one" text-label="one"></calcite-combobox-item>
-      <calcite-combobox-item value="two" text-label="two"></calcite-combobox-item>
-      <calcite-combobox-item value="three" text-label="three"></calcite-combobox-item>
+      <calcite-combobox-item value="one" heading="one"></calcite-combobox-item>
+      <calcite-combobox-item value="two" heading="two"></calcite-combobox-item>
+      <calcite-combobox-item value="three" heading="three"></calcite-combobox-item>
     </calcite-combobox>
     <br />
     <calcite-combobox open placeholder="choose a number" scale="l">
-      <calcite-combobox-item value="one" text-label="one"></calcite-combobox-item>
-      <calcite-combobox-item value="two" text-label="two"></calcite-combobox-item>
-      <calcite-combobox-item value="three" text-label="three"></calcite-combobox-item>
+      <calcite-combobox-item value="one" heading="one"></calcite-combobox-item>
+      <calcite-combobox-item value="two" heading="two"></calcite-combobox-item>
+      <calcite-combobox-item value="three" heading="three"></calcite-combobox-item>
     </calcite-combobox>
   </div>
 `;
@@ -795,21 +795,21 @@ export const openInAllScales_TestOnly = (): string => html`
 export const openWithPlaceholderIconInAllScales_TestOnly = (): string => html`
   <div style="display: flex">
     <calcite-combobox open placeholder="choose a number" placeholder-icon="number" scale="s">
-      <calcite-combobox-item value="one" text-label="one"></calcite-combobox-item>
-      <calcite-combobox-item value="two" text-label="two"></calcite-combobox-item>
-      <calcite-combobox-item value="three" text-label="three"></calcite-combobox-item>
+      <calcite-combobox-item value="one" heading="one"></calcite-combobox-item>
+      <calcite-combobox-item value="two" heading="two"></calcite-combobox-item>
+      <calcite-combobox-item value="three" heading="three"></calcite-combobox-item>
     </calcite-combobox>
     <br />
     <calcite-combobox open placeholder="choose a number" placeholder-icon="number" scale="m">
-      <calcite-combobox-item value="one" text-label="one"></calcite-combobox-item>
-      <calcite-combobox-item value="two" text-label="two"></calcite-combobox-item>
-      <calcite-combobox-item value="three" text-label="three"></calcite-combobox-item>
+      <calcite-combobox-item value="one" heading="one"></calcite-combobox-item>
+      <calcite-combobox-item value="two" heading="two"></calcite-combobox-item>
+      <calcite-combobox-item value="three" heading="three"></calcite-combobox-item>
     </calcite-combobox>
     <br />
     <calcite-combobox open placeholder="choose a number" placeholder-icon="number" scale="l">
-      <calcite-combobox-item value="one" text-label="one"></calcite-combobox-item>
-      <calcite-combobox-item value="two" text-label="two"></calcite-combobox-item>
-      <calcite-combobox-item value="three" text-label="three"></calcite-combobox-item>
+      <calcite-combobox-item value="one" heading="one"></calcite-combobox-item>
+      <calcite-combobox-item value="two" heading="two"></calcite-combobox-item>
+      <calcite-combobox-item value="three" heading="three"></calcite-combobox-item>
     </calcite-combobox>
   </div>
 `;
@@ -833,9 +833,9 @@ export const validationMessageInAllScales_TestOnly = (): string => html`
       validation-message="This field is required."
       validation-icon
     >
-      <calcite-combobox-item value="one" text-label="one"></calcite-combobox-item>
-      <calcite-combobox-item value="two" text-label="two"></calcite-combobox-item>
-      <calcite-combobox-item value="three" text-label="three"></calcite-combobox-item>
+      <calcite-combobox-item value="one" heading="one"></calcite-combobox-item>
+      <calcite-combobox-item value="two" heading="two"></calcite-combobox-item>
+      <calcite-combobox-item value="three" heading="three"></calcite-combobox-item>
     </calcite-combobox>
 
     <calcite-combobox
@@ -846,9 +846,9 @@ export const validationMessageInAllScales_TestOnly = (): string => html`
       validation-message="This field is required."
       validation-icon
     >
-      <calcite-combobox-item value="one" text-label="one"></calcite-combobox-item>
-      <calcite-combobox-item value="two" text-label="two"></calcite-combobox-item>
-      <calcite-combobox-item value="three" text-label="three"></calcite-combobox-item>
+      <calcite-combobox-item value="one" heading="one"></calcite-combobox-item>
+      <calcite-combobox-item value="two" heading="two"></calcite-combobox-item>
+      <calcite-combobox-item value="three" heading="three"></calcite-combobox-item>
     </calcite-combobox>
 
     <calcite-combobox
@@ -859,9 +859,9 @@ export const validationMessageInAllScales_TestOnly = (): string => html`
       validation-message="This field is required."
       validation-icon
     >
-      <calcite-combobox-item value="one" text-label="one"></calcite-combobox-item>
-      <calcite-combobox-item value="two" text-label="two"></calcite-combobox-item>
-      <calcite-combobox-item value="three" text-label="three"></calcite-combobox-item>
+      <calcite-combobox-item value="one" heading="one"></calcite-combobox-item>
+      <calcite-combobox-item value="two" heading="two"></calcite-combobox-item>
+      <calcite-combobox-item value="three" heading="three"></calcite-combobox-item>
     </calcite-combobox>
   </div>
 `;
@@ -871,61 +871,61 @@ export const readOnlyAllModes = (): string => html`
 
   <h2>single</h2>
   <calcite-combobox read-only selection-mode="single">
-    <calcite-combobox-item value="one" text-label="one" selected></calcite-combobox-item>
-    <calcite-combobox-item value="two" text-label="two"></calcite-combobox-item>
-    <calcite-combobox-item value="three" text-label="three"></calcite-combobox-item>
+    <calcite-combobox-item value="one" heading="one" selected></calcite-combobox-item>
+    <calcite-combobox-item value="two" heading="two"></calcite-combobox-item>
+    <calcite-combobox-item value="three" heading="three"></calcite-combobox-item>
   </calcite-combobox>
 
   <h2>single-persist</h2>
   <calcite-combobox read-only selection-mode="single-persist">
-    <calcite-combobox-item value="one" text-label="one" selected></calcite-combobox-item>
-    <calcite-combobox-item value="two" text-label="two"></calcite-combobox-item>
-    <calcite-combobox-item value="three" text-label="three"></calcite-combobox-item>
+    <calcite-combobox-item value="one" heading="one" selected></calcite-combobox-item>
+    <calcite-combobox-item value="two" heading="two"></calcite-combobox-item>
+    <calcite-combobox-item value="three" heading="three"></calcite-combobox-item>
   </calcite-combobox>
 
   <h2>multiple</h2>
   <calcite-combobox read-only selection-mode="multiple">
-    <calcite-combobox-item value="one" text-label="one" selected></calcite-combobox-item>
-    <calcite-combobox-item value="two" text-label="two" selected></calcite-combobox-item>
-    <calcite-combobox-item value="three" text-label="three"></calcite-combobox-item>
+    <calcite-combobox-item value="one" heading="one" selected></calcite-combobox-item>
+    <calcite-combobox-item value="two" heading="two" selected></calcite-combobox-item>
+    <calcite-combobox-item value="three" heading="three"></calcite-combobox-item>
   </calcite-combobox>
 
   <h2>ancestors</h2>
   <calcite-combobox read-only selection-mode="ancestors">
-    <calcite-combobox-item value="parent" text-label="parent">
-      <calcite-combobox-item value="child1" text-label="child1"></calcite-combobox-item>
-      <calcite-combobox-item selected value="child2" text-label="child2"></calcite-combobox-item>
+    <calcite-combobox-item value="parent" heading="parent">
+      <calcite-combobox-item value="child1" heading="child1"></calcite-combobox-item>
+      <calcite-combobox-item selected value="child2" heading="child2"></calcite-combobox-item>
     </calcite-combobox-item>
   </calcite-combobox>
 `;
 
 export const filterHighlighting = (): string => html`
   <calcite-combobox filter-text="Susan" max-items="6" open>
-    <calcite-combobox-item value="Trees" text-label="Trees">
-      <calcite-combobox-item value="Pine" text-label="Pine">
-        <calcite-combobox-item value="Pine Nested" text-label="Pine Nested"></calcite-combobox-item>
+    <calcite-combobox-item value="Trees" heading="Trees">
+      <calcite-combobox-item value="Pine" heading="Pine">
+        <calcite-combobox-item value="Pine Nested" heading="Pine Nested"></calcite-combobox-item>
       </calcite-combobox-item>
-      <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia"></calcite-combobox-item>
-      <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir"></calcite-combobox-item>
+      <calcite-combobox-item value="Sequoia" disabled heading="Sequoia"></calcite-combobox-item>
+      <calcite-combobox-item value="Douglas Fir" heading="Douglas Fir"></calcite-combobox-item>
     </calcite-combobox-item>
-    <calcite-combobox-item value="Flowers" text-label="Flowers">
-      <calcite-combobox-item value="Daffodil" text-label="Daffodil"></calcite-combobox-item>
+    <calcite-combobox-item value="Flowers" heading="Flowers">
+      <calcite-combobox-item value="Daffodil" heading="Daffodil"></calcite-combobox-item>
       <calcite-combobox-item
         value="Black Eyed Susan"
         description="The Black Eyed Susan is a yellow flower with a dark center."
-        text-label="Black Eyed Susan"
+        heading="Black Eyed Susan"
         short-heading="Susan"
       ></calcite-combobox-item>
-      <calcite-combobox-item value="Nasturtium" text-label="Nasturtium"></calcite-combobox-item>
+      <calcite-combobox-item value="Nasturtium" heading="Nasturtium"></calcite-combobox-item>
     </calcite-combobox-item>
-    <calcite-combobox-item value="Animals" text-label="Animals">
-      <calcite-combobox-item value="Birds" text-label="Birds"></calcite-combobox-item>
-      <calcite-combobox-item value="Reptiles" text-label="Reptiles"></calcite-combobox-item>
-      <calcite-combobox-item value="Amphibians" text-label="Amphibians"></calcite-combobox-item>
+    <calcite-combobox-item value="Animals" heading="Animals">
+      <calcite-combobox-item value="Birds" heading="Birds"></calcite-combobox-item>
+      <calcite-combobox-item value="Reptiles" heading="Reptiles"></calcite-combobox-item>
+      <calcite-combobox-item value="Amphibians" heading="Amphibians"></calcite-combobox-item>
     </calcite-combobox-item>
-    <calcite-combobox-item value="Rocks" text-label="Rocks"></calcite-combobox-item>
-    <calcite-combobox-item value="Insects" text-label="Insects"></calcite-combobox-item>
-    <calcite-combobox-item value="Rivers" text-label="Rivers"></calcite-combobox-item>
+    <calcite-combobox-item value="Rocks" heading="Rocks"></calcite-combobox-item>
+    <calcite-combobox-item value="Insects" heading="Insects"></calcite-combobox-item>
+    <calcite-combobox-item value="Rivers" heading="Rivers"></calcite-combobox-item>
   </calcite-combobox>
 `;
 
@@ -936,7 +936,7 @@ export const withDescriptionIconsAndContentSlots = (): string => html`
       description="the first installment in this thrilling series"
       selected
       short-heading="#1"
-      text-label="1ne"
+      heading="1ne"
       value="one"
     >
       <calcite-icon icon="arrow-left" slot="content-start" scale="s"></calcite-icon>
@@ -946,7 +946,7 @@ export const withDescriptionIconsAndContentSlots = (): string => html`
       icon="layer"
       description="the sequel to the smash hit 'one'"
       short-heading="#2"
-      text-label="2woo"
+      heading="2woo"
       value="two"
     >
       <calcite-icon icon="arrow-left" slot="content-start" scale="s"></calcite-icon>
@@ -956,7 +956,7 @@ export const withDescriptionIconsAndContentSlots = (): string => html`
       icon="layer"
       description="the thrilling conclusion to the number series"
       short-heading="#3"
-      text-label="Thr333"
+      heading="Thr333"
       value="three"
     >
       <calcite-icon icon="arrow-left" slot="content-start" scale="s"></calcite-icon>
@@ -967,35 +967,35 @@ export const withDescriptionIconsAndContentSlots = (): string => html`
 
 export const selectAllEnabled = (): string => html`
   <calcite-combobox selection-mode="multiple" placeholder="placeholder" select-all-enabled open scale="l">
-    <calcite-combobox-item value="Trees" text-label="Trees" selected>
-      <calcite-combobox-item value="Pine" text-label="Pine" selected>
-        <calcite-combobox-item value="Pine Nested" text-label="Pine Nested" selected></calcite-combobox-item>
+    <calcite-combobox-item value="Trees" heading="Trees" selected>
+      <calcite-combobox-item value="Pine" heading="Pine" selected>
+        <calcite-combobox-item value="Pine Nested" heading="Pine Nested" selected></calcite-combobox-item>
       </calcite-combobox-item>
-      <calcite-combobox-item value="Sequoia" text-label="Sequoia" selected></calcite-combobox-item>
-      <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir" selected></calcite-combobox-item>
+      <calcite-combobox-item value="Sequoia" heading="Sequoia" selected></calcite-combobox-item>
+      <calcite-combobox-item value="Douglas Fir" heading="Douglas Fir" selected></calcite-combobox-item>
     </calcite-combobox-item>
   </calcite-combobox>
 
   <calcite-combobox style="margin-top:280px; margin-bottom:350px;" selection-mode="multiple" select-all-enabled open>
-    <calcite-combobox-item value="Trees" text-label="Trees" selected>
-      <calcite-combobox-item value="Pine" text-label="Pine" selected>
-        <calcite-combobox-item value="Pine Nested" text-label="Pine Nested" selected></calcite-combobox-item>
+    <calcite-combobox-item value="Trees" heading="Trees" selected>
+      <calcite-combobox-item value="Pine" heading="Pine" selected>
+        <calcite-combobox-item value="Pine Nested" heading="Pine Nested" selected></calcite-combobox-item>
       </calcite-combobox-item>
-      <calcite-combobox-item value="Sequoia" text-label="Sequoia" selected></calcite-combobox-item>
-      <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir" selected></calcite-combobox-item>
+      <calcite-combobox-item value="Sequoia" heading="Sequoia" selected></calcite-combobox-item>
+      <calcite-combobox-item value="Douglas Fir" heading="Douglas Fir" selected></calcite-combobox-item>
     </calcite-combobox-item>
   </calcite-combobox>
 
   <calcite-combobox style="margin-top:450px; margin-bottom:30px;" selection-mode="multiple" select-all-enabled open>
-    <calcite-combobox-item value="Trees" text-label="Trees">
-      <calcite-combobox-item value="Pine" text-label="Pine" selected>
-        <calcite-combobox-item value="Pine Nested" text-label="Pine Nested"></calcite-combobox-item>
+    <calcite-combobox-item value="Trees" heading="Trees">
+      <calcite-combobox-item value="Pine" heading="Pine" selected>
+        <calcite-combobox-item value="Pine Nested" heading="Pine Nested"></calcite-combobox-item>
       </calcite-combobox-item>
-      <calcite-combobox-item value="Sequoia" text-label="Sequoia"></calcite-combobox-item>
+      <calcite-combobox-item value="Sequoia" heading="Sequoia"></calcite-combobox-item>
     </calcite-combobox-item>
-    <calcite-combobox-item value="Flowers" text-label="Flowers" selected>
-      <calcite-combobox-item value="Daffodil" text-label="Daffodil"></calcite-combobox-item>
-      <calcite-combobox-item value="Nasturtium" text-label="Nasturtium"></calcite-combobox-item>
+    <calcite-combobox-item value="Flowers" heading="Flowers" selected>
+      <calcite-combobox-item value="Daffodil" heading="Daffodil"></calcite-combobox-item>
+      <calcite-combobox-item value="Nasturtium" heading="Nasturtium"></calcite-combobox-item>
     </calcite-combobox-item>
   </calcite-combobox>
 `;
@@ -1005,25 +1005,20 @@ export const withDescriptionShortLabelAndContentSlots = (): string => html`
     description="the first installment in this thrilling series"
     selected
     short-heading="#1"
-    text-label="1ne"
+    heading="1ne"
     value="one"
   >
     <calcite-icon icon="number-circle-1" slot="content-start" scale="s"></calcite-icon>
     <calcite-icon icon="number-circle-2" slot="content-end" scale="s"></calcite-icon>
   </calcite-combobox-item>
-  <calcite-combobox-item
-    description="the sequel to the smash hit 'one'"
-    short-heading="#2"
-    text-label="2woo"
-    value="two"
-  >
+  <calcite-combobox-item description="the sequel to the smash hit 'one'" short-heading="#2" heading="2woo" value="two">
     <calcite-icon icon="number-circle-3" slot="content-start" scale="s"></calcite-icon>
     <calcite-icon icon="number-circle-4" slot="content-end" scale="s"></calcite-icon>
   </calcite-combobox-item>
   <calcite-combobox-item
     description="the thrilling conclusion to the number series"
     short-heading="#3"
-    text-label="Thr333"
+    heading="Thr333"
     value="three"
   >
     <calcite-icon icon="number-circle-5" slot="content-start" scale="s"></calcite-icon>
@@ -1035,25 +1030,25 @@ export const noMatchesScaledOrAddCustomValue = (): string => html`
   <div style="display: flex; gap: 48px; padding: 100px;">
     <div style="display: flex; flex-direction: column; gap: 48px;">
       <calcite-combobox open filter-text="Three" selection-mode="single" scale="s">
-        <calcite-combobox-item value="one" text-label="One"></calcite-combobox-item>
-        <calcite-combobox-item value="two" text-label="Two"></calcite-combobox-item>
+        <calcite-combobox-item value="one" heading="One"></calcite-combobox-item>
+        <calcite-combobox-item value="two" heading="Two"></calcite-combobox-item>
       </calcite-combobox>
 
       <calcite-combobox open filter-text="Three" selection-mode="single" scale="m">
-        <calcite-combobox-item value="one" text-label="One"></calcite-combobox-item>
-        <calcite-combobox-item value="two" text-label="Two"></calcite-combobox-item>
+        <calcite-combobox-item value="one" heading="One"></calcite-combobox-item>
+        <calcite-combobox-item value="two" heading="Two"></calcite-combobox-item>
       </calcite-combobox>
 
       <calcite-combobox open filter-text="Three" selection-mode="single" scale="l">
-        <calcite-combobox-item value="one" text-label="One"></calcite-combobox-item>
-        <calcite-combobox-item value="two" text-label="Two"></calcite-combobox-item>
+        <calcite-combobox-item value="one" heading="One"></calcite-combobox-item>
+        <calcite-combobox-item value="two" heading="Two"></calcite-combobox-item>
       </calcite-combobox>
     </div>
 
     <div>
       <calcite-combobox open allow-custom-values filter-text="Three" selection-mode="single">
-        <calcite-combobox-item value="one" text-label="One"></calcite-combobox-item>
-        <calcite-combobox-item value="two" text-label="Two"></calcite-combobox-item>
+        <calcite-combobox-item value="one" heading="One"></calcite-combobox-item>
+        <calcite-combobox-item value="two" heading="Two"></calcite-combobox-item>
       </calcite-combobox>
     </div>
   </div>

--- a/packages/components/src/components/combobox/combobox.tsx
+++ b/packages/components/src/components/combobox/combobox.tsx
@@ -248,7 +248,7 @@ export class Combobox
 
   private get effectiveFilterProps(): string[] {
     if (!this.filterProps) {
-      return ["description", "label", "metadata", "shortHeading", "textLabel"];
+      return ["description", "label", "metadata", "shortHeading"];
     }
 
     return this.filterProps.filter((prop) => prop !== "el");
@@ -1375,7 +1375,6 @@ export class Combobox
       label: item.heading,
       metadata: item.metadata,
       shortHeading: item.shortHeading,
-      textLabel: item.textLabel,
       el: item, // used for matching items to data
     }));
   }
@@ -1407,7 +1406,7 @@ export class Combobox
   }
 
   private addCustomChip(value: string, focus?: boolean): void {
-    const existingItem = this.items.find((el) => (el.heading || el.textLabel) === value);
+    const existingItem = this.items.find((el) => el.heading === value);
     if (existingItem) {
       this.toggleSelection(existingItem, true);
     } else {
@@ -1791,7 +1790,7 @@ export class Combobox
         ariaLabel: item.label,
         ariaSelected: item.selected,
         id: `${IDS.item(item.guid)}`,
-        textContent: item.heading || item.textLabel,
+        textContent: item.heading,
       }),
     );
 

--- a/packages/components/src/components/combobox/combobox.tsx
+++ b/packages/components/src/components/combobox/combobox.tsx
@@ -1832,6 +1832,7 @@ export class Combobox
               this.selectionMode !== "single-persist" && (
                 <calcite-combobox-item
                   class={CSS.selectAll}
+                  heading={messages.selectAll}
                   id={`${this.guid}-select-all-enabled-interactive`}
                   indeterminate={this.indeterminate}
                   label={messages.selectAll}
@@ -1839,7 +1840,6 @@ export class Combobox
                   scale={scale}
                   selected={this.allSelected}
                   tabIndex="-1"
-                  text-label={messages.selectAll}
                   value="select-all"
                 />
               )}

--- a/packages/components/src/components/combobox/interfaces.ts
+++ b/packages/components/src/components/combobox/interfaces.ts
@@ -8,7 +8,6 @@ export interface ItemData extends BaseData {
   description: string;
   metadata: Record<string, unknown>;
   shortHeading: string;
-  textLabel: string;
   el: ComboboxItem["el"] | ComboboxItemGroup["el"];
 }
 

--- a/packages/components/src/components/combobox/utils.ts
+++ b/packages/components/src/components/combobox/utils.ts
@@ -59,5 +59,5 @@ export function isSingleLike(selectionMode: Combobox["selectionMode"]): boolean 
 }
 
 export function getLabel(item: ComboboxItem["el"]): string {
-  return item.shortHeading || item.heading || item.textLabel;
+  return item.shortHeading || item.heading;
 }

--- a/packages/components/src/components/input-time-zone/input-time-zone.e2e.ts
+++ b/packages/components/src/components/input-time-zone/input-time-zone.e2e.ts
@@ -104,7 +104,7 @@ describe("calcite-input-time-zone", () => {
 
             const timeZoneItem = await page.find("calcite-input-time-zone >>> calcite-combobox-item[selected]");
 
-            expect(await timeZoneItem.getProperty("textLabel")).toMatch(label);
+            expect(await timeZoneItem.getProperty("heading")).toMatch(label);
           });
         });
       });
@@ -122,7 +122,7 @@ describe("calcite-input-time-zone", () => {
 
         const timeZoneItem = await page.find("calcite-input-time-zone >>> calcite-combobox-item[selected]");
 
-        expect(await timeZoneItem.getProperty("textLabel")).toMatch(testTimeZoneItems[1].label);
+        expect(await timeZoneItem.getProperty("heading")).toMatch(testTimeZoneItems[1].label);
       });
 
       it("ignores invalid values", async () => {
@@ -136,7 +136,7 @@ describe("calcite-input-time-zone", () => {
 
         const timeZoneItem = await page.find("calcite-input-time-zone >>> calcite-combobox-item[selected]");
 
-        expect(await timeZoneItem.getProperty("textLabel")).toMatch(testTimeZoneItems[0].label);
+        expect(await timeZoneItem.getProperty("heading")).toMatch(testTimeZoneItems[0].label);
       });
 
       it("omits filtered or non-localized time zones (incoming to browser)", async () => {
@@ -150,7 +150,7 @@ describe("calcite-input-time-zone", () => {
 
         const timeZoneItem = await page.find("calcite-input-time-zone >>> calcite-combobox-item[selected]");
 
-        expect(await timeZoneItem.getProperty("textLabel")).toMatch(testTimeZoneItems[2].label);
+        expect(await timeZoneItem.getProperty("heading")).toMatch(testTimeZoneItems[2].label);
       });
 
       it("looks up in label and time zone groups (not displayed)", async () => {
@@ -240,7 +240,7 @@ describe("calcite-input-time-zone", () => {
 
             const timeZoneItem = await page.find("calcite-input-time-zone >>> calcite-combobox-item[selected]");
 
-            expect(await timeZoneItem.getProperty("textLabel")).toMatch(name);
+            expect(await timeZoneItem.getProperty("heading")).toMatch(name);
           });
         });
       });
@@ -258,7 +258,7 @@ describe("calcite-input-time-zone", () => {
 
         const timeZoneItem = await page.find("calcite-input-time-zone >>> calcite-combobox-item[selected]");
 
-        expect(await timeZoneItem.getProperty("textLabel")).toMatch(testTimeZoneItems[1].name);
+        expect(await timeZoneItem.getProperty("heading")).toMatch(testTimeZoneItems[1].name);
       });
 
       it("ignores invalid values", async () => {
@@ -274,7 +274,7 @@ describe("calcite-input-time-zone", () => {
 
         const timeZoneItem = await page.find("calcite-input-time-zone >>> calcite-combobox-item[selected]");
 
-        expect(await timeZoneItem.getProperty("textLabel")).toMatch(testTimeZoneItems[0].name);
+        expect(await timeZoneItem.getProperty("heading")).toMatch(testTimeZoneItems[0].name);
       });
     });
 
@@ -292,7 +292,7 @@ describe("calcite-input-time-zone", () => {
 
             const timeZoneItem = await page.find("calcite-input-time-zone >>> calcite-combobox-item[selected]");
 
-            expect(await timeZoneItem.getProperty("textLabel")).toMatch(toUserFriendlyName(getCity(name)));
+            expect(await timeZoneItem.getProperty("heading")).toMatch(toUserFriendlyName(getCity(name)));
           });
         });
       });
@@ -310,7 +310,7 @@ describe("calcite-input-time-zone", () => {
 
         const timeZoneItem = await page.find("calcite-input-time-zone >>> calcite-combobox-item[selected]");
 
-        expect(await timeZoneItem.getProperty("textLabel")).toBe("Phoenix, United States");
+        expect(await timeZoneItem.getProperty("heading")).toBe("Phoenix, United States");
       });
 
       it("ignores invalid values", async () => {
@@ -327,7 +327,7 @@ describe("calcite-input-time-zone", () => {
 
         const timeZoneItem = await page.find("calcite-input-time-zone >>> calcite-combobox-item[selected]");
 
-        expect(await timeZoneItem.getProperty("textLabel")).toBe("Mexico City, Mexico");
+        expect(await timeZoneItem.getProperty("heading")).toBe("Mexico City, Mexico");
       });
 
       it("properly sets region label when setting value programmatically", async () => {
@@ -346,7 +346,7 @@ describe("calcite-input-time-zone", () => {
 
         const timeZoneItem = await page.find("calcite-input-time-zone >>> calcite-combobox-item[selected]");
 
-        expect(await timeZoneItem.getProperty("textLabel")).toBe("New York, United States");
+        expect(await timeZoneItem.getProperty("heading")).toBe("New York, United States");
       });
 
       it("updates the label and shows selection immediately on user interaction", async () => {
@@ -374,7 +374,7 @@ describe("calcite-input-time-zone", () => {
         // we use page click to avoid the internal call to waitForChanges that E2EElement interaction APIs have
         await page.click(testTimeZoneItemSelector);
 
-        expect(await page.$eval(testTimeZoneItemSelector, async (el) => el.textLabel)).toBe("New York, United States");
+        expect(await page.$eval(testTimeZoneItemSelector, async (el) => el.heading)).toBe("New York, United States");
       });
 
       it("maps deprecated time zones to aliases", async () => {
@@ -421,14 +421,14 @@ describe("calcite-input-time-zone", () => {
       const input = await page.find("calcite-input-time-zone");
 
       expect(await input.getProperty("value")).toBe(`${testTimeZoneItems[1].offset}`);
-      expect(await selectedTimeZoneItem.getProperty("textLabel")).toMatch(testTimeZoneItems[1].label);
+      expect(await selectedTimeZoneItem.getProperty("heading")).toMatch(testTimeZoneItems[1].label);
 
       input.setProperty("value", "");
       await page.waitForChanges();
 
       selectedTimeZoneItem = await page.find("calcite-input-time-zone >>> calcite-combobox-item[selected]");
       expect(await input.getProperty("value")).toBe(`${testTimeZoneItems[1].offset}`);
-      expect(await selectedTimeZoneItem.getProperty("textLabel")).toMatch(testTimeZoneItems[1].label);
+      expect(await selectedTimeZoneItem.getProperty("heading")).toMatch(testTimeZoneItems[1].label);
     });
 
     describe("clearing by value", () => {
@@ -597,7 +597,7 @@ describe("calcite-input-time-zone", () => {
       // all items are formatted equally, so we only need to check the first one
       const firstTimeZoneItem = await page.find("calcite-input-time-zone >>> calcite-combobox-item");
 
-      expect(await firstTimeZoneItem.getProperty("textLabel")).toContain(offsetMarker);
+      expect(await firstTimeZoneItem.getProperty("heading")).toContain(offsetMarker);
     }
 
     beforeEach(async () => {

--- a/packages/components/src/components/input-time-zone/input-time-zone.tsx
+++ b/packages/components/src/components/input-time-zone/input-time-zone.tsx
@@ -379,7 +379,7 @@ export class InputTimeZone extends LitElement implements FormComponent, Labelabl
       return;
     }
 
-    this.comboboxRef.value.selectedItems[0].textLabel = this.getItemLabel(
+    this.comboboxRef.value.selectedItems[0].heading = this.getItemLabel(
       this.selectedTimeZoneItem,
       open,
     );
@@ -545,10 +545,10 @@ export class InputTimeZone extends LitElement implements FormComponent, Labelabl
       return (
         <calcite-combobox-item
           data-label={label}
+          heading={label}
           key={label}
           metadata={metadata}
           selected={selected}
-          textLabel={label}
           value={value}
         />
       );
@@ -561,15 +561,15 @@ export class InputTimeZone extends LitElement implements FormComponent, Labelabl
         {items.map((item) => {
           const selected = this.selectedTimeZoneItem === item;
           const { label, metadata, value } = item;
-          const textLabel = this.getItemLabel(item);
+          const heading = this.getItemLabel(item);
           return (
             <calcite-combobox-item
               data-label={label}
               description={metadata.country}
+              heading={heading}
               key={label}
               metadata={metadata}
               selected={selected}
-              textLabel={textLabel}
               value={value}
             >
               <span class={CSS.offset} slot="content-end">

--- a/packages/components/src/custom-theme/combobox.ts
+++ b/packages/components/src/custom-theme/combobox.ts
@@ -19,29 +19,29 @@ export const comboboxTokens = {
 
 export const defaultCombobox = html`<calcite-combobox label="test" max-items="6" open>
   <calcite-combobox-item-group value="Trees" label="Trees">
-    <calcite-combobox-item value="Pine" text-label="Pine">
-      <calcite-combobox-item value="Pine Nested" text-label="Pine Nested"></calcite-combobox-item>
+    <calcite-combobox-item value="Pine" heading="Pine">
+      <calcite-combobox-item value="Pine Nested" heading="Pine Nested"></calcite-combobox-item>
     </calcite-combobox-item>
   </calcite-combobox-item-group>
-  <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia"></calcite-combobox-item>
-  <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir" selected></calcite-combobox-item>
+  <calcite-combobox-item value="Sequoia" disabled heading="Sequoia"></calcite-combobox-item>
+  <calcite-combobox-item value="Douglas Fir" heading="Douglas Fir" selected></calcite-combobox-item>
 </calcite-combobox>`;
 
 export const singleSelectCombobox = html`<calcite-combobox label="test" selection-mode="single">
-  <calcite-combobox-item value="Trees" text-label="Trees"></calcite-combobox-item>
-  <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia"></calcite-combobox-item>
-  <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir" selected></calcite-combobox-item>
+  <calcite-combobox-item value="Trees" heading="Trees"></calcite-combobox-item>
+  <calcite-combobox-item value="Sequoia" disabled heading="Sequoia"></calcite-combobox-item>
+  <calcite-combobox-item value="Douglas Fir" heading="Douglas Fir" selected></calcite-combobox-item>
 </calcite-combobox>`;
 
 export const comboboxWithPlaceHolderIcon = html`<calcite-combobox label="test" placeholder-icon="layers">
-  <calcite-combobox-item value="Trees" text-label="Trees"></calcite-combobox-item>
-  <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia"></calcite-combobox-item>
-  <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir"></calcite-combobox-item>
+  <calcite-combobox-item value="Trees" heading="Trees"></calcite-combobox-item>
+  <calcite-combobox-item value="Sequoia" disabled heading="Sequoia"></calcite-combobox-item>
+  <calcite-combobox-item value="Douglas Fir" heading="Douglas Fir"></calcite-combobox-item>
 </calcite-combobox>`;
 
 export const noMatches = html`
   <calcite-combobox open filter-text="Three" selection-mode="single">
-    <calcite-combobox-item value="one" text-label="One"></calcite-combobox-item>
-    <calcite-combobox-item value="two" text-label="Two"></calcite-combobox-item>
+    <calcite-combobox-item value="one" heading="One"></calcite-combobox-item>
+    <calcite-combobox-item value="two" heading="Two"></calcite-combobox-item>
   </calcite-combobox>
 `;

--- a/packages/components/src/internal-label/combobox.ts
+++ b/packages/components/src/internal-label/combobox.ts
@@ -9,8 +9,8 @@ export const combobox = html`<calcite-combobox
   scale="m"
   required
 >
-  <calcite-combobox-item value="Rocks" text-label="Rocks"></calcite-combobox-item>
-  <calcite-combobox-item value="Insects" text-label="Insects"></calcite-combobox-item>
-  <calcite-combobox-item value="Rivers" text-label="Rivers"></calcite-combobox-item>
+  <calcite-combobox-item value="Rocks" heading="Rocks"></calcite-combobox-item>
+  <calcite-combobox-item value="Insects" heading="Insects"></calcite-combobox-item>
+  <calcite-combobox-item value="Rivers" heading="Rivers"></calcite-combobox-item>
   <calcite-icon slot="label-content" icon="banana" scale="m"></calcite-icon>
 </calcite-combobox>`;


### PR DESCRIPTION
**Related Issue:** [#9989](https://github.com/Esri/calcite-design-system/issues/9989)

## Summary

- Remove `textLabel` prop.
- Make the `heading` prop be required.
- Make the `value` prop be optional.
- Update all tests to use the updated props.

BREAKING CHANGE: Deprecated `textLabel` prop has been removed, use `heading` instead.