### PR TITLE
chore: improve demo snippet util

### DIFF
--- a/packages/components-snippets/cli.ts
+++ b/packages/components-snippets/cli.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
+import type { Dirent } from "node:fs";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 import select from "@inquirer/select";
@@ -356,7 +357,15 @@ async function run(): Promise<void> {
   console.log(`Updated ${indexHtmlPath} with snippet(s) from ${selectedComponentName}: ${snippetNames.join(", ")}`);
 }
 
-run().catch((error) => {
+try {
+  await run();
+} catch (error) {
+  const userCancelled = error && typeof error === "object" && "name" in error && error.name === "ExitPromptError";
+
+  if (userCancelled) {
+    process.exit(130);
+  }
+
   console.error(error);
   process.exit(1);
-});
+}

--- a/packages/components/index.html
+++ b/packages/components/index.html
@@ -9,8 +9,12 @@
 
   <body>
     <demo-dom-swapper>
+      <!-- demo snippet start -->
+
       <!-- use this page for quickly setting up your page for a bug fix/repro cases or feature enhancement -->
-      <!-- demo snippet start --><!-- demo snippet end -->
+      <!-- you can add a demo snippet by running `npx snippet` -->
+
+      <!-- demo snippet end -->
     </demo-dom-swapper>
     <demo-options></demo-options>
   </body>


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Improves `components-snippets` CLI util by:

* gracefully handling user cancellation (`Ctrl+C`)
* adding more context to demo snippet destination (`components/index.html`)