### PR TITLE
ci(update-components): provide expected `base` argument to create-pull-request action

### DIFF
--- a/.github/workflows/update-components.yml
+++ b/.github/workflows/update-components.yml
@@ -22,6 +22,7 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          base: dev
           commit-message: "chore: update issue template component lists"
           branch: update/issue-template-components
           title: "chore: update issue template component lists"


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Fixes the following error that shows up under commit checks:

<img width="620" height="327" alt="Screenshot 2025-12-15 at 10 44 56 AM" src="https://github.com/user-attachments/assets/2e5f2aa5-4196-4680-900b-b12611c80018" />

&nbsp;

<img width="965" height="358" alt="Screenshot 2025-12-15 at 10 53 11 AM" src="https://github.com/user-attachments/assets/4cb4f80a-def7-495d-9880-ac01f5223123" />