### PR TITLE
fix(action): remove text color change for loading state

### DIFF
--- a/packages/components/src/components/action/action.scss
+++ b/packages/components/src/components/action/action.scss
@@ -200,10 +200,6 @@
     }
   }
 
-  .text-container {
-    @apply opacity-disabled;
-  }
-
   calcite-loader[inline] {
     margin-inline-end: theme("spacing.0");
   }

--- a/packages/components/src/components/action/action.stories.ts
+++ b/packages/components/src/components/action/action.stories.ts
@@ -85,26 +85,38 @@ export const simple = (args: ActionStoryArgs): string => html`
 export const disabledAndTextOnly_TestOnly = (): string => html`
   <div>
     <calcite-action
-      icon="banana"
       alignment="start"
       appearance="solid"
-      label="Label"
-      scale="m"
       disabled
-      text="Text"
+      icon="banana"
       text-enabled
+      text="Text"
     ></calcite-action>
     <calcite-action
       active
-      icon="banana"
       alignment="start"
       appearance="solid"
-      label="Label"
-      scale="m"
       disabled
-      text="Text"
+      icon="banana"
       text-enabled
+      text="Text"
     ></calcite-action>
+    <calcite-action
+      alignment="start"
+      appearance="solid"
+      disabled
+      icon="banana"
+      loading
+      text-enabled
+      text="Text"
+    ></calcite-action>
+  </div>
+`;
+
+export const loading = (): string => html`
+  <div>
+    <calcite-action icon="banana" loading text-enabled text="Text"></calcite-action>
+    <calcite-action active icon="banana" loading text-enabled text="Text"></calcite-action>
   </div>
 `;
 


### PR DESCRIPTION
**Related Issue:** #12601

## Summary

Removes unintentional text styling when `loading=true`.

**Note**: removes redundant attributes in updated story.