### PR TITLE
feat(shell-panel): improve support for height setting of float-all display mode

### DIFF
--- a/packages/components/src/components/shell-panel/shell-panel.scss
+++ b/packages/components/src/components/shell-panel/shell-panel.scss
@@ -111,7 +111,7 @@
 :host([display-mode="float-all"][layout]) {
   .content,
   .float-all {
-    block-size: var(--calcite-shell-panel-height);
+    block-size: var(--calcite-shell-panel-height, var(--calcite-internal-shell-panel-max-height));
   }
 }
 
@@ -347,7 +347,7 @@
   min-inline-size: var(--calcite-internal-shell-panel-min-width);
 }
 
-:host([layout="horizontal"]) .content {
+:host([layout="horizontal"]:not([display-mode="float-all"])) .content {
   block-size: var(--calcite-internal-shell-panel-height);
   max-block-size: var(--calcite-internal-shell-panel-max-height);
   min-block-size: var(--calcite-internal-shell-panel-min-height);


### PR DESCRIPTION
**Related Issue:** [#10825](https://github.com/Esri/calcite-design-system/issues/10825)

## Summary
- When `layout="horizontal/vertical"` and `display-mode="float-all"` apply default height based on `height/height-scale="s/m/l"`.
- Update slotted `calcite-panel` to fill the parent `shell-panel`'s height.
