### PR TITLE
feat(semantic-tokens): add surface colors

### DIFF
--- a/packages/design-tokens/src/tokens/semantic/color/dark.json
+++ b/packages/design-tokens/src/tokens/semantic/color/dark.json
@@ -3,7 +3,7 @@
     "color": {
       "surface": {
         "1": {
-          "value": "{core.color.neutral.blk-200}",
+          "value": "{core.color.neutral.blk-210}",
           "type": "color",
           "attributes": {
             "category": "color",
@@ -11,7 +11,7 @@
           }
         },
         "2": {
-          "value": "{core.color.neutral.blk-210}",
+          "value": "{core.color.neutral.blk-200}",
           "type": "color",
           "attributes": {
             "category": "color",
@@ -51,7 +51,7 @@
             "category": "color",
             "group": "background"
           },
-          "description": "Deprecated, use `--calcite-color-surface-2` instead"
+          "description": "Deprecated, use `--calcite-color-surface-1` instead"
         },
         "none": {
           "value": "rgba({core.color.neutral.blk-000}, {core.opacity.0})",
@@ -70,7 +70,7 @@
             "category": "color",
             "group": "foreground"
           },
-          "description": "Deprecated, use `--calcite-color-surface-1` instead"
+          "description": "Deprecated, use `--calcite-color-surface-2` instead"
         },
         "2": {
           "value": "{core.color.neutral.blk-190}",

--- a/packages/design-tokens/src/tokens/semantic/color/dark.json
+++ b/packages/design-tokens/src/tokens/semantic/color/dark.json
@@ -1,6 +1,48 @@
 {
   "semantic": {
     "color": {
+      "surface": {
+        "1": {
+          "value": "{core.color.neutral.blk-200}",
+          "type": "color",
+          "attributes": {
+            "category": "color",
+            "group": "surface"
+          }
+        },
+        "2": {
+          "value": "{core.color.neutral.blk-210}",
+          "type": "color",
+          "attributes": {
+            "category": "color",
+            "group": "surface"
+          }
+        },
+        "3": {
+          "value": "{core.color.neutral.blk-190}",
+          "type": "color",
+          "attributes": {
+            "category": "color",
+            "group": "surface"
+          }
+        },
+        "4": {
+          "value": "{core.color.neutral.blk-180}",
+          "type": "color",
+          "attributes": {
+            "category": "color",
+            "group": "surface"
+          }
+        },
+        "highlight": {
+          "value": "{core.color.medium-saturation.blue.m-bb-090}",
+          "type": "color",
+          "attributes": {
+            "category": "color",
+            "group": "surface"
+          }
+        }
+      },
       "background": {
         "default": {
           "value": "{core.color.neutral.blk-210}",
@@ -52,16 +94,6 @@
             "group": "foreground"
           },
           "description": "deprecated, use --calcite-color-surface-highlight instead"
-        }
-      },
-      "surface": {
-        "highlight": {
-          "value": "{core.color.medium-saturation.blue.m-bb-090}",
-          "type": "color",
-          "attributes": {
-            "category": "color",
-            "group": "foreground"
-          }
         }
       },
       "transparent": {

--- a/packages/design-tokens/src/tokens/semantic/color/dark.json
+++ b/packages/design-tokens/src/tokens/semantic/color/dark.json
@@ -50,7 +50,8 @@
           "attributes": {
             "category": "color",
             "group": "background"
-          }
+          },
+          "description": "Deprecated, use `--calcite-color-surface-2` instead"
         },
         "none": {
           "value": "rgba({core.color.neutral.blk-000}, {core.opacity.0})",
@@ -68,7 +69,8 @@
           "attributes": {
             "category": "color",
             "group": "foreground"
-          }
+          },
+          "description": "Deprecated, use `--calcite-color-surface-1` instead"
         },
         "2": {
           "value": "{core.color.neutral.blk-190}",
@@ -76,7 +78,8 @@
           "attributes": {
             "category": "color",
             "group": "foreground"
-          }
+          },
+          "description": "Deprecated, use `--calcite-color-surface-3` instead"
         },
         "3": {
           "value": "{core.color.neutral.blk-180}",
@@ -84,7 +87,8 @@
           "attributes": {
             "category": "color",
             "group": "foreground"
-          }
+          },
+          "description": "Deprecated, use `--calcite-color-surface-4` instead"
         },
         "current": {
           "value": "{core.color.medium-saturation.blue.m-bb-090}",

--- a/packages/design-tokens/src/tokens/semantic/color/light.json
+++ b/packages/design-tokens/src/tokens/semantic/color/light.json
@@ -3,7 +3,7 @@
     "color": {
       "surface": {
         "1": {
-          "value": "{core.color.neutral.blk-000}",
+          "value": "{core.color.neutral.blk-005}",
           "type": "color",
           "attributes": {
             "category": "color",
@@ -11,7 +11,7 @@
           }
         },
         "2": {
-          "value": "{core.color.neutral.blk-005}",
+          "value": "{core.color.neutral.blk-000}",
           "type": "color",
           "attributes": {
             "category": "color",
@@ -51,7 +51,7 @@
             "category": "color",
             "group": "background"
           },
-          "description": "Deprecated, use `--calcite-color-surface-2` instead"
+          "description": "Deprecated, use `--calcite-color-surface-1` instead"
         },
         "none": {
           "value": "rgba({core.color.neutral.blk-000}, {core.opacity.0})",
@@ -70,7 +70,7 @@
             "category": "color",
             "group": "foreground"
           },
-          "description": "Deprecated, use `--calcite-color-surface-1` instead"
+          "description": "Deprecated, use `--calcite-color-surface-2` instead"
         },
         "2": {
           "value": "{core.color.neutral.blk-010}",

--- a/packages/design-tokens/src/tokens/semantic/color/light.json
+++ b/packages/design-tokens/src/tokens/semantic/color/light.json
@@ -1,6 +1,48 @@
 {
   "semantic": {
     "color": {
+      "surface": {
+        "1": {
+          "value": "{core.color.neutral.blk-000}",
+          "type": "color",
+          "attributes": {
+            "category": "color",
+            "group": "surface"
+          }
+        },
+        "2": {
+          "value": "{core.color.neutral.blk-005}",
+          "type": "color",
+          "attributes": {
+            "category": "color",
+            "group": "surface"
+          }
+        },
+        "3": {
+          "value": "{core.color.neutral.blk-010}",
+          "type": "color",
+          "attributes": {
+            "category": "color",
+            "group": "surface"
+          }
+        },
+        "4": {
+          "value": "{core.color.neutral.blk-020}",
+          "type": "color",
+          "attributes": {
+            "category": "color",
+            "group": "surface"
+          }
+        },
+        "highlight": {
+          "value": "{core.color.high-saturation.blue.h-bb-010}",
+          "type": "color",
+          "attributes": {
+            "category": "color",
+            "group": "surface"
+          }
+        }
+      },
       "background": {
         "default": {
           "value": "{core.color.neutral.blk-005}",
@@ -52,16 +94,6 @@
             "group": "foreground"
           },
           "description": "deprecated, use --calcite-color-surface-highlight instead"
-        }
-      },
-      "surface": {
-        "highlight": {
-          "value": "{core.color.high-saturation.blue.h-bb-010}",
-          "type": "color",
-          "attributes": {
-            "category": "color",
-            "group": "foreground"
-          }
         }
       },
       "transparent": {

--- a/packages/design-tokens/src/tokens/semantic/color/light.json
+++ b/packages/design-tokens/src/tokens/semantic/color/light.json
@@ -50,7 +50,8 @@
           "attributes": {
             "category": "color",
             "group": "background"
-          }
+          },
+          "description": "Deprecated, use `--calcite-color-surface-2` instead"
         },
         "none": {
           "value": "rgba({core.color.neutral.blk-000}, {core.opacity.0})",
@@ -68,7 +69,8 @@
           "attributes": {
             "category": "color",
             "group": "foreground"
-          }
+          },
+          "description": "Deprecated, use `--calcite-color-surface-1` instead"
         },
         "2": {
           "value": "{core.color.neutral.blk-010}",
@@ -76,7 +78,8 @@
           "attributes": {
             "category": "color",
             "group": "foreground"
-          }
+          },
+          "description": "Deprecated, use `--calcite-color-surface-3` instead"
         },
         "3": {
           "value": "{core.color.neutral.blk-020}",
@@ -84,7 +87,8 @@
           "attributes": {
             "category": "color",
             "group": "foreground"
-          }
+          },
+          "description": "Deprecated, use `--calcite-color-surface-4` instead"
         },
         "current": {
           "value": "{core.color.high-saturation.blue.h-bb-010}",

--- a/packages/design-tokens/tests/spec/__snapshots__/index.spec.ts.snap
+++ b/packages/design-tokens/tests/spec/__snapshots__/index.spec.ts.snap
@@ -921,13 +921,17 @@ exports[`generated tokens > CSS > dark should match 1`] = `
  */
 
 :root {
-  --calcite-color-background: #212121;
-  --calcite-color-background-none: rgba(255, 255, 255, 0);
-  --calcite-color-foreground-1: #2b2b2b;
-  --calcite-color-foreground-2: #363636;
-  --calcite-color-foreground-3: #404040;
-  --calcite-color-foreground-current: #2b465f; /** deprecated, use --calcite-color-surface-highlight instead */
+  --calcite-color-surface-1: #212121;
+  --calcite-color-surface-2: #2b2b2b;
+  --calcite-color-surface-3: #363636;
+  --calcite-color-surface-4: #404040;
   --calcite-color-surface-highlight: #2b465f;
+  --calcite-color-background: #212121; /** Deprecated, use \`--calcite-color-surface-1\` instead */
+  --calcite-color-background-none: rgba(255, 255, 255, 0);
+  --calcite-color-foreground-1: #2b2b2b; /** Deprecated, use \`--calcite-color-surface-2\` instead */
+  --calcite-color-foreground-2: #363636; /** Deprecated, use \`--calcite-color-surface-3\` instead */
+  --calcite-color-foreground-3: #404040; /** Deprecated, use \`--calcite-color-surface-4\` instead */
+  --calcite-color-foreground-current: #2b465f; /** deprecated, use --calcite-color-surface-highlight instead */
   --calcite-color-transparent: rgba(255, 255, 255, 0);
   --calcite-color-transparent-hover: rgba(255, 255, 255, 0.12);
   --calcite-color-transparent-press: rgba(255, 255, 255, 0.16);
@@ -1190,13 +1194,17 @@ exports[`generated tokens > CSS > index should match 1`] = `
   --calcite-color-transparent-press: rgba(0, 0, 0, 0.08);
   --calcite-color-transparent-hover: rgba(0, 0, 0, 0.04);
   --calcite-color-transparent: rgba(0, 0, 0, 0);
-  --calcite-color-surface-highlight: #d6efff;
   --calcite-color-foreground-current: #d6efff; /** deprecated, use --calcite-color-surface-highlight instead */
-  --calcite-color-foreground-3: #ebebeb;
-  --calcite-color-foreground-2: #f2f2f2;
-  --calcite-color-foreground-1: #ffffff;
+  --calcite-color-foreground-3: #ebebeb; /** Deprecated, use \`--calcite-color-surface-4\` instead */
+  --calcite-color-foreground-2: #f2f2f2; /** Deprecated, use \`--calcite-color-surface-3\` instead */
+  --calcite-color-foreground-1: #ffffff; /** Deprecated, use \`--calcite-color-surface-2\` instead */
   --calcite-color-background-none: rgba(255, 255, 255, 0);
-  --calcite-color-background: #f7f7f7;
+  --calcite-color-background: #f7f7f7; /** Deprecated, use \`--calcite-color-surface-1\` instead */
+  --calcite-color-surface-highlight: #d6efff;
+  --calcite-color-surface-4: #ebebeb;
+  --calcite-color-surface-3: #f2f2f2;
+  --calcite-color-surface-2: #ffffff;
+  --calcite-color-surface-1: #f7f7f7;
   --calcite-color-focus: var(--calcite-color-brand);
 }
 @media (prefers-color-scheme: light) {
@@ -1239,13 +1247,17 @@ exports[`generated tokens > CSS > index should match 1`] = `
     --calcite-color-transparent-press: rgba(0, 0, 0, 0.08);
     --calcite-color-transparent-hover: rgba(0, 0, 0, 0.04);
     --calcite-color-transparent: rgba(0, 0, 0, 0);
-    --calcite-color-surface-highlight: #d6efff;
     --calcite-color-foreground-current: #d6efff; /** deprecated, use --calcite-color-surface-highlight instead */
-    --calcite-color-foreground-3: #ebebeb;
-    --calcite-color-foreground-2: #f2f2f2;
-    --calcite-color-foreground-1: #ffffff;
+    --calcite-color-foreground-3: #ebebeb; /** Deprecated, use \`--calcite-color-surface-4\` instead */
+    --calcite-color-foreground-2: #f2f2f2; /** Deprecated, use \`--calcite-color-surface-3\` instead */
+    --calcite-color-foreground-1: #ffffff; /** Deprecated, use \`--calcite-color-surface-2\` instead */
     --calcite-color-background-none: rgba(255, 255, 255, 0);
-    --calcite-color-background: #f7f7f7;
+    --calcite-color-background: #f7f7f7; /** Deprecated, use \`--calcite-color-surface-1\` instead */
+    --calcite-color-surface-highlight: #d6efff;
+    --calcite-color-surface-4: #ebebeb;
+    --calcite-color-surface-3: #f2f2f2;
+    --calcite-color-surface-2: #ffffff;
+    --calcite-color-surface-1: #f7f7f7;
     --calcite-color-focus: var(--calcite-color-brand);
   }
 }
@@ -1289,13 +1301,17 @@ exports[`generated tokens > CSS > index should match 1`] = `
     --calcite-color-transparent-press: rgba(255, 255, 255, 0.16);
     --calcite-color-transparent-hover: rgba(255, 255, 255, 0.12);
     --calcite-color-transparent: rgba(255, 255, 255, 0);
-    --calcite-color-surface-highlight: #2b465f;
     --calcite-color-foreground-current: #2b465f; /** deprecated, use --calcite-color-surface-highlight instead */
-    --calcite-color-foreground-3: #404040;
-    --calcite-color-foreground-2: #363636;
-    --calcite-color-foreground-1: #2b2b2b;
+    --calcite-color-foreground-3: #404040; /** Deprecated, use \`--calcite-color-surface-4\` instead */
+    --calcite-color-foreground-2: #363636; /** Deprecated, use \`--calcite-color-surface-3\` instead */
+    --calcite-color-foreground-1: #2b2b2b; /** Deprecated, use \`--calcite-color-surface-2\` instead */
     --calcite-color-background-none: rgba(255, 255, 255, 0);
-    --calcite-color-background: #212121;
+    --calcite-color-background: #212121; /** Deprecated, use \`--calcite-color-surface-1\` instead */
+    --calcite-color-surface-highlight: #2b465f;
+    --calcite-color-surface-4: #404040;
+    --calcite-color-surface-3: #363636;
+    --calcite-color-surface-2: #2b2b2b;
+    --calcite-color-surface-1: #212121;
     --calcite-color-focus: var(--calcite-color-brand);
   }
 }
@@ -1338,13 +1354,17 @@ exports[`generated tokens > CSS > index should match 1`] = `
   --calcite-color-transparent-press: rgba(0, 0, 0, 0.08);
   --calcite-color-transparent-hover: rgba(0, 0, 0, 0.04);
   --calcite-color-transparent: rgba(0, 0, 0, 0);
-  --calcite-color-surface-highlight: #d6efff;
   --calcite-color-foreground-current: #d6efff; /** deprecated, use --calcite-color-surface-highlight instead */
-  --calcite-color-foreground-3: #ebebeb;
-  --calcite-color-foreground-2: #f2f2f2;
-  --calcite-color-foreground-1: #ffffff;
+  --calcite-color-foreground-3: #ebebeb; /** Deprecated, use \`--calcite-color-surface-4\` instead */
+  --calcite-color-foreground-2: #f2f2f2; /** Deprecated, use \`--calcite-color-surface-3\` instead */
+  --calcite-color-foreground-1: #ffffff; /** Deprecated, use \`--calcite-color-surface-2\` instead */
   --calcite-color-background-none: rgba(255, 255, 255, 0);
-  --calcite-color-background: #f7f7f7;
+  --calcite-color-background: #f7f7f7; /** Deprecated, use \`--calcite-color-surface-1\` instead */
+  --calcite-color-surface-highlight: #d6efff;
+  --calcite-color-surface-4: #ebebeb;
+  --calcite-color-surface-3: #f2f2f2;
+  --calcite-color-surface-2: #ffffff;
+  --calcite-color-surface-1: #f7f7f7;
   --calcite-color-focus: var(--calcite-color-brand);
 }
 .calcite-mode-dark {
@@ -1386,13 +1406,17 @@ exports[`generated tokens > CSS > index should match 1`] = `
   --calcite-color-transparent-press: rgba(255, 255, 255, 0.16);
   --calcite-color-transparent-hover: rgba(255, 255, 255, 0.12);
   --calcite-color-transparent: rgba(255, 255, 255, 0);
-  --calcite-color-surface-highlight: #2b465f;
   --calcite-color-foreground-current: #2b465f; /** deprecated, use --calcite-color-surface-highlight instead */
-  --calcite-color-foreground-3: #404040;
-  --calcite-color-foreground-2: #363636;
-  --calcite-color-foreground-1: #2b2b2b;
+  --calcite-color-foreground-3: #404040; /** Deprecated, use \`--calcite-color-surface-4\` instead */
+  --calcite-color-foreground-2: #363636; /** Deprecated, use \`--calcite-color-surface-3\` instead */
+  --calcite-color-foreground-1: #2b2b2b; /** Deprecated, use \`--calcite-color-surface-2\` instead */
   --calcite-color-background-none: rgba(255, 255, 255, 0);
-  --calcite-color-background: #212121;
+  --calcite-color-background: #212121; /** Deprecated, use \`--calcite-color-surface-1\` instead */
+  --calcite-color-surface-highlight: #2b465f;
+  --calcite-color-surface-4: #404040;
+  --calcite-color-surface-3: #363636;
+  --calcite-color-surface-2: #2b2b2b;
+  --calcite-color-surface-1: #212121;
   --calcite-color-focus: var(--calcite-color-brand);
 }
 "
@@ -1405,13 +1429,17 @@ exports[`generated tokens > CSS > light should match 1`] = `
  */
 
 :root {
-  --calcite-color-background: #f7f7f7;
-  --calcite-color-background-none: rgba(255, 255, 255, 0);
-  --calcite-color-foreground-1: #ffffff;
-  --calcite-color-foreground-2: #f2f2f2;
-  --calcite-color-foreground-3: #ebebeb;
-  --calcite-color-foreground-current: #d6efff; /** deprecated, use --calcite-color-surface-highlight instead */
+  --calcite-color-surface-1: #f7f7f7;
+  --calcite-color-surface-2: #ffffff;
+  --calcite-color-surface-3: #f2f2f2;
+  --calcite-color-surface-4: #ebebeb;
   --calcite-color-surface-highlight: #d6efff;
+  --calcite-color-background: #f7f7f7; /** Deprecated, use \`--calcite-color-surface-1\` instead */
+  --calcite-color-background-none: rgba(255, 255, 255, 0);
+  --calcite-color-foreground-1: #ffffff; /** Deprecated, use \`--calcite-color-surface-2\` instead */
+  --calcite-color-foreground-2: #f2f2f2; /** Deprecated, use \`--calcite-color-surface-3\` instead */
+  --calcite-color-foreground-3: #ebebeb; /** Deprecated, use \`--calcite-color-surface-4\` instead */
+  --calcite-color-foreground-current: #d6efff; /** deprecated, use --calcite-color-surface-highlight instead */
   --calcite-color-transparent: rgba(0, 0, 0, 0);
   --calcite-color-transparent-hover: rgba(0, 0, 0, 0.04);
   --calcite-color-transparent-press: rgba(0, 0, 0, 0.08);
@@ -18106,6 +18134,141 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
   "timestamp": "TEST_TIMESTAMP",
   "tokens": [
     {
+      "key": "{semantic.color.surface.1}",
+      "value": "{\\"light\\":\\"#f7f7f7\\",\\"dark\\":\\"#212121\\"}",
+      "type": "color",
+      "attributes": {
+        "category": "color",
+        "group": "surface",
+        "type": "color",
+        "item": "surface",
+        "subitem": "1",
+        "names": {
+          "scss": "$calcite-color-surface-1",
+          "css": "var(--calcite-color-surface-1)",
+          "docs": "semantic.color.surface.1",
+          "es6": "calciteColorSurface1"
+        },
+        "calcite-schema": {
+          "system": "calcite",
+          "tier": "color",
+          "type": "color"
+        }
+      },
+      "filePath": "src/tokens/semantic/color/light.json",
+      "isSource": false,
+      "name": "Color Surface 1",
+      "path": ["semantic", "color", "surface", "1"]
+    },
+    {
+      "key": "{semantic.color.surface.2}",
+      "value": "{\\"light\\":\\"#ffffff\\",\\"dark\\":\\"#2b2b2b\\"}",
+      "type": "color",
+      "attributes": {
+        "category": "color",
+        "group": "surface",
+        "type": "color",
+        "item": "surface",
+        "subitem": "2",
+        "names": {
+          "scss": "$calcite-color-surface-2",
+          "css": "var(--calcite-color-surface-2)",
+          "docs": "semantic.color.surface.2",
+          "es6": "calciteColorSurface2"
+        },
+        "calcite-schema": {
+          "system": "calcite",
+          "tier": "color",
+          "type": "color"
+        }
+      },
+      "filePath": "src/tokens/semantic/color/light.json",
+      "isSource": false,
+      "name": "Color Surface 2",
+      "path": ["semantic", "color", "surface", "2"]
+    },
+    {
+      "key": "{semantic.color.surface.3}",
+      "value": "{\\"light\\":\\"#f2f2f2\\",\\"dark\\":\\"#363636\\"}",
+      "type": "color",
+      "attributes": {
+        "category": "color",
+        "group": "surface",
+        "type": "color",
+        "item": "surface",
+        "subitem": "3",
+        "names": {
+          "scss": "$calcite-color-surface-3",
+          "css": "var(--calcite-color-surface-3)",
+          "docs": "semantic.color.surface.3",
+          "es6": "calciteColorSurface3"
+        },
+        "calcite-schema": {
+          "system": "calcite",
+          "tier": "color",
+          "type": "color"
+        }
+      },
+      "filePath": "src/tokens/semantic/color/light.json",
+      "isSource": false,
+      "name": "Color Surface 3",
+      "path": ["semantic", "color", "surface", "3"]
+    },
+    {
+      "key": "{semantic.color.surface.4}",
+      "value": "{\\"light\\":\\"#ebebeb\\",\\"dark\\":\\"#404040\\"}",
+      "type": "color",
+      "attributes": {
+        "category": "color",
+        "group": "surface",
+        "type": "color",
+        "item": "surface",
+        "subitem": "4",
+        "names": {
+          "scss": "$calcite-color-surface-4",
+          "css": "var(--calcite-color-surface-4)",
+          "docs": "semantic.color.surface.4",
+          "es6": "calciteColorSurface4"
+        },
+        "calcite-schema": {
+          "system": "calcite",
+          "tier": "color",
+          "type": "color"
+        }
+      },
+      "filePath": "src/tokens/semantic/color/light.json",
+      "isSource": false,
+      "name": "Color Surface 4",
+      "path": ["semantic", "color", "surface", "4"]
+    },
+    {
+      "key": "{semantic.color.surface.highlight}",
+      "value": "{\\"light\\":\\"#d6efff\\",\\"dark\\":\\"#2b465f\\"}",
+      "type": "color",
+      "attributes": {
+        "category": "color",
+        "group": "surface",
+        "type": "color",
+        "item": "surface",
+        "subitem": "highlight",
+        "names": {
+          "scss": "$calcite-color-surface-highlight",
+          "css": "var(--calcite-color-surface-highlight)",
+          "docs": "semantic.color.surface.highlight",
+          "es6": "calciteColorSurfaceHighlight"
+        },
+        "calcite-schema": {
+          "system": "calcite",
+          "tier": "color",
+          "type": "color"
+        }
+      },
+      "filePath": "src/tokens/semantic/color/light.json",
+      "isSource": false,
+      "name": "Color Surface Highlight",
+      "path": ["semantic", "color", "surface", "highlight"]
+    },
+    {
       "key": "{semantic.color.background.default}",
       "value": "{\\"light\\":\\"#f7f7f7\\",\\"dark\\":\\"#212121\\"}",
       "type": "color",
@@ -18115,6 +18278,14 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "color",
         "item": "background",
         "subitem": "default",
+        "value": "#f7f7f7",
+        "description": "Deprecated, use \`--calcite-color-surface-1\` instead",
+        "filePath": "src/tokens/semantic/color/light.json",
+        "isSource": false,
+        "key": "{semantic.color.background.default}",
+        "name": "calcite-semantic-color-background-default",
+        "path": ["semantic", "color", "background", "default"],
+        "comment": "Deprecated, use \`--calcite-color-surface-1\` instead",
         "names": {
           "scss": "$calcite-color-background",
           "css": "var(--calcite-color-background)",
@@ -18127,10 +18298,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "color"
         }
       },
+      "description": "Deprecated, use \`--calcite-color-surface-1\` instead",
       "filePath": "src/tokens/semantic/color/light.json",
       "isSource": false,
       "name": "Color Background",
-      "path": ["semantic", "color", "background", "default"]
+      "path": ["semantic", "color", "background", "default"],
+      "comment": "Deprecated, use \`--calcite-color-surface-1\` instead"
     },
     {
       "key": "{semantic.color.background.none}",
@@ -18169,6 +18342,14 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "color",
         "item": "foreground",
         "subitem": "1",
+        "value": "#ffffff",
+        "description": "Deprecated, use \`--calcite-color-surface-2\` instead",
+        "filePath": "src/tokens/semantic/color/light.json",
+        "isSource": false,
+        "key": "{semantic.color.foreground.1}",
+        "name": "calcite-semantic-color-foreground-1",
+        "path": ["semantic", "color", "foreground", "1"],
+        "comment": "Deprecated, use \`--calcite-color-surface-2\` instead",
         "names": {
           "scss": "$calcite-color-foreground-1",
           "css": "var(--calcite-color-foreground-1)",
@@ -18181,10 +18362,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "color"
         }
       },
+      "description": "Deprecated, use \`--calcite-color-surface-2\` instead",
       "filePath": "src/tokens/semantic/color/light.json",
       "isSource": false,
       "name": "Color Foreground 1",
-      "path": ["semantic", "color", "foreground", "1"]
+      "path": ["semantic", "color", "foreground", "1"],
+      "comment": "Deprecated, use \`--calcite-color-surface-2\` instead"
     },
     {
       "key": "{semantic.color.foreground.2}",
@@ -18196,6 +18379,14 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "color",
         "item": "foreground",
         "subitem": "2",
+        "value": "#f2f2f2",
+        "description": "Deprecated, use \`--calcite-color-surface-3\` instead",
+        "filePath": "src/tokens/semantic/color/light.json",
+        "isSource": false,
+        "key": "{semantic.color.foreground.2}",
+        "name": "calcite-semantic-color-foreground-2",
+        "path": ["semantic", "color", "foreground", "2"],
+        "comment": "Deprecated, use \`--calcite-color-surface-3\` instead",
         "names": {
           "scss": "$calcite-color-foreground-2",
           "css": "var(--calcite-color-foreground-2)",
@@ -18208,10 +18399,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "color"
         }
       },
+      "description": "Deprecated, use \`--calcite-color-surface-3\` instead",
       "filePath": "src/tokens/semantic/color/light.json",
       "isSource": false,
       "name": "Color Foreground 2",
-      "path": ["semantic", "color", "foreground", "2"]
+      "path": ["semantic", "color", "foreground", "2"],
+      "comment": "Deprecated, use \`--calcite-color-surface-3\` instead"
     },
     {
       "key": "{semantic.color.foreground.3}",
@@ -18223,6 +18416,14 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "color",
         "item": "foreground",
         "subitem": "3",
+        "value": "#ebebeb",
+        "description": "Deprecated, use \`--calcite-color-surface-4\` instead",
+        "filePath": "src/tokens/semantic/color/light.json",
+        "isSource": false,
+        "key": "{semantic.color.foreground.3}",
+        "name": "calcite-semantic-color-foreground-3",
+        "path": ["semantic", "color", "foreground", "3"],
+        "comment": "Deprecated, use \`--calcite-color-surface-4\` instead",
         "names": {
           "scss": "$calcite-color-foreground-3",
           "css": "var(--calcite-color-foreground-3)",
@@ -18235,10 +18436,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "color"
         }
       },
+      "description": "Deprecated, use \`--calcite-color-surface-4\` instead",
       "filePath": "src/tokens/semantic/color/light.json",
       "isSource": false,
       "name": "Color Foreground 3",
-      "path": ["semantic", "color", "foreground", "3"]
+      "path": ["semantic", "color", "foreground", "3"],
+      "comment": "Deprecated, use \`--calcite-color-surface-4\` instead"
     },
     {
       "key": "{semantic.color.foreground.current}",
@@ -18276,33 +18479,6 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "name": "Color Foreground Current",
       "path": ["semantic", "color", "foreground", "current"],
       "comment": "deprecated, use --calcite-color-surface-highlight instead"
-    },
-    {
-      "key": "{semantic.color.surface.highlight}",
-      "value": "{\\"light\\":\\"#d6efff\\",\\"dark\\":\\"#2b465f\\"}",
-      "type": "color",
-      "attributes": {
-        "category": "color",
-        "group": "foreground",
-        "type": "color",
-        "item": "surface",
-        "subitem": "highlight",
-        "names": {
-          "scss": "$calcite-color-surface-highlight",
-          "css": "var(--calcite-color-surface-highlight)",
-          "docs": "semantic.color.surface.highlight",
-          "es6": "calciteColorSurfaceHighlight"
-        },
-        "calcite-schema": {
-          "system": "calcite",
-          "tier": "color",
-          "type": "color"
-        }
-      },
-      "filePath": "src/tokens/semantic/color/light.json",
-      "isSource": false,
-      "name": "Color Surface Highlight",
-      "path": ["semantic", "color", "surface", "highlight"]
     },
     {
       "key": "{semantic.color.transparent.default.default}",
@@ -33290,19 +33466,23 @@ exports[`generated tokens > ES6 > global should match 1`] = `
  * Do not edit directly, this file was auto-generated.
  */
 
-export const calciteColorBackground = { light: "#f7f7f7", dark: "#212121" };
-export const calciteColorBackgroundNone = "rgba(255, 255, 255, 0)";
-export const calciteColorForeground1 = { light: "#ffffff", dark: "#2b2b2b" };
-export const calciteColorForeground2 = { light: "#f2f2f2", dark: "#363636" };
-export const calciteColorForeground3 = { light: "#ebebeb", dark: "#404040" };
-export const calciteColorForegroundCurrent = {
-  light: "#d6efff",
-  dark: "#2b465f",
-}; // deprecated, use --calcite-color-surface-highlight instead
+export const calciteColorSurface1 = { light: "#f7f7f7", dark: "#212121" };
+export const calciteColorSurface2 = { light: "#ffffff", dark: "#2b2b2b" };
+export const calciteColorSurface3 = { light: "#f2f2f2", dark: "#363636" };
+export const calciteColorSurface4 = { light: "#ebebeb", dark: "#404040" };
 export const calciteColorSurfaceHighlight = {
   light: "#d6efff",
   dark: "#2b465f",
 };
+export const calciteColorBackground = { light: "#f7f7f7", dark: "#212121" }; // Deprecated, use \`--calcite-color-surface-1\` instead
+export const calciteColorBackgroundNone = "rgba(255, 255, 255, 0)";
+export const calciteColorForeground1 = { light: "#ffffff", dark: "#2b2b2b" }; // Deprecated, use \`--calcite-color-surface-2\` instead
+export const calciteColorForeground2 = { light: "#f2f2f2", dark: "#363636" }; // Deprecated, use \`--calcite-color-surface-3\` instead
+export const calciteColorForeground3 = { light: "#ebebeb", dark: "#404040" }; // Deprecated, use \`--calcite-color-surface-4\` instead
+export const calciteColorForegroundCurrent = {
+  light: "#d6efff",
+  dark: "#2b465f",
+}; // deprecated, use --calcite-color-surface-highlight instead
 export const calciteColorTransparent = {
   light: "rgba(0, 0, 0, 0)",
   dark: "rgba(255, 255, 255, 0)",
@@ -33860,14 +34040,22 @@ exports[`generated tokens > ES6 > global types should match 1`] = `
  * Do not edit directly, this file was auto-generated.
  */
 
+export const calciteColorSurface1: { light: string; dark: string };
+export const calciteColorSurface2: { light: string; dark: string };
+export const calciteColorSurface3: { light: string; dark: string };
+export const calciteColorSurface4: { light: string; dark: string };
+export const calciteColorSurfaceHighlight: { light: string; dark: string };
+/** Deprecated, use \`--calcite-color-surface-1\` instead */
 export const calciteColorBackground: { light: string; dark: string };
 export const calciteColorBackgroundNone: string;
+/** Deprecated, use \`--calcite-color-surface-2\` instead */
 export const calciteColorForeground1: { light: string; dark: string };
+/** Deprecated, use \`--calcite-color-surface-3\` instead */
 export const calciteColorForeground2: { light: string; dark: string };
+/** Deprecated, use \`--calcite-color-surface-4\` instead */
 export const calciteColorForeground3: { light: string; dark: string };
 /** deprecated, use --calcite-color-surface-highlight instead */
 export const calciteColorForegroundCurrent: { light: string; dark: string };
-export const calciteColorSurfaceHighlight: { light: string; dark: string };
 export const calciteColorTransparent: { light: string; dark: string };
 export const calciteColorTransparentHover: { light: string; dark: string };
 export const calciteColorTransparentPress: { light: string; dark: string };
@@ -35522,13 +35710,17 @@ exports[`generated tokens > SCSS > dark should match 1`] = `
 // Calcite Design System
 // Do not edit directly, this file was auto-generated.
 
-$calcite-color-background: #212121;
-$calcite-color-background-none: rgba(255, 255, 255, 0);
-$calcite-color-foreground-1: #2b2b2b;
-$calcite-color-foreground-2: #363636;
-$calcite-color-foreground-3: #404040;
-$calcite-color-foreground-current: #2b465f; // deprecated, use --calcite-color-surface-highlight instead
+$calcite-color-surface-1: #212121;
+$calcite-color-surface-2: #2b2b2b;
+$calcite-color-surface-3: #363636;
+$calcite-color-surface-4: #404040;
 $calcite-color-surface-highlight: #2b465f;
+$calcite-color-background: #212121; // Deprecated, use \`--calcite-color-surface-1\` instead
+$calcite-color-background-none: rgba(255, 255, 255, 0);
+$calcite-color-foreground-1: #2b2b2b; // Deprecated, use \`--calcite-color-surface-2\` instead
+$calcite-color-foreground-2: #363636; // Deprecated, use \`--calcite-color-surface-3\` instead
+$calcite-color-foreground-3: #404040; // Deprecated, use \`--calcite-color-surface-4\` instead
+$calcite-color-foreground-current: #2b465f; // deprecated, use --calcite-color-surface-highlight instead
 $calcite-color-transparent: rgba(255, 255, 255, 0);
 $calcite-color-transparent-hover: rgba(255, 255, 255, 0.12);
 $calcite-color-transparent-press: rgba(255, 255, 255, 0.16);
@@ -35788,13 +35980,17 @@ exports[`generated tokens > SCSS > index should match 1`] = `
   --calcite-color-transparent-press: rgba(0, 0, 0, 0.08);
   --calcite-color-transparent-hover: rgba(0, 0, 0, 0.04);
   --calcite-color-transparent: rgba(0, 0, 0, 0);
-  --calcite-color-surface-highlight: #d6efff;
   --calcite-color-foreground-current: #d6efff; /** deprecated, use --calcite-color-surface-highlight instead */
-  --calcite-color-foreground-3: #ebebeb;
-  --calcite-color-foreground-2: #f2f2f2;
-  --calcite-color-foreground-1: #ffffff;
+  --calcite-color-foreground-3: #ebebeb; /** Deprecated, use \`--calcite-color-surface-4\` instead */
+  --calcite-color-foreground-2: #f2f2f2; /** Deprecated, use \`--calcite-color-surface-3\` instead */
+  --calcite-color-foreground-1: #ffffff; /** Deprecated, use \`--calcite-color-surface-2\` instead */
   --calcite-color-background-none: rgba(255, 255, 255, 0);
-  --calcite-color-background: #f7f7f7;
+  --calcite-color-background: #f7f7f7; /** Deprecated, use \`--calcite-color-surface-1\` instead */
+  --calcite-color-surface-highlight: #d6efff;
+  --calcite-color-surface-4: #ebebeb;
+  --calcite-color-surface-3: #f2f2f2;
+  --calcite-color-surface-2: #ffffff;
+  --calcite-color-surface-1: #f7f7f7;
   --calcite-color-focus: var(--calcite-color-brand);
 }
 @mixin calcite-mode-dark {
@@ -35836,13 +36032,17 @@ exports[`generated tokens > SCSS > index should match 1`] = `
   --calcite-color-transparent-press: rgba(255, 255, 255, 0.16);
   --calcite-color-transparent-hover: rgba(255, 255, 255, 0.12);
   --calcite-color-transparent: rgba(255, 255, 255, 0);
-  --calcite-color-surface-highlight: #2b465f;
   --calcite-color-foreground-current: #2b465f; /** deprecated, use --calcite-color-surface-highlight instead */
-  --calcite-color-foreground-3: #404040;
-  --calcite-color-foreground-2: #363636;
-  --calcite-color-foreground-1: #2b2b2b;
+  --calcite-color-foreground-3: #404040; /** Deprecated, use \`--calcite-color-surface-4\` instead */
+  --calcite-color-foreground-2: #363636; /** Deprecated, use \`--calcite-color-surface-3\` instead */
+  --calcite-color-foreground-1: #2b2b2b; /** Deprecated, use \`--calcite-color-surface-2\` instead */
   --calcite-color-background-none: rgba(255, 255, 255, 0);
-  --calcite-color-background: #212121;
+  --calcite-color-background: #212121; /** Deprecated, use \`--calcite-color-surface-1\` instead */
+  --calcite-color-surface-highlight: #2b465f;
+  --calcite-color-surface-4: #404040;
+  --calcite-color-surface-3: #363636;
+  --calcite-color-surface-2: #2b2b2b;
+  --calcite-color-surface-1: #212121;
   --calcite-color-focus: var(--calcite-color-brand);
 }
 "
@@ -35853,13 +36053,17 @@ exports[`generated tokens > SCSS > light should match 1`] = `
 // Calcite Design System
 // Do not edit directly, this file was auto-generated.
 
-$calcite-color-background: #f7f7f7;
-$calcite-color-background-none: rgba(255, 255, 255, 0);
-$calcite-color-foreground-1: #ffffff;
-$calcite-color-foreground-2: #f2f2f2;
-$calcite-color-foreground-3: #ebebeb;
-$calcite-color-foreground-current: #d6efff; // deprecated, use --calcite-color-surface-highlight instead
+$calcite-color-surface-1: #f7f7f7;
+$calcite-color-surface-2: #ffffff;
+$calcite-color-surface-3: #f2f2f2;
+$calcite-color-surface-4: #ebebeb;
 $calcite-color-surface-highlight: #d6efff;
+$calcite-color-background: #f7f7f7; // Deprecated, use \`--calcite-color-surface-1\` instead
+$calcite-color-background-none: rgba(255, 255, 255, 0);
+$calcite-color-foreground-1: #ffffff; // Deprecated, use \`--calcite-color-surface-2\` instead
+$calcite-color-foreground-2: #f2f2f2; // Deprecated, use \`--calcite-color-surface-3\` instead
+$calcite-color-foreground-3: #ebebeb; // Deprecated, use \`--calcite-color-surface-4\` instead
+$calcite-color-foreground-current: #d6efff; // deprecated, use --calcite-color-surface-highlight instead
 $calcite-color-transparent: rgba(0, 0, 0, 0);
 $calcite-color-transparent-hover: rgba(0, 0, 0, 0.04);
 $calcite-color-transparent-press: rgba(0, 0, 0, 0.08);


### PR DESCRIPTION
**Related Issue:** #10023

## Summary

Added to light and dark mode:
- `--calcite-color-surface-1`
  - light-mode references: `--calcite-color-neutral-blk-005`
  - dark-mode references: `--calcite-color-neutral-blk-210`
- `--calcite-color-surface-2`
  - light-mode references: `--calcite-color-neutral-blk-000`
  - dark-mode references: `--calcite-color-neutral-blk-200`
- `--calcite-color-surface-3`
  - light-mode references: `--calcite-color-neutral-blk-010`
  - dark-mode references: `--calcite-color-neutral-blk-190`
- `--calcite-color-surface-4`
  - light-mode references: `--calcite-color-neutral-blk-020`
  - dark-mode references: `--calcite-color-neutral-blk-180`

Deprecated from light and dark mode:
- `--calcite-color-background`   `// Deprecated, use --calcite-color-surface-1 instead.`
- `--calcite-color-foreground-1`   `// Deprecated, use --calcite-color-surface-2 instead.`
- `--calcite-color-foreground-2`   `// Deprecated, use --calcite-color-surface-3 instead.`
- `--calcite-color-foreground-3`   `// Deprecated, use --calcite-color-surface-4 instead.`