### PR TITLE
feat(tab-title): update to Action 5.0 spacing

### DIFF
--- a/packages/components/src/components/tab-nav/tab-nav.scss
+++ b/packages/components/src/components/tab-nav/tab-nav.scss
@@ -42,17 +42,17 @@
 }
 
 .scale-s {
-  --calcite-internal-tab-nav-button-width: #{core.$calcite-size-16};
+  --calcite-internal-tab-nav-button-width: #{core.$calcite-size-24};
   min-block-size: theme("spacing.6");
 }
 
 .scale-m {
-  --calcite-internal-tab-nav-button-width: #{core.$calcite-size-24};
+  --calcite-internal-tab-nav-button-width: #{core.$calcite-size-32};
   min-block-size: theme("spacing.8");
 }
 
 .scale-l {
-  --calcite-internal-tab-nav-button-width: #{core.$calcite-size-32};
+  --calcite-internal-tab-nav-button-width: #{core.$calcite-size-44};
   min-block-size: theme("spacing.11");
 }
 

--- a/packages/components/src/components/tab-nav/tab-nav.scss
+++ b/packages/components/src/components/tab-nav/tab-nav.scss
@@ -42,17 +42,17 @@
 }
 
 .scale-s {
-  --calcite-internal-tab-nav-button-width: #{core.$calcite-size-24};
+  --calcite-internal-tab-nav-button-width: #{core.$calcite-size-16};
   min-block-size: theme("spacing.6");
 }
 
 .scale-m {
-  --calcite-internal-tab-nav-button-width: #{core.$calcite-size-32};
+  --calcite-internal-tab-nav-button-width: #{core.$calcite-size-24};
   min-block-size: theme("spacing.8");
 }
 
 .scale-l {
-  --calcite-internal-tab-nav-button-width: #{core.$calcite-size-44};
+  --calcite-internal-tab-nav-button-width: #{core.$calcite-size-32};
   min-block-size: theme("spacing.11");
 }
 

--- a/packages/components/src/components/tab-title/resources.ts
+++ b/packages/components/src/components/tab-title/resources.ts
@@ -1,6 +1,7 @@
 import { Scale } from "../interfaces";
 
 export const CSS = {
+  close: "close",
   container: "container",
   containerBottom: "container--bottom",
   content: "content",

--- a/packages/components/src/components/tab-title/tab-title.e2e.ts
+++ b/packages/components/src/components/tab-title/tab-title.e2e.ts
@@ -2,7 +2,6 @@ import { newE2EPage, E2EPage, E2EElement } from "@arcgis/lumina-compiler/puppete
 import { describe, expect, it, beforeEach } from "vitest";
 import { HYDRATED_ATTR, themed } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
-import { CSS as XButtonCSS } from "../functional/XButton";
 import { CSS } from "./resources";
 
 describe("calcite-tab-title", () => {
@@ -40,7 +39,7 @@ describe("calcite-tab-title", () => {
   `;
   const iconStartSelector = `calcite-tab-title >>> .${CSS.titleIcon}.${CSS.iconStart}`;
   const iconEndSelector = `calcite-tab-title >>> .${CSS.titleIcon}.${CSS.iconEnd}`;
-  const closeSelector = `calcite-tab-title >>> .${XButtonCSS.button}`;
+  const closeSelector = `calcite-tab-title >>> .${CSS.close}`;
 
   it("renders with an icon-start", async () => {
     const page = await newE2EPage();
@@ -111,7 +110,7 @@ describe("calcite-tab-title", () => {
       `);
 
       let containerElOne = await page.find(`calcite-tab-title[id='one']`);
-      const closeOne = await page.find(`calcite-tab-title[id='one'] >>> .${XButtonCSS.button}`);
+      const closeOne = await page.find(`calcite-tab-title[id='one'] >>> .${CSS.close}`);
       expect(containerElOne).toHaveAttribute(HYDRATED_ATTR);
 
       await closeOne.click();
@@ -120,7 +119,7 @@ describe("calcite-tab-title", () => {
       containerElOne = await page.find(`calcite-tab-title[id='one']>>> .${CSS.container}`);
       expect(await containerElOne.getProperty("hidden")).toBe(true);
 
-      const closeTwo = await page.find(`calcite-tab-title[id='two'] >>> .${XButtonCSS.button}`);
+      const closeTwo = await page.find(`calcite-tab-title[id='two'] >>> .${CSS.close}`);
       expect(await closeTwo.getProperty("closable")).not.toBe(true);
     });
   });
@@ -140,7 +139,7 @@ describe("calcite-tab-title", () => {
 
         tabEl = await page.find(`#${id}`);
         tabTitleContainerEl = await page.find(`calcite-tab-title[id='${id}'] >>> .${CSS.container}`);
-        const tabTitleCloseButtonEl = await page.find(`calcite-tab-title[id='${id}'] >>> .${XButtonCSS.button}`);
+        const tabTitleCloseButtonEl = await page.find(`calcite-tab-title[id='${id}'] >>> .${CSS.close}`);
 
         expect(await tabTitleContainerEl.getProperty("hidden")).not.toBe(true);
 
@@ -196,7 +195,7 @@ describe("calcite-tab-title", () => {
 
       const carTabTitleContainerEl = await page.find(`#title2 >>> .${CSS.container}`);
       matchingTabEl = await page.find("#tab2");
-      tabTitleCloseButtonEl = await page.find(`#title2 >>> .${XButtonCSS.button}`);
+      tabTitleCloseButtonEl = await page.find(`#title2 >>> .${CSS.close}`);
 
       await tabTitleCloseButtonEl.click();
       await page.waitForChanges();
@@ -209,7 +208,7 @@ describe("calcite-tab-title", () => {
 
       const planeTabTitleContainerEl = await page.find(`#title3 >>> .${CSS.container}`);
       matchingTabEl = await page.find("#tab3");
-      tabTitleCloseButtonEl = await page.find(`#title3 >>> .${XButtonCSS.button}`);
+      tabTitleCloseButtonEl = await page.find(`#title3 >>> .${CSS.close}`);
 
       await tabTitleCloseButtonEl.click();
       await page.waitForChanges();
@@ -224,7 +223,7 @@ describe("calcite-tab-title", () => {
 
       const bikingTabTitleContainerEl = await page.find(`#title4 >>> .${CSS.container}`);
       matchingTabEl = await page.find("#tab4");
-      tabTitleCloseButtonEl = await page.find(`#title4 >>> .${XButtonCSS.button}`);
+      tabTitleCloseButtonEl = await page.find(`#title4 >>> .${CSS.close}`);
 
       await tabTitleCloseButtonEl.click();
       await page.waitForChanges();
@@ -249,7 +248,7 @@ describe("calcite-tab-title", () => {
       expect(await matchingTabEl.getProperty("selected")).toBe(true);
 
       const embarkTabTitleContainerEl = await page.find(`#title1 >>> .${CSS.container}`);
-      tabTitleCloseButtonEl = await page.find(`#title1 >>> .${XButtonCSS.button}`);
+      tabTitleCloseButtonEl = await page.find(`#title1 >>> .${CSS.close}`);
 
       await tabTitleCloseButtonEl.click();
       await page.waitForChanges();
@@ -261,7 +260,7 @@ describe("calcite-tab-title", () => {
 
       const planeTabTitleContainerEl = await page.find(`#title3 >>> .${CSS.container}`);
       matchingTabEl = await page.find("#tab3");
-      tabTitleCloseButtonEl = await page.find(`#title2 >>> .${XButtonCSS.button}`);
+      tabTitleCloseButtonEl = await page.find(`#title2 >>> .${CSS.close}`);
 
       await tabTitleCloseButtonEl.click();
       await page.waitForChanges();
@@ -283,7 +282,7 @@ describe("calcite-tab-title", () => {
       expect(await matchingTabEl.getProperty("selected")).toBe(true);
 
       const embarkTabTitleContainerEl = await page.find(`#title1 >>> .${CSS.container}`);
-      tabTitleCloseButtonEl = await page.find(`#title1 >>> .${XButtonCSS.button}`);
+      tabTitleCloseButtonEl = await page.find(`#title1 >>> .${CSS.close}`);
 
       await tabTitleCloseButtonEl.click();
       await page.waitForChanges();
@@ -303,7 +302,7 @@ describe("calcite-tab-title", () => {
       const planeTabTitleContainerEl = await page.find(`#title3 >>> .${CSS.container}`);
       const bikingTabTitleContainerEl = await page.find(`#title4 >>> .${CSS.container}`);
       matchingTabEl = await page.find("#title3");
-      tabTitleCloseButtonEl = await page.find(`#title2 >>> .${XButtonCSS.button}`);
+      tabTitleCloseButtonEl = await page.find(`#title2 >>> .${CSS.close}`);
 
       await tabTitleCloseButtonEl.click();
       await page.waitForChanges();
@@ -348,18 +347,23 @@ describe("calcite-tab-title", () => {
           state: { press: `calcite-tab-title >>> .${CSS.selectedIndicator}` },
         },
         "--calcite-tab-close-icon-color": {
-          shadowSelector: `.${XButtonCSS.button}`,
-          targetProp: "color",
+          shadowSelector: `.${CSS.close}`,
+          targetProp: "--calcite-action-text-color",
         },
         "--calcite-tab-close-icon-color-press": {
-          shadowSelector: `.${XButtonCSS.button}`,
-          targetProp: "color",
-          state: { press: `calcite-tab-title >>> .${XButtonCSS.button}` },
+          shadowSelector: `.${CSS.close}`,
+          targetProp: "--calcite-action-text-color-press",
+          state: { press: `calcite-tab-title >>> .${CSS.close}` },
         },
         "--calcite-tab-close-icon-background-color-press": {
-          shadowSelector: `.${XButtonCSS.button}`,
-          targetProp: "backgroundColor",
-          state: { press: `calcite-tab-title >>> .${XButtonCSS.button}` },
+          shadowSelector: `.${CSS.close}`,
+          targetProp: "--calcite-action-background-color-press",
+          state: { press: `calcite-tab-title >>> .${CSS.close}` },
+        },
+        "--calcite-tab-close-icon-background-color": {
+          shadowSelector: `.${CSS.close}`,
+          targetProp: "--calcite-action-background-color",
+          state: { press: `calcite-tab-title >>> .${CSS.close}` },
         },
         "--calcite-tab-background-color": {
           shadowSelector: `.${CSS.container}`,
@@ -385,8 +389,8 @@ describe("calcite-tab-title", () => {
           targetProp: "color",
         },
         "--calcite-tab-close-icon-background-color": {
-          shadowSelector: `.${XButtonCSS.button}`,
-          targetProp: "backgroundColor",
+          shadowSelector: `.${CSS.close}`,
+          targetProp: "--calcite-action-background-color",
         },
       });
     });

--- a/packages/components/src/components/tab-title/tab-title.scss
+++ b/packages/components/src/components/tab-title/tab-title.scss
@@ -20,7 +20,12 @@
 //
 // Internal CSS custom properties for component use only. Overwriting is not recommended.
 //
+// --calcite-internal-action-height
+// --calcite-internal-action-spacing
 // --calcite-internal-tab-shadow-length
+// --calcite-internal-tab-title-close-margin-end
+// --calcite-internal-tab-title-close-margin-start
+// --calcite-internal-tab-title-close-padding
 
 @use "../../styles/includes";
 
@@ -42,29 +47,32 @@
 }
 
 .scale-s {
+  --calcite-internal-tab-title-close-padding: var(--calcite-spacing-none);
+  --calcite-internal-tab-title-close-margin-start: var(--calcite-spacing-xxs);
+  --calcite-internal-tab-title-close-margin-end: var(--calcite-spacing-sm);
+
   .content {
     @apply text-n2h py-1;
-  }
-  .x-button {
-    @apply w-5;
   }
 }
 
 .scale-m {
+  --calcite-internal-tab-title-close-padding: var(--calcite-spacing-xxs);
+  --calcite-internal-tab-title-close-margin-start: var(--calcite-spacing-xxs);
+  --calcite-internal-tab-title-close-margin-end: var(--calcite-spacing-sm);
+
   .content {
     @apply text-n1h py-2;
-  }
-  .x-button {
-    @apply w-7;
   }
 }
 
 .scale-l {
+  --calcite-internal-tab-title-close-padding: var(--calcite-spacing-xxs);
+  --calcite-internal-tab-title-close-margin-start: var(--calcite-spacing-xs);
+  --calcite-internal-tab-title-close-margin-end: var(--calcite-spacing-sm);
+
   .content {
     @apply text-0h py-2.5;
-  }
-  .x-button {
-    @apply w-8;
   }
 }
 
@@ -208,37 +216,6 @@
     &.icon-end {
       margin-inline-start: var(--calcite-spacing-sm);
     }
-  }
-}
-
-.x-button {
-  @apply appearance-none
-  bg-transparent
-  border-none
-  content-center
-  cursor-pointer
-  flex
-  focus-base
-  items-center
-  justify-center
-  h-full
-  self-center
-  transition-default;
-  margin-inline-start: var(--calcite-spacing-sm);
-  margin-inline-end: var(--calcite-spacing-px);
-  block-size: calc(100% - var(--calcite-spacing-xxs));
-  color: var(--calcite-tab-close-icon-color, var(--calcite-color-text-3));
-  background-color: var(--calcite-tab-close-icon-background-color, var(--calcite-color-transparent));
-
-  &:focus {
-    @apply focus-normal;
-  }
-
-  &:focus,
-  &:hover,
-  &:active {
-    color: var(--calcite-tab-close-icon-color-press, var(--calcite-color-text-1));
-    background-color: var(--calcite-tab-close-icon-background-color-press, var(--calcite-color-foreground-3));
   }
 }
 
@@ -417,6 +394,13 @@
   }
 }
 
+.close {
+  --calcite-internal-action-spacing: var(--calcite-internal-tab-title-close-padding);
+  --calcite-internal-action-height: unset;
+  margin: auto;
+  margin-inline: var(--calcite-internal-tab-title-close-margin-end) var(--calcite-internal-tab-title-close-margin-start);
+}
+
 @media (forced-colors: active) {
   :host {
     outline-width: 0;
@@ -433,11 +417,6 @@
 
   :host([bordered][selected]) .container--bottom {
     border-block-start-style: none;
-  }
-
-  .x-button {
-    /* in high contrast the tab title outline covers the close button outline without a z-index */
-    @apply z-default;
   }
 
   .selected-indicator {

--- a/packages/components/src/components/tab-title/tab-title.scss
+++ b/packages/components/src/components/tab-title/tab-title.scss
@@ -23,7 +23,6 @@
 // --calcite-internal-action-height
 // --calcite-internal-action-spacing
 // --calcite-internal-tab-shadow-length
-// --calcite-internal-tab-title-close-margin-end
 // --calcite-internal-tab-title-close-margin-start
 // --calcite-internal-tab-title-close-padding
 
@@ -49,7 +48,6 @@
 .scale-s {
   --calcite-internal-tab-title-close-padding: var(--calcite-spacing-none);
   --calcite-internal-tab-title-close-margin-start: var(--calcite-spacing-xxs);
-  --calcite-internal-tab-title-close-margin-end: var(--calcite-spacing-sm);
 
   .content {
     @apply text-n2h py-1;
@@ -59,7 +57,6 @@
 .scale-m {
   --calcite-internal-tab-title-close-padding: var(--calcite-spacing-xxs);
   --calcite-internal-tab-title-close-margin-start: var(--calcite-spacing-xxs);
-  --calcite-internal-tab-title-close-margin-end: var(--calcite-spacing-sm);
 
   .content {
     @apply text-n1h py-2;
@@ -69,7 +66,6 @@
 .scale-l {
   --calcite-internal-tab-title-close-padding: var(--calcite-spacing-xxs);
   --calcite-internal-tab-title-close-margin-start: var(--calcite-spacing-xs);
-  --calcite-internal-tab-title-close-margin-end: var(--calcite-spacing-sm);
 
   .content {
     @apply text-0h py-2.5;
@@ -403,7 +399,7 @@
   --calcite-action-background-color-press: var(--calcite-tab-close-icon-background-color-press);
 
   margin: auto;
-  margin-inline: var(--calcite-internal-tab-title-close-margin-end) var(--calcite-internal-tab-title-close-margin-start);
+  margin-inline: var(--calcite-spacing-sm) var(--calcite-internal-tab-title-close-margin-start);
 }
 
 @media (forced-colors: active) {

--- a/packages/components/src/components/tab-title/tab-title.scss
+++ b/packages/components/src/components/tab-title/tab-title.scss
@@ -397,6 +397,11 @@
 .close {
   --calcite-internal-action-spacing: var(--calcite-internal-tab-title-close-padding);
   --calcite-internal-action-height: unset;
+  --calcite-action-text-color: var(--calcite-tab-close-icon-color);
+  --calcite-action-text-color-press: var(--calcite-tab-close-icon-color-press);
+  --calcite-action-background-color: var(--calcite-tab-close-icon-background-color);
+  --calcite-action-background-color-press: var(--calcite-tab-close-icon-background-color-press);
+
   margin: auto;
   margin-inline: var(--calcite-internal-tab-title-close-margin-end) var(--calcite-internal-tab-title-close-margin-start);
 }

--- a/packages/components/src/components/tab-title/tab-title.tsx
+++ b/packages/components/src/components/tab-title/tab-title.tsx
@@ -456,7 +456,6 @@ export class TabTitle extends LitElement {
 
     return closable ? (
       <calcite-action
-        appearance="transparent"
         class={CSS.close}
         icon="x"
         key="close-button"

--- a/packages/components/src/components/tab-title/tab-title.tsx
+++ b/packages/components/src/components/tab-title/tab-title.tsx
@@ -460,11 +460,10 @@ export class TabTitle extends LitElement {
         class={CSS.close}
         icon="x"
         key="close-button"
-        label={messages.close}
         onClick={this.closeClickHandler}
         ref={this.closeButtonRef}
         scale={this.scale}
-        title={messages.close}
+        text={messages.close}
       />
     ) : null;
   }

--- a/packages/components/src/components/tab-title/tab-title.tsx
+++ b/packages/components/src/components/tab-title/tab-title.tsx
@@ -19,10 +19,10 @@ import { TabChangeEventDetail, TabCloseEventDetail } from "../tab/interfaces";
 import { TabID, TabLayout, TabPosition } from "../tabs/interfaces";
 import { getIconScale } from "../../utils/component";
 import { IconName } from "../icon/interfaces";
-import { XButton } from "../functional/XButton";
 import { useT9n } from "../../controllers/useT9n";
 import type { Tabs } from "../tabs/tabs";
 import { useInteractive } from "../../controllers/useInteractive";
+import { Action } from "../action/action";
 import T9nStrings from "./assets/t9n/messages.en.json";
 import { CSS, IDS } from "./resources";
 import { styles } from "./tab-title.scss";
@@ -47,7 +47,7 @@ export class TabTitle extends LitElement {
 
   //#region Private Properties
 
-  private closeButtonRef = createRef<HTMLButtonElement>();
+  private closeButtonRef = createRef<Action["el"]>();
 
   private containerEl: HTMLDivElement;
 
@@ -455,14 +455,14 @@ export class TabTitle extends LitElement {
     const { closable, messages } = this;
 
     return closable ? (
-      <XButton
-        disabled={false}
-        focusable={true}
+      <calcite-action
+        appearance="transparent"
+        class={CSS.close}
+        icon="x"
         key="close-button"
         label={messages.close}
         onClick={this.closeClickHandler}
         ref={this.closeButtonRef}
-        round={false}
         scale={this.scale}
         title={messages.close}
       />

--- a/packages/components/src/components/tabs/tabs.e2e.ts
+++ b/packages/components/src/components/tabs/tabs.e2e.ts
@@ -5,7 +5,7 @@ import { html } from "../../../support/formatting";
 import { accessible, themed } from "../../tests/commonTests";
 import { findAll } from "../../tests/utils/puppeteer";
 import { Scale } from "../interfaces";
-import { CSS as XButtonCSS } from "../functional/XButton";
+import { CSS as TabTitleCSS } from "../tab-title/resources";
 import type { TabTitle } from "../tab-title/tab-title";
 import type { TabNav } from "../tab-nav/tab-nav";
 import { GlobalTestProps } from "../../tests/utils/interfaces";
@@ -324,7 +324,7 @@ describe("calcite-tabs", () => {
     });
 
     it("should emit tab change events when closing affects selected tab", async () => {
-      await page.click(`#tab-title-4 >>> .${XButtonCSS.button}`);
+      await page.click(`#tab-title-4 >>> .${TabTitleCSS.close}`);
       await page.waitForChanges();
 
       expect(tabsActivateSpy).toHaveReceivedEventTimes(1);
@@ -342,7 +342,7 @@ describe("calcite-tabs", () => {
     });
 
     it("should NOT emit tab change events when closing does not affect selected tab", async () => {
-      await page.click(`#tab-title-1 >>> .${XButtonCSS.button}`);
+      await page.click(`#tab-title-1 >>> .${TabTitleCSS.close}`);
       await page.waitForChanges();
 
       expect(tabsActivateSpy).toHaveReceivedEventTimes(0);
@@ -376,7 +376,7 @@ describe("calcite-tabs", () => {
 
       const tab2 = await page.find("#tab-title-2");
 
-      await page.click(`#tab-title-1 >>> .${XButtonCSS.button}`);
+      await page.click(`#tab-title-1 >>> .${TabTitleCSS.close}`);
       await tab2.click();
       await page.waitForChanges();
 
@@ -388,11 +388,11 @@ describe("calcite-tabs", () => {
     describe("hiding/displaying X", () => {
       it("should hide x when tabs 2 to 4 closed and display x closable tab added", async () => {
         for (let i = 2; i <= 4; ++i) {
-          await page.click(`#tab-title-${i} >>> .${XButtonCSS.button}`);
+          await page.click(`#tab-title-${i} >>> .${TabTitleCSS.close}`);
         }
         let tab1 = await page.find(`#tab-title-1`);
         expect(await tab1.getProperty("closable")).toBe(false);
-        expect(await page.find(`#tab-title-1 >>> .${XButtonCSS.button}`)).toBeNull();
+        expect(await page.find(`#tab-title-1 >>> .${TabTitleCSS.close}`)).toBeNull();
 
         await page.evaluate(() => {
           document
@@ -402,16 +402,16 @@ describe("calcite-tabs", () => {
         await page.waitForChanges();
         tab1 = await page.find(`#tab-title-1`);
         expect(await tab1.getProperty("closable")).toBe(true);
-        expect(await page.find(`#tab-title-1 >>> .${XButtonCSS.button}`)).toBeDefined();
+        expect(await page.find(`#tab-title-1 >>> .${TabTitleCSS.close}`)).toBeDefined();
       });
 
       it("should hide x when tabs 1 to 3 closed and display x when closable tab added", async () => {
         for (let i = 1; i <= 3; ++i) {
-          await page.click(`#tab-title-${i} >>> .${XButtonCSS.button}`);
+          await page.click(`#tab-title-${i} >>> .${TabTitleCSS.close}`);
         }
         let tab4 = await page.find(`#tab-title-4`);
         expect(await tab4.getProperty("closable")).toBe(false);
-        expect(await page.find(`#tab-title-4 >>> .${XButtonCSS.button}`)).toBeNull();
+        expect(await page.find(`#tab-title-4 >>> .${TabTitleCSS.close}`)).toBeNull();
 
         await page.evaluate(() => {
           document
@@ -421,7 +421,7 @@ describe("calcite-tabs", () => {
         await page.waitForChanges();
         tab4 = await page.find(`#tab-title-4`);
         expect(await tab4.getProperty("closable")).toBe(true);
-        expect(await page.find(`#tab-title-4 >>> .${XButtonCSS.button}`)).toBeDefined();
+        expect(await page.find(`#tab-title-4 >>> .${TabTitleCSS.close}`)).toBeDefined();
       });
     });
 
@@ -441,7 +441,7 @@ describe("calcite-tabs", () => {
       const allExceptLast = allTabTitles.slice(0, 3);
 
       for (const tabTitle of allExceptLast) {
-        const closeButton = await tabTitle.find(`:scope >>> .${XButtonCSS.button}`);
+        const closeButton = await tabTitle.find(`:scope >>> .${TabTitleCSS.close}`);
         await closeButton.click();
         await tabCloseSpy.next();
       }


### PR DESCRIPTION
**Related Issue:** #10777

## Summary

Updates `calcite-tab-title` to use `calcite-action`'s new 5.0 spacing settings and converts the internal close button to a `calcite-action`.


