### PR TITLE
feat(shell-panel): update default max height for slotted calcite-panel

### DIFF
--- a/packages/components/src/components/shell-panel/shell-panel.scss
+++ b/packages/components/src/components/shell-panel/shell-panel.scss
@@ -347,7 +347,7 @@
   min-inline-size: var(--calcite-internal-shell-panel-min-width);
 }
 
-:host([layout="horizontal"]:not([display-mode="float-all"])) .content {
+:host([layout="horizontal"]) .content {
   block-size: var(--calcite-internal-shell-panel-height);
   max-block-size: var(--calcite-internal-shell-panel-max-height);
   min-block-size: var(--calcite-internal-shell-panel-min-height);


### PR DESCRIPTION
**Related Issue:** [#10825](https://github.com/Esri/calcite-design-system/issues/10825)

## Summary
Update default max height for slotted `calcite-panel`.