### PR TITLE
feat(block): update to Action 5.0 spacing

### DIFF
--- a/packages/components/src/components/action-menu/action-menu.scss
+++ b/packages/components/src/components/action-menu/action-menu.scss
@@ -43,9 +43,7 @@
 
 .default-trigger {
   @apply relative
-  h-full
-  flex-initial
-  self-stretch;
+  flex-initial;
 }
 
 @include includes.slotted("trigger", "calcite-action") {

--- a/packages/components/src/components/action-menu/action-menu.scss
+++ b/packages/components/src/components/action-menu/action-menu.scss
@@ -43,6 +43,8 @@
 
 .default-trigger {
   @apply relative
+  h-full
+  self-stretch
   flex-initial;
 }
 

--- a/packages/components/src/components/action-menu/action-menu.scss
+++ b/packages/components/src/components/action-menu/action-menu.scss
@@ -44,8 +44,8 @@
 .default-trigger {
   @apply relative
   h-full
-  self-stretch
-  flex-initial;
+  flex-initial
+  self-stretch;
 }
 
 @include includes.slotted("trigger", "calcite-action") {

--- a/packages/components/src/components/block/block.scss
+++ b/packages/components/src/components/block/block.scss
@@ -21,7 +21,8 @@
 //
 // Internal CSS custom properties for component use only. Overwriting is not recommended.
 //
-// --calcite-internal-block-actions-end-spacing
+// --calcite-internal-block-actions-spacing
+// --calcite-internal-block-header-content-padding
 // --calcite-internal-block-padding-block
 // --calcite-internal-block-padding-inline
 
@@ -31,10 +32,6 @@
 :host([scale="s"]) {
   .header {
     gap: var(--calcite-spacing-sm);
-  }
-
-  .header--has-content {
-    padding: var(--calcite-spacing-sm);
   }
 
   .icon-end-container {
@@ -50,7 +47,8 @@
     font-size: var(--calcite-font-size-xs);
   }
 
-  --calcite-internal-block-actions-end-spacing: var(--calcite-spacing-xxs);
+  --calcite-internal-block-actions-spacing: var(--calcite-spacing-xxs);
+  --calcite-internal-block-header-content-padding: var(--calcite-spacing-sm);
   --calcite-internal-block-padding-block: var(
     --calcite-block-content-space,
     var(--calcite-block-padding, var(--calcite-spacing-xxs))
@@ -66,10 +64,6 @@
     gap: var(--calcite-spacing-md);
   }
 
-  .header--has-content {
-    padding: var(--calcite-spacing-md);
-  }
-
   .icon-end-container {
     gap: var(--calcite-spacing-md);
     padding-inline-end: var(--calcite-spacing-md);
@@ -83,7 +77,8 @@
     font-size: var(--calcite-font-size-sm);
   }
 
-  --calcite-internal-block-actions-end-spacing: var(--calcite-spacing-xxs);
+  --calcite-internal-block-actions-spacing: var(--calcite-spacing-xxs);
+  --calcite-internal-block-header-content-padding: var(--calcite-spacing-md);
   --calcite-internal-block-padding-block: var(
     --calcite-block-content-space,
     var(--calcite-block-padding, var(--calcite-spacing-sm))
@@ -99,10 +94,6 @@
     gap: var(--calcite-spacing-lg);
   }
 
-  .header--has-content {
-    padding: var(--calcite-spacing-lg);
-  }
-
   .icon-end-container {
     gap: var(--calcite-spacing-lg);
     padding-inline-end: var(--calcite-spacing-lg);
@@ -116,7 +107,8 @@
     font-size: var(--calcite-font-size);
   }
 
-  --calcite-internal-block-actions-end-spacing: var(--calcite-spacing-xs);
+  --calcite-internal-block-actions-spacing: var(--calcite-spacing-xs);
+  --calcite-internal-block-header-content-padding: var(--calcite-spacing-lg);
   --calcite-internal-block-padding-block: var(
     --calcite-block-content-space,
     var(--calcite-block-padding, var(--calcite-spacing-md))
@@ -140,6 +132,12 @@
 .header {
   @apply justify-start;
 }
+.header--has-content {
+  padding: var(--calcite-internal-block-header-content-padding);
+}
+.header--has-drag-handle {
+  padding-inline-start: var(--calcite-spacing-xxs);
+}
 
 .header,
 .toggle {
@@ -160,10 +158,10 @@
 .actions-end {
   align-items: center;
   display: flex;
-  gap: var(--calcite-internal-block-actions-end-spacing);
+  gap: var(--calcite-internal-block-actions-spacing);
   grid-area: actions-end;
-  padding-block: var(--calcite-internal-block-actions-end-spacing);
-  padding-inline-end: var(--calcite-internal-block-actions-end-spacing);
+  padding-block: var(--calcite-internal-block-actions-spacing);
+  padding-inline-end: var(--calcite-internal-block-actions-spacing);
 }
 
 .toggle {
@@ -282,7 +280,9 @@ calcite-sort-handle {
 }
 
 calcite-action-menu {
+  align-self: center;
   grid-area: menu;
+  margin-inline-end: var(--calcite-internal-block-actions-spacing);
 }
 
 :host([expanded]) {

--- a/packages/components/src/components/block/block.scss
+++ b/packages/components/src/components/block/block.scss
@@ -194,7 +194,9 @@ calcite-loader[inline] {
 }
 
 calcite-sort-handle {
+  align-self: center;
   grid-area: handle;
+  margin-block: var(--calcite-internal-block-actions-spacing);
   padding-inline-start: var(--calcite-spacing-xxs);
 }
 

--- a/packages/components/src/components/block/block.scss
+++ b/packages/components/src/components/block/block.scss
@@ -154,6 +154,8 @@
 }
 
 .actions-end {
+  align-items: center;
+  display: flex;
   grid-area: actions-end;
 }
 
@@ -188,6 +190,7 @@ calcite-loader[inline] {
 
 calcite-sort-handle {
   grid-area: handle;
+  padding-inline-start: var(--calcite-spacing-xxs);
 }
 
 .title {
@@ -273,10 +276,6 @@ calcite-sort-handle {
 
 calcite-action-menu {
   grid-area: menu;
-}
-
-.actions-end {
-  @apply flex items-stretch;
 }
 
 :host([expanded]) {

--- a/packages/components/src/components/block/block.scss
+++ b/packages/components/src/components/block/block.scss
@@ -21,6 +21,7 @@
 //
 // Internal CSS custom properties for component use only. Overwriting is not recommended.
 //
+// --calcite-internal-block-actions-end-spacing
 // --calcite-internal-block-padding-block
 // --calcite-internal-block-padding-inline
 
@@ -49,6 +50,7 @@
     font-size: var(--calcite-font-size-xs);
   }
 
+  --calcite-internal-block-actions-end-spacing: var(--calcite-spacing-xxs);
   --calcite-internal-block-padding-block: var(
     --calcite-block-content-space,
     var(--calcite-block-padding, var(--calcite-spacing-xxs))
@@ -81,6 +83,7 @@
     font-size: var(--calcite-font-size-sm);
   }
 
+  --calcite-internal-block-actions-end-spacing: var(--calcite-spacing-xxs);
   --calcite-internal-block-padding-block: var(
     --calcite-block-content-space,
     var(--calcite-block-padding, var(--calcite-spacing-sm))
@@ -113,6 +116,7 @@
     font-size: var(--calcite-font-size);
   }
 
+  --calcite-internal-block-actions-end-spacing: var(--calcite-spacing-xs);
   --calcite-internal-block-padding-block: var(
     --calcite-block-content-space,
     var(--calcite-block-padding, var(--calcite-spacing-md))
@@ -156,7 +160,10 @@
 .actions-end {
   align-items: center;
   display: flex;
+  gap: var(--calcite-internal-block-actions-end-spacing);
   grid-area: actions-end;
+  padding-block: var(--calcite-internal-block-actions-end-spacing);
+  padding-inline-end: var(--calcite-internal-block-actions-end-spacing);
 }
 
 .toggle {

--- a/packages/components/src/components/block/block.scss
+++ b/packages/components/src/components/block/block.scss
@@ -135,7 +135,7 @@
 .header--has-content {
   padding: var(--calcite-internal-block-header-content-padding);
 }
-.header--has-drag-handle {
+.header--draggable {
   padding-inline-start: var(--calcite-spacing-xxs);
 }
 

--- a/packages/components/src/components/block/block.tsx
+++ b/packages/components/src/components/block/block.tsx
@@ -548,6 +548,7 @@ export class Block extends LitElement {
         class={{
           [CSS.header]: true,
           [CSS.headerHasContent]: headerHasContent,
+          [CSS.headerHasDragHandle]: this.dragHandle,
         }}
         id={IDS.header}
       >

--- a/packages/components/src/components/block/block.tsx
+++ b/packages/components/src/components/block/block.tsx
@@ -548,7 +548,7 @@ export class Block extends LitElement {
         class={{
           [CSS.header]: true,
           [CSS.headerHasContent]: headerHasContent,
-          [CSS.headerHasDragHandle]: this.dragHandle,
+          [CSS.headerDraggable]: this.dragHandle,
         }}
         id={IDS.header}
       >

--- a/packages/components/src/components/block/resources.ts
+++ b/packages/components/src/components/block/resources.ts
@@ -17,7 +17,7 @@ export const CSS = {
   header: "header",
   headerContainer: "header-container",
   headerHasContent: "header--has-content",
-  headerHasDragHandle: "header--has-drag-handle",
+  headerDraggable: "header--draggable",
   heading: "heading",
   icon: "icon",
   iconStart: "icon--start",

--- a/packages/components/src/components/block/resources.ts
+++ b/packages/components/src/components/block/resources.ts
@@ -17,6 +17,7 @@ export const CSS = {
   header: "header",
   headerContainer: "header-container",
   headerHasContent: "header--has-content",
+  headerHasDragHandle: "header--has-drag-handle",
   heading: "heading",
   icon: "icon",
   iconStart: "icon--start",


### PR DESCRIPTION
**Related Issue:** #10777 

## Summary

This PR updates action button spacing in `calcite-block` to match the 5.0 design.  Also updates Actions to no longer flex to fill height.
