### PR TITLE
fix: ensure popovers are toggled outside animations

### DIFF
--- a/packages/components/src/components/alert/alert.tsx
+++ b/packages/components/src/components/alert/alert.tsx
@@ -288,7 +288,6 @@ export class Alert extends LitElement {
     } else {
       manager.unregisterElement(this.el);
     }
-    this.handlePopover();
   }
 
   private updateDuration(): void {
@@ -347,7 +346,6 @@ export class Alert extends LitElement {
     }
 
     this.transitionEl = el;
-    this.handlePopover();
   }
 
   /** close and emit calciteInternalAlertSync event with the updated queue payload */
@@ -358,6 +356,7 @@ export class Alert extends LitElement {
 
   onBeforeOpen(): void {
     this.calciteAlertBeforeOpen.emit();
+    this.handlePopover();
   }
 
   onOpen(): void {
@@ -370,6 +369,7 @@ export class Alert extends LitElement {
 
   onClose(): void {
     this.calciteAlertClose.emit();
+    this.handlePopover();
   }
 
   private actionsEndSlotChangeHandler(event: Event): void {

--- a/packages/components/src/components/autocomplete/autocomplete.tsx
+++ b/packages/components/src/components/autocomplete/autocomplete.tsx
@@ -27,7 +27,6 @@ import {
   disconnectFloatingUI,
   reposition,
 } from "../../utils/floating-ui";
-import { toggleOpenClose } from "../../utils/openCloseComponent";
 import { Alignment, Scale, Status } from "../interfaces";
 import { IconName } from "../icon/interfaces";
 import { connectLabel, disconnectLabel, LabelableComponent, getLabelText } from "../../utils/label";
@@ -539,8 +538,6 @@ export class Autocomplete
   }
 
   private openHandler(): void {
-    toggleOpenClose(this);
-
     if (!this.open) {
       this.activeIndex = -1;
     }

--- a/packages/components/src/components/autocomplete/autocomplete.tsx
+++ b/packages/components/src/components/autocomplete/autocomplete.tsx
@@ -539,13 +539,13 @@ export class Autocomplete
   }
 
   private openHandler(): void {
-    if (!this.open) {
-      this.activeIndex = -1;
-    }
-
     if (this.disabled) {
       this.open = false;
       return;
+    }
+
+    if (!this.open) {
+      this.activeIndex = -1;
     }
 
     toggleOpenClose(this);

--- a/packages/components/src/components/autocomplete/autocomplete.tsx
+++ b/packages/components/src/components/autocomplete/autocomplete.tsx
@@ -552,7 +552,6 @@ export class Autocomplete
 
     this.setFloatingElSize();
     this.reposition(true);
-    this.handlePopover();
   }
 
   private async documentClickHandler(event: MouseEvent): Promise<void> {
@@ -580,6 +579,7 @@ export class Autocomplete
 
   onBeforeOpen(): void {
     this.calciteAutocompleteBeforeOpen.emit();
+    this.handlePopover();
   }
 
   onOpen(): void {
@@ -592,6 +592,7 @@ export class Autocomplete
 
   onClose(): void {
     this.calciteAutocompleteClose.emit();
+    this.handlePopover();
   }
 
   private emitChange(): void {
@@ -760,7 +761,6 @@ export class Autocomplete
   private setFloatingEl(el: HTMLDivElement): void {
     this.floatingEl = el;
     connectFloatingUI(this);
-    this.handlePopover();
   }
 
   //#endregion

--- a/packages/components/src/components/autocomplete/autocomplete.tsx
+++ b/packages/components/src/components/autocomplete/autocomplete.tsx
@@ -53,6 +53,7 @@ import { Validation } from "../functional/Validation";
 import { createObserver, updateRefObserver } from "../../utils/observers";
 import { useSetFocus } from "../../controllers/useSetFocus";
 import { useInteractive } from "../../controllers/useInteractive";
+import { toggleOpenClose } from "../../utils/openCloseComponent";
 import { styles } from "./autocomplete.scss";
 import T9nStrings from "./assets/t9n/messages.en.json";
 import { CSS, IDS, SLOTS } from "./resources";
@@ -547,6 +548,7 @@ export class Autocomplete
       return;
     }
 
+    toggleOpenClose(this);
     this.setFloatingElSize();
     this.reposition(true);
   }

--- a/packages/components/src/components/combobox/combobox.tsx
+++ b/packages/components/src/components/combobox/combobox.tsx
@@ -691,12 +691,11 @@ export class Combobox
   }
 
   private openHandler(): void {
-    toggleOpenClose(this);
-
     if (this.disabled) {
       return;
     }
 
+    toggleOpenClose(this);
     this.setMaxScrollerHeight();
   }
 

--- a/packages/components/src/components/combobox/combobox.tsx
+++ b/packages/components/src/components/combobox/combobox.tsx
@@ -698,7 +698,6 @@ export class Combobox
     }
 
     this.setMaxScrollerHeight();
-    this.handlePopover();
   }
 
   private handleDisabledChange(value: boolean): void {
@@ -988,6 +987,7 @@ export class Combobox
   onBeforeOpen(): void {
     this.scrollToActiveOrSelectedItem();
     this.calciteComboboxBeforeOpen.emit();
+    this.handlePopover();
   }
 
   onOpen(): void {
@@ -1002,6 +1002,7 @@ export class Combobox
   onClose(): void {
     this.calciteComboboxClose.emit();
     hideFloatingUI(this);
+    this.handlePopover();
   }
 
   private async setMaxScrollerHeight(): Promise<void> {
@@ -1171,7 +1172,6 @@ export class Combobox
   private setFloatingEl(el: HTMLDivElement): void {
     this.floatingEl = el;
     connectFloatingUI(this);
-    this.handlePopover();
   }
 
   private setCompactSelectionDisplay({

--- a/packages/components/src/components/dialog/dialog.tsx
+++ b/packages/components/src/components/dialog/dialog.tsx
@@ -370,6 +370,7 @@ export class Dialog extends LitElement {
 
   onBeforeOpen(): void {
     this.calciteDialogBeforeOpen.emit();
+    this.handlePopover();
   }
 
   onOpen(): void {
@@ -387,6 +388,7 @@ export class Dialog extends LitElement {
   onClose(): void {
     this.focusTrap.deactivate();
     this.calciteDialogClose.emit();
+    this.handlePopover();
   }
 
   private async setOpenState(value: boolean): Promise<void> {
@@ -430,7 +432,6 @@ export class Dialog extends LitElement {
 
     transitionEl.classList.toggle(CSS.openingActive, value);
     toggleOpenClose(this);
-    this.handlePopover();
   }
 
   private async triggerInteractModifiers(): Promise<void> {
@@ -721,7 +722,6 @@ export class Dialog extends LitElement {
 
     this.transitionEl = el;
     this.setupInteractions();
-    this.handlePopover();
   }
 
   private handleInternalPanelScroll(event: CustomEvent<void>): void {

--- a/packages/components/src/components/dropdown/dropdown.tsx
+++ b/packages/components/src/components/dropdown/dropdown.tsx
@@ -323,7 +323,6 @@ export class Dropdown extends LitElement implements FloatingUIComponent {
     }
 
     this.reposition(true);
-    this.handlePopover();
   }
 
   private handleDisabledChange(value: boolean): void {
@@ -501,6 +500,7 @@ export class Dropdown extends LitElement implements FloatingUIComponent {
   onBeforeOpen(): void {
     this.focusOnFirstActiveOrDefaultItem();
     this.calciteDropdownBeforeOpen.emit();
+    this.handlePopover();
   }
 
   onOpen(): void {
@@ -514,6 +514,7 @@ export class Dropdown extends LitElement implements FloatingUIComponent {
   onClose(): void {
     this.calciteDropdownClose.emit();
     hideFloatingUI(this);
+    this.handlePopover();
   }
 
   private setReferenceEl(el: HTMLDivElement): void {
@@ -525,7 +526,6 @@ export class Dropdown extends LitElement implements FloatingUIComponent {
   private setFloatingEl(el: HTMLDivElement): void {
     this.floatingEl = el;
     connectFloatingUI(this);
-    this.handlePopover();
   }
 
   private keyDownHandler(event: KeyboardEvent): void {

--- a/packages/components/src/components/dropdown/dropdown.tsx
+++ b/packages/components/src/components/dropdown/dropdown.tsx
@@ -316,12 +316,11 @@ export class Dropdown extends LitElement implements FloatingUIComponent {
   }
 
   private openHandler(): void {
-    toggleOpenClose(this);
-
     if (this.disabled) {
       return;
     }
 
+    toggleOpenClose(this);
     this.reposition(true);
   }
 

--- a/packages/components/src/components/input-date-picker/input-date-picker.tsx
+++ b/packages/components/src/components/input-date-picker/input-date-picker.tsx
@@ -611,7 +611,6 @@ export class InputDatePicker
     }
 
     this.reposition(true);
-    this.handlePopover();
   }
 
   private calciteInternalInputInputHandler(event: CustomEvent<any>): void {
@@ -698,6 +697,7 @@ export class InputDatePicker
 
   onBeforeOpen(): void {
     this.calciteInputDatePickerBeforeOpen.emit();
+    this.handlePopover();
   }
 
   onOpen(): void {
@@ -715,6 +715,7 @@ export class InputDatePicker
     this.focusTrap.deactivate();
     this.focusOnOpen = false;
     this.datePickerEl?.reset();
+    this.handlePopover();
   }
 
   syncHiddenFormInput(input: HTMLInputElement): void {
@@ -813,7 +814,6 @@ export class InputDatePicker
   private setFloatingEl(el: HTMLDivElement): void {
     this.floatingEl = el;
     connectFloatingUI(this);
-    this.handlePopover();
   }
 
   private setStartWrapper(el: HTMLDivElement): void {

--- a/packages/components/src/components/input-date-picker/input-date-picker.tsx
+++ b/packages/components/src/components/input-date-picker/input-date-picker.tsx
@@ -604,12 +604,11 @@ export class InputDatePicker
   }
 
   private openHandler(): void {
-    toggleOpenClose(this);
-
     if (this.disabled || this.readOnly) {
       return;
     }
 
+    toggleOpenClose(this);
     this.reposition(true);
   }
 

--- a/packages/components/src/components/popover/popover.tsx
+++ b/packages/components/src/components/popover/popover.tsx
@@ -363,7 +363,6 @@ export class Popover extends LitElement implements FloatingUIComponent {
     toggleOpenClose(this);
     this.reposition(true);
     this.setExpandedAttr();
-    this.handlePopover();
   }
 
   private referenceElementHandler(): void {
@@ -400,7 +399,6 @@ export class Popover extends LitElement implements FloatingUIComponent {
     }
 
     this.addReferences();
-    this.handlePopover();
   }
 
   private getId(): string {
@@ -467,6 +465,7 @@ export class Popover extends LitElement implements FloatingUIComponent {
 
   onBeforeOpen(): void {
     this.calcitePopoverBeforeOpen.emit();
+    this.handlePopover();
   }
 
   onOpen(): void {
@@ -482,6 +481,7 @@ export class Popover extends LitElement implements FloatingUIComponent {
     this.calcitePopoverClose.emit();
     hideFloatingUI(this);
     this.focusTrap.deactivate();
+    this.handlePopover();
   }
 
   private setArrowEl(el: SVGSVGElement): void {

--- a/packages/components/src/components/popover/popover.tsx
+++ b/packages/components/src/components/popover/popover.tsx
@@ -319,6 +319,10 @@ export class Popover extends LitElement implements FloatingUIComponent {
 
     if (changes.has("referenceElement")) {
       this.referenceElementHandler();
+
+      if (!this.referenceElement && this.open) {
+        this.handlePopover();
+      }
     }
   }
 

--- a/packages/components/src/components/sheet/sheet.tsx
+++ b/packages/components/src/components/sheet/sheet.tsx
@@ -287,7 +287,6 @@ export class Sheet extends LitElement {
     Docs: https://webgis.esri.com/arcgis-components/?path=/docs/lumina-transition-from-stencil--docs#watching-for-property-changes */
     if (changes.has("opened") && (this.hasUpdated || this.opened !== false)) {
       toggleOpenClose(this);
-      this.handlePopover();
     }
 
     if (
@@ -524,6 +523,7 @@ export class Sheet extends LitElement {
 
   onBeforeOpen(): void {
     this.calciteSheetBeforeOpen.emit();
+    this.handlePopover();
   }
 
   onOpen(): void {
@@ -541,6 +541,7 @@ export class Sheet extends LitElement {
   onClose(): void {
     this.calciteSheetClose.emit();
     this.focusTrap.deactivate();
+    this.handlePopover();
   }
 
   private setResizeHandleEl(el: HTMLDivElement): void {
@@ -559,7 +560,6 @@ export class Sheet extends LitElement {
     }
 
     this.transitionEl = el;
-    this.handlePopover();
   }
 
   private handleOutsideClose(): void {

--- a/packages/components/src/components/tooltip/tooltip.tsx
+++ b/packages/components/src/components/tooltip/tooltip.tsx
@@ -201,6 +201,10 @@ export class Tooltip extends LitElement implements FloatingUIComponent {
 
     if (changes.has("referenceElement")) {
       this.setUpReferenceElement();
+
+      if (!this.referenceElement && this.open) {
+        this.handlePopover();
+      }
     }
   }
 

--- a/packages/components/src/components/tooltip/tooltip.tsx
+++ b/packages/components/src/components/tooltip/tooltip.tsx
@@ -236,11 +236,11 @@ export class Tooltip extends LitElement implements FloatingUIComponent {
   private openHandler(): void {
     toggleOpenClose(this);
     this.reposition(true);
-    this.handlePopover();
   }
 
   onBeforeOpen(): void {
     this.calciteTooltipBeforeOpen.emit();
+    this.handlePopover();
   }
 
   onOpen(): void {
@@ -254,6 +254,7 @@ export class Tooltip extends LitElement implements FloatingUIComponent {
   onClose(): void {
     this.calciteTooltipClose.emit();
     hideFloatingUI(this);
+    this.handlePopover();
   }
 
   private setFloatingEl(el: HTMLDivElement): void {
@@ -277,7 +278,6 @@ export class Tooltip extends LitElement implements FloatingUIComponent {
     }
 
     this.addReferences();
-    this.handlePopover();
   }
 
   private getId(): string {


### PR DESCRIPTION
**Related Issue:** #13211

## Summary

Moves native popover handling logic to open/close hooks to ensure they do not affect animations.

**Note**: no tests were updated since our current test setup does not cover animations.