### PR TITLE
feat(popover): update to Action 5.0 spacing

### DIFF
--- a/packages/components/src/components/popover/popover.e2e.ts
+++ b/packages/components/src/components/popover/popover.e2e.ts
@@ -791,26 +791,5 @@ describe("calcite-popover", () => {
         },
       );
     });
-    describe("closable", () => {
-      themed(
-        html`
-          <calcite-popover heading="I'm a heading in the header using the 'heading' prop!" closable>
-            Lorem Ipsum
-          </calcite-popover>
-        `,
-        {
-          "--calcite-popover-corner-radius": [
-            {
-              shadowSelector: `.${CSS.closeButtonContainer}`,
-              targetProp: "borderStartEndRadius",
-            },
-            {
-              shadowSelector: `.${CSS.closeButtonContainer}`,
-              targetProp: "borderEndEndRadius",
-            },
-          ],
-        },
-      );
-    });
   });
 });

--- a/packages/components/src/components/popover/popover.scss
+++ b/packages/components/src/components/popover/popover.scss
@@ -10,6 +10,12 @@
  * @prop --calcite-popover-text-color: Specifies the component's text color.
  */
 
+// AUTO-GENERATED — do not modify. Changes will be overwritten.
+//
+// Internal CSS custom properties for component use only. Overwriting is not recommended.
+//
+// --calcite-internal-popover-margin-inline-end
+
 @use "../../styles/includes";
 @use "../../styles/shared/floating-ui";
 
@@ -34,6 +40,10 @@
   }
 }
 
+:host(:is([scale="s"], [scale="m"])) {
+  --calcite-internal-popover-margin-inline-end: var(--calcite-spacing-xs);
+}
+
 :host([scale="m"]) {
   .heading {
     @apply text-0-wrap
@@ -43,6 +53,8 @@
 }
 
 :host([scale="l"]) {
+  --calcite-internal-popover-margin-inline-end: var(--calcite-spacing-sm);
+
   .heading {
     @apply text-1-wrap
     px-5
@@ -115,13 +127,14 @@
   self-center;
 }
 
+.close-button {
+  margin: auto;
+  margin-inline-end: var(--calcite-internal-popover-margin-inline-end);
+}
+
 .close-button-container {
-  @apply flex overflow-hidden;
+  @apply flex;
   flex: 0 0 auto;
-  border-start-end-radius: var(--calcite-popover-corner-radius, var(--calcite-corner-radius-round));
-  border-end-end-radius: var(--calcite-popover-corner-radius, var(--calcite-corner-radius-round));
-  --calcite-action-corner-radius-start-end: var(--calcite-popover-corner-radius, var(--calcite-corner-radius-sharp));
-  --calcite-action-corner-radius-end-end: var(--calcite-popover-corner-radius, var(--calcite-corner-radius-sharp));
 }
 
 ::slotted(calcite-panel),

--- a/packages/components/src/components/popover/popover.scss
+++ b/packages/components/src/components/popover/popover.scss
@@ -14,7 +14,7 @@
 //
 // Internal CSS custom properties for component use only. Overwriting is not recommended.
 //
-// --calcite-internal-popover-margin-inline-end
+// --calcite-internal-popover-close-spacing
 
 @use "../../styles/includes";
 @use "../../styles/shared/floating-ui";
@@ -41,7 +41,7 @@
 }
 
 :host(:is([scale="s"], [scale="m"])) {
-  --calcite-internal-popover-margin-inline-end: var(--calcite-spacing-xs);
+  --calcite-internal-popover-close-spacing: var(--calcite-spacing-xs);
 }
 
 :host([scale="m"]) {
@@ -53,7 +53,7 @@
 }
 
 :host([scale="l"]) {
-  --calcite-internal-popover-margin-inline-end: var(--calcite-spacing-sm);
+  --calcite-internal-popover-close-spacing: var(--calcite-spacing-sm);
 
   .heading {
     @apply text-1-wrap
@@ -129,7 +129,7 @@
 
 .close-button {
   margin: auto;
-  margin-inline-end: var(--calcite-internal-popover-margin-inline-end);
+  margin-inline-end: var(--calcite-internal-popover-close-spacing);
 }
 
 .close-button-container {

--- a/packages/components/src/components/popover/popover.tsx
+++ b/packages/components/src/components/popover/popover.tsx
@@ -33,7 +33,6 @@ import { Heading, HeadingLevel } from "../functional/Heading";
 import { Scale } from "../interfaces";
 import { createObserver } from "../../utils/observers";
 import { FloatingArrow } from "../functional/FloatingArrow";
-import { getIconScale } from "../../utils/component";
 import { useT9n } from "../../controllers/useT9n";
 import { FocusTrapOptions, useFocusTrap } from "../../controllers/useFocusTrap";
 import { useSetFocus } from "../../controllers/useSetFocus";
@@ -501,12 +500,11 @@ export class Popover extends LitElement implements FloatingUIComponent {
         <calcite-action
           appearance="transparent"
           class={CSS.closeButton}
+          icon="x"
           onClick={this.hide}
           scale={this.scale}
           text={messages.close}
-        >
-          <calcite-icon icon="x" scale={getIconScale(this.scale)} />
-        </calcite-action>
+        />
       </div>
     ) : null;
   }


### PR DESCRIPTION
**Related Issue:** #10777

## Summary

Updates `calcite-popover` to use `calcite-action`'s new 5.0 spacing settings and converts the internal close button to a `calcite-action`.


