### PR TITLE
refactor(list-item, popover, sort-handle, stepper, tab-nav): remove unnecessary assignment of `appearance=transparent` (default) on actions

### DIFF
--- a/packages/components/src/components/list-item/list-item.tsx
+++ b/packages/components/src/components/list-item/list-item.tsx
@@ -869,7 +869,6 @@ export class ListItem extends LitElement implements SortableComponentItem {
         <slot name={SLOTS.actionsEnd} onSlotChange={this.handleActionsEndSlotChange} />
         {closable ? (
           <calcite-action
-            appearance="transparent"
             class={CSS.close}
             icon={ICONS.close}
             key="close-action"

--- a/packages/components/src/components/popover/popover.tsx
+++ b/packages/components/src/components/popover/popover.tsx
@@ -498,7 +498,6 @@ export class Popover extends LitElement implements FloatingUIComponent {
     return closable ? (
       <div class={CSS.closeButtonContainer} key={CSS.closeButtonContainer}>
         <calcite-action
-          appearance="transparent"
           class={CSS.closeButton}
           icon="x"
           onClick={this.hide}

--- a/packages/components/src/components/sort-handle/sort-handle.tsx
+++ b/packages/components/src/components/sort-handle/sort-handle.tsx
@@ -298,7 +298,6 @@ export class SortHandle extends LitElement {
         >
           <calcite-action
             active={open}
-            appearance="transparent"
             aria={{ expanded: open }}
             class={CSS.handle}
             dragHandle

--- a/packages/components/src/components/stepper/stepper.tsx
+++ b/packages/components/src/components/stepper/stepper.tsx
@@ -439,7 +439,6 @@ export class Stepper extends LitElement {
     return layout === "horizontal-single" && !multipleViewMode ? (
       <calcite-action
         alignment="center"
-        appearance="transparent"
         class={{
           [CSS.actionIcon]: true,
         }}

--- a/packages/components/src/components/tab-nav/tab-nav.tsx
+++ b/packages/components/src/components/tab-nav/tab-nav.tsx
@@ -622,7 +622,6 @@ export class TabNav extends LitElement {
         key={overflowDirection}
       >
         <calcite-button
-          appearance="transparent"
           ariaLabel={isEnd ? messages.nextTabTitles : messages.previousTabTitles}
           disabled={isEnd ? !hasOverflowingEndTabTitle : !hasOverflowingStartTabTitle}
           iconFlipRtl="both"


### PR DESCRIPTION
**monday.com sync:** #12164360849

**Related Issue:** N/A

## Summary

✨🧹✨

Spotted by @anveshmekala. 🏆