### PR TITLE
docs(readme): fix CDN URL

### DIFF
--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -15,7 +15,7 @@ The most common approach for loading Calcite components is to use the version ho
 <!-- x-release-please-start-version -->
 
 ```html
-<script type="module" src="https://cdn.jsdelivr.net/npm/@esri/calcite-components@5.0.0/dist/index.js"></script>
+<script type="module" src="https://cdn.jsdelivr.net/npm/@esri/calcite-components@5.0.0/dist/cdn/index.js"></script>
 ```
 
 <!-- x-release-please-end -->


### PR DESCRIPTION
**Related Issue:** #13266

## Summary

Fixes CDN URL missed in https://github.com/Esri/calcite-design-system/pull/13415. 

Thanks for the catch, @dasa! ✨🎣✨
