### PR TITLE
feat(tile): fix excess margins with headingLevel property

### DIFF
--- a/packages/components/.stylelintrc.cjs
+++ b/packages/components/.stylelintrc.cjs
@@ -1,7 +1,10 @@
 // @ts-check
 
 // ⚠️ AUTO-GENERATED CODE - DO NOT EDIT
-const customFunctions = ["get-trailing-text-input-padding", "scale-duration"];
+const customFunctions = [
+  "get-trailing-text-input-padding",
+  "scale-duration"
+];
 // ⚠️ END OF AUTO-GENERATED CODE
 
 const scssPatternRules = [

--- a/packages/components/src/components/tile/tile.scss
+++ b/packages/components/src/components/tile/tile.scss
@@ -92,6 +92,7 @@ calcite-link {
 }
 
 .heading {
+  @apply m-0 p-0;
   color: var(--calcite-tile-heading-text-color, var(--calcite-color-text-2));
   font-weight: var(--calcite-font-weight-medium);
   line-height: 1.20313rem;

--- a/packages/components/src/components/tile/tile.stories.ts
+++ b/packages/components/src/components/tile/tile.stories.ts
@@ -51,6 +51,60 @@ export const simple = (args: TileStoryArgs): string => html`
   </calcite-tile>
 `;
 
+export const headingLevelAllScales = (): string => html`
+  <style>
+    .container {
+      display: flex;
+      gap: 25px;
+    }
+
+    .scale-container {
+      display: flex;
+      flex-direction: column;
+    }
+  </style>
+  <div class="container">
+    <div class="scale-container">
+      <h2>Small</h2>
+      <calcite-tile-group scale="s" layout="vertical">
+        <calcite-tile heading="No Heading Level" description="Description for item"></calcite-tile>
+        <calcite-tile heading="Heading Level = 1" heading-level="1" description="Description for item"></calcite-tile>
+        <calcite-tile heading="Heading Level = 2" heading-level="2" description="Description for item"></calcite-tile>
+        <calcite-tile heading="Heading Level = 3" heading-level="3" description="Description for item"></calcite-tile>
+        <calcite-tile heading="Heading Level = 4" heading-level="4" description="Description for item"></calcite-tile>
+        <calcite-tile heading="Heading Level = 5" heading-level="5" description="Description for item"></calcite-tile>
+        <calcite-tile heading="Heading Level = 6" heading-level="6" description="Description for item"></calcite-tile>
+      </calcite-tile-group>
+    </div>
+
+    <div class="scale-container">
+      <h2>Medium</h2>
+      <calcite-tile-group scale="m" layout="vertical">
+        <calcite-tile heading="No Heading Level" description="Description for item"></calcite-tile>
+        <calcite-tile heading="Heading Level = 1" heading-level="1" description="Description for item"></calcite-tile>
+        <calcite-tile heading="Heading Level = 2" heading-level="2" description="Description for item"></calcite-tile>
+        <calcite-tile heading="Heading Level = 3" heading-level="3" description="Description for item"></calcite-tile>
+        <calcite-tile heading="Heading Level = 4" heading-level="4" description="Description for item"></calcite-tile>
+        <calcite-tile heading="Heading Level = 5" heading-level="5" description="Description for item"></calcite-tile>
+        <calcite-tile heading="Heading Level = 6" heading-level="6" description="Description for item"></calcite-tile>
+      </calcite-tile-group>
+    </div>
+
+    <div class="scale-container">
+      <h2>Large</h2>
+      <calcite-tile-group scale="l" layout="vertical">
+        <calcite-tile heading="No Heading Level" description="Description for item"></calcite-tile>
+        <calcite-tile heading="Heading Level = 1" heading-level="1" description="Description for item"></calcite-tile>
+        <calcite-tile heading="Heading Level = 2" heading-level="2" description="Description for item"></calcite-tile>
+        <calcite-tile heading="Heading Level = 3" heading-level="3" description="Description for item"></calcite-tile>
+        <calcite-tile heading="Heading Level = 4" heading-level="4" description="Description for item"></calcite-tile>
+        <calcite-tile heading="Heading Level = 5" heading-level="5" description="Description for item"></calcite-tile>
+        <calcite-tile heading="Heading Level = 6" heading-level="6" description="Description for item"></calcite-tile>
+      </calcite-tile-group>
+    </div>
+  </div>
+`;
+
 export const allVariants = (): string => html`
   <style>
     .parent {


### PR DESCRIPTION
**Related Issue:** #12460 

## Summary
This PR is to address the issue found during verification of #12460 ([verification comment](https://github.com/Esri/calcite-design-system/issues/12460#issuecomment-3667861071)).
- Fix excess margins when using the new `headingLevel` property
- Adds screenshot test to catch any regression