### PR TITLE
fix(action): enable customizing background-color on hover & active when `appearance="transparent"`

### DIFF
--- a/packages/components/src/components/action/action.e2e.ts
+++ b/packages/components/src/components/action/action.e2e.ts
@@ -16,13 +16,11 @@ describe("calcite-action", () => {
       "--calcite-action-background-color-hover": {
         shadowSelector: `.${CSS.button}`,
         targetProp: "backgroundColor",
-        expectedValue: "rgba(0, 0, 0, 0.04)",
         state: "hover",
       },
       "--calcite-action-background-color-pressed": {
         shadowSelector: `.${CSS.button}`,
         targetProp: "backgroundColor",
-        expectedValue: "rgba(0, 0, 0, 0.08)",
         state: { press: { attribute: "class", value: CSS.button } },
       },
     });

--- a/packages/components/src/components/action/action.e2e.ts
+++ b/packages/components/src/components/action/action.e2e.ts
@@ -23,6 +23,11 @@ describe("calcite-action", () => {
         targetProp: "backgroundColor",
         state: { press: { attribute: "class", value: CSS.button } },
       },
+      "--calcite-action-background-color-press": {
+        shadowSelector: `.${CSS.button}`,
+        targetProp: "backgroundColor",
+        state: { press: { attribute: "class", value: CSS.button } },
+      },
     });
   });
 

--- a/packages/components/src/components/action/action.scss
+++ b/packages/components/src/components/action/action.scss
@@ -211,7 +211,10 @@
 
 :host([appearance="transparent"]) {
   &:host([active]) .button {
-    background-color: var(--calcite-color-transparent-press);
+    background-color: var(
+      --calcite-action-background-color-press,
+      var(--calcite-action-background-color-pressed, var(--calcite-color-transparent-press))
+    );
   }
 
   .button {
@@ -220,11 +223,14 @@
       ease-in-out;
 
     &:hover {
-      background-color: var(--calcite-color-transparent-hover);
+      background-color: var(--calcite-action-background-color-hover, var(--calcite-color-transparent-hover));
     }
 
     &:active {
-      background-color: var(--calcite-color-transparent-press);
+      background-color: var(
+        --calcite-action-background-color-press,
+        var(--calcite-action-background-color-pressed, var(--calcite-color-transparent-press))
+      );
     }
   }
 }


### PR DESCRIPTION
**Related Issue:** #13462 

## Summary

Allows customizing `background-color` on hover & active states when appearance is set to `transparent`.