### PR TITLE
feat(notice): add token for customizing border-radius

### DIFF
--- a/packages/components/src/components/notice/notice.e2e.ts
+++ b/packages/components/src/components/notice/notice.e2e.ts
@@ -164,6 +164,10 @@ describe("calcite-notice", () => {
           shadowSelector: `.${CSS.container}`,
           targetProp: "borderColor",
         },
+        "--calcite-notice-corner-radius": {
+          shadowSelector: `.${CSS.container}`,
+          targetProp: "borderRadius",
+        },
       });
     });
 

--- a/packages/components/src/components/notice/notice.scss
+++ b/packages/components/src/components/notice/notice.scss
@@ -5,6 +5,7 @@
  *
  * @prop --calcite-notice-background-color: Specifies the component's background color when `appearance="outline-fill"`.
  * @prop --calcite-notice-border-color: Specifies the component's border color when `appearance="outline-fill"`.
+ * @prop --calcite-notice-corner-radius: Specifies the component's border radius. 
  * @prop --calcite-notice-close-background-color: Specifies the background color of the component's close button.
  * @prop --calcite-notice-close-background-color-focus: Specifies the background color of the component's close button when focused or hovered.
  * @prop --calcite-notice-close-background-color-press: Specifies the background color of the component's close button when active.
@@ -98,7 +99,7 @@
   transition-property: opacity, max-block-size;
   transition-duration: var(--calcite-animation-timing);
   text-align: start;
-  border-radius: var(--calcite-corner-radius-sm);
+  border-radius: var(--calcite-notice-corner-radius, var(--calcite-corner-radius-sm));
 }
 
 :host {


### PR DESCRIPTION
**Related Issue:** #10477 

## Summary

Adds `--calcite-notice-corner-radius` token for customizing border-radius. 
Followup for https://github.com/Esri/calcite-design-system/pull/13406