### PR TITLE
test: add screenshot story for floating-ui elements in both directions

### DIFF
--- a/packages/components/.storybook/decorators/body-dir-reset.ts
+++ b/packages/components/.storybook/decorators/body-dir-reset.ts
@@ -1,0 +1,10 @@
+import type { Decorator } from "@storybook/html";
+
+/**
+ * Ensures that the `dir` attribute on the body is always reset between stories.
+ * Some stories may set it to "rtl" for testing purposes.
+ */
+export const bodyDirReset: Decorator = (story) => {
+  document.body.removeAttribute("dir");
+  return story();
+};

--- a/packages/components/.storybook/decorators/theme.ts
+++ b/packages/components/.storybook/decorators/theme.ts
@@ -1,0 +1,11 @@
+import { withThemeByClassName } from "@storybook/addon-themes";
+import { CSS_UTILITY } from "../../src/utils/resources";
+
+export const theme = withThemeByClassName({
+  themes: {
+    auto: CSS_UTILITY.autoMode,
+    light: CSS_UTILITY.lightMode,
+    dark: CSS_UTILITY.darkMode,
+  },
+  defaultTheme: "light",
+});

--- a/packages/components/.storybook/preview.ts
+++ b/packages/components/.storybook/preview.ts
@@ -1,6 +1,7 @@
-import { themeDecorator } from "./utils";
+import { theme } from "./decorators/theme";
+import { bodyDirReset } from "./decorators/body-dir-reset";
 
-export const decorators = [themeDecorator];
+export const decorators = [bodyDirReset, theme];
 
 export const parameters = {
   a11y: {

--- a/packages/components/.storybook/utils.ts
+++ b/packages/components/.storybook/utils.ts
@@ -1,17 +1,6 @@
-import { withThemeByClassName } from "@storybook/addon-themes";
-import { CSS_UTILITY } from "../src/utils/resources";
 import { Scale } from "../src/components/interfaces";
 import { html } from "../support/formatting";
 import { Breakpoints } from "../src/utils/responsive";
-
-export const themeDecorator = withThemeByClassName({
-  themes: {
-    auto: CSS_UTILITY.autoMode,
-    light: CSS_UTILITY.lightMode,
-    dark: CSS_UTILITY.darkMode,
-  },
-  defaultTheme: "light",
-});
 
 export const modesDarkDefault = {
   themeOverride: "dark",

--- a/packages/components/src/floating-ui.stories.ts
+++ b/packages/components/src/floating-ui.stories.ts
@@ -2,6 +2,11 @@ import { html } from "../support/formatting";
 
 export default {
   title: "Components/Floating UI/Open",
+  parameters: {
+    chromatic: {
+      delay: 1000,
+    },
+  },
 };
 
 const template = html`

--- a/packages/components/src/floating-ui.stories.ts
+++ b/packages/components/src/floating-ui.stories.ts
@@ -1,0 +1,50 @@
+import { html } from "../support/formatting";
+
+export default {
+  title: "Components/Floating UI/Open",
+};
+
+const template = html`
+  <div style="display: flex; flex-direction: row; gap: 80px;">
+    <calcite-dropdown width="m" open>
+      <calcite-button slot="trigger">Dropdown</calcite-button>
+      <calcite-dropdown-group group-title="Options">
+        <calcite-dropdown-item>A</calcite-dropdown-item>
+        <calcite-dropdown-item>B</calcite-dropdown-item>
+        <calcite-dropdown-item>C</calcite-dropdown-item>
+      </calcite-dropdown-group>
+    </calcite-dropdown>
+
+    <div>
+      <calcite-link id="tooltip-button">Tooltip</calcite-link>
+      <calcite-tooltip reference-element="tooltip-button" placement="bottom-end" open>
+        <span>Test</span>
+      </calcite-tooltip>
+    </div>
+
+    <calcite-popover heading="Popover" reference-element="popover-button" closable open placement="bottom-start">
+      <p>content</p>
+    </calcite-popover>
+    <calcite-button id="popover-button">Popover trigger</calcite-button>
+  </div>
+`;
+
+export const ltrPositioning = (): HTMLElement => {
+  const container = document.createElement("div");
+  container.innerHTML = template;
+
+  return container;
+};
+
+export const rtlPositioning = (): HTMLElement => {
+  const container = document.createElement("div");
+  container.innerHTML = template;
+
+  /*
+   * setting body-level dir for better coverage (e.g., https://github.com/Esri/calcite-design-system/issues/13388)
+   * note: this will be reset by the bodyDirReset global decorator
+   */
+  document.body.dir = "rtl";
+
+  return container;
+};

--- a/packages/components/src/floating-ui.stories.ts
+++ b/packages/components/src/floating-ui.stories.ts
@@ -2,11 +2,6 @@ import { html } from "../support/formatting";
 
 export default {
   title: "Components/Floating UI/Open",
-  parameters: {
-    chromatic: {
-      delay: 1000,
-    },
-  },
 };
 
 const template = html`

--- a/packages/components/src/floating-ui.stories.ts
+++ b/packages/components/src/floating-ui.stories.ts
@@ -20,12 +20,14 @@ const template = html`
       </calcite-dropdown-group>
     </calcite-dropdown>
 
-    <div>
-      <calcite-link id="tooltip-button">Tooltip</calcite-link>
-      <calcite-tooltip reference-element="tooltip-button" placement="bottom-end" open>
-        <span>Test</span>
-      </calcite-tooltip>
-    </div>
+    <br />
+
+    <calcite-link id="tooltip-button">Tooltip</calcite-link>
+    <calcite-tooltip reference-element="tooltip-button" placement="bottom-end" open>
+      <span>Test</span>
+    </calcite-tooltip>
+
+    <br />
 
     <calcite-popover heading="Popover" reference-element="popover-button" closable open placement="bottom-start">
       <p>content</p>
@@ -41,6 +43,10 @@ export const ltrPositioning = (): HTMLElement => {
   return container;
 };
 
+ltrPositioning.globals = {
+  addonRtl: "ltr",
+};
+
 export const rtlPositioning = (): HTMLElement => {
   const container = document.createElement("div");
   container.innerHTML = template;
@@ -52,4 +58,8 @@ export const rtlPositioning = (): HTMLElement => {
   document.body.dir = "rtl";
 
   return container;
+};
+
+rtlPositioning.globals = {
+  addonRtl: "rtl",
 };


### PR DESCRIPTION
**Related Issue:** #13388

## Summary

Adds screenshot coverage missing from https://github.com/Esri/calcite-design-system/pull/13489.

### Notes

* the repro case depends on setting `dir="rtl"` on `<body>` and not the story container
* `<body>` `dir` is reset it via a global decorator
* adds `decorator` dir for Storybook and houses currently used decorators
