### PR TITLE
chore: remove obsolete NPM script

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -66,7 +66,6 @@
     "util:copy-icons": "cpy \"../ui-icons/js/*.json\" \"src/components/icon/assets/\" --flat",
     "util:generate-t9n-docs-json": "node support/generate-t9n-docs-json.ts",
     "util:generate-supported-browsers-json": "node support/generate-supported-browsers-json.ts",
-    "util:hydration-styles": "node support/hydrationStyles.ts",
     "util:is-working-tree-clean": "[ -z \"$(git status --porcelain=v1)\" ]",
     "util:prep-build-reqs": "npm run util:copy-assets",
     "util:sync-t9n-en-bundles": "node support/sync-en-t9n-bundles.ts",


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Removes `util:hydration-styles` (restored [here](https://github.com/Esri/calcite-design-system/pull/6988)), which references [removed script](https://github.com/Esri/calcite-design-system/pull/4916).