### PR TITLE
refactor(action-bar, action-pad): update test imports

### DIFF
--- a/packages/components/src/components/action-bar/action-bar.browser.e2e.tsx
+++ b/packages/components/src/components/action-bar/action-bar.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { h } from "@arcgis/lumina";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { userEvent } from "@vitest/browser/context";
+import { userEvent } from "vitest/browser";
 import { describe, it, expect } from "vitest";
 import {
   cancelable,

--- a/packages/components/src/components/action-pad/action-pad.browser.e2e.tsx
+++ b/packages/components/src/components/action-pad/action-pad.browser.e2e.tsx
@@ -1,5 +1,5 @@
 import { h } from "@arcgis/lumina";
-import { userEvent } from "@vitest/browser/context";
+import { userEvent } from "vitest/browser";
 import { describe, it, expect } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import {


### PR DESCRIPTION
**monday.com sync:** #12164338237

**Related Issue:** N/A

## Summary

Updates `@vitest/browser/context` import to `vitest/browser` per [Vitest v4 doc](https://vitest.dev/guide/migration.html#vitest-4:~:text=WARNING,a%20future%20release.):

> With this change, the `@vitest/browser` package is no longer needed, and you can remove it from your dependencies. To support the context import, you should update the `@vitest/browser/context` to `vitest/browser`

> Both `@vitest/browser/context` and `@vitest/browser/utils` work at runtime during the transition period, but they will be removed in a future release.