### PR TITLE
feat(flow-item): remove border from back button

### DIFF
--- a/packages/components/src/components/flow-item/flow-item.e2e.ts
+++ b/packages/components/src/components/flow-item/flow-item.e2e.ts
@@ -293,10 +293,6 @@ describe("calcite-flow-item", () => {
       },
       "--calcite-flow-border-color": [
         {
-          shadowSelector: `.${CSS.backButton}`,
-          targetProp: "borderColor",
-        },
-        {
           shadowSelector: "calcite-panel",
           targetProp: "--calcite-panel-border-color",
         },

--- a/packages/components/src/components/flow-item/flow-item.scss
+++ b/packages/components/src/components/flow-item/flow-item.scss
@@ -43,13 +43,6 @@
 
 @include includes.disabled();
 
-.back-button {
-  @apply border-0
-  border-solid;
-  border-inline-end-width: theme("borderWidth.DEFAULT");
-  border-color: var(--calcite-flow-border-color, var(--calcite-color-border-3));
-}
-
 calcite-panel {
   --calcite-panel-background-color: var(--calcite-flow-background-color);
   --calcite-panel-border-color: var(--calcite-flow-border-color, var(--calcite-flow-item-header-border-block-end));


### PR DESCRIPTION
**Related Issue:** [#10777](https://github.com/Esri/calcite-design-system/issues/10777)

## Summary
This removes `border` from the back button.
