### PR TITLE
feat(shell-panel): improve layout and height functionalities for float all display mode

### DIFF
--- a/packages/components/.stylelintrc.cjs
+++ b/packages/components/.stylelintrc.cjs
@@ -1,7 +1,10 @@
 // @ts-check
 
 // ⚠️ AUTO-GENERATED CODE - DO NOT EDIT
-const customFunctions = ["get-trailing-text-input-padding", "scale-duration"];
+const customFunctions = [
+  "get-trailing-text-input-padding",
+  "scale-duration"
+];
 // ⚠️ END OF AUTO-GENERATED CODE
 
 const scssPatternRules = [

--- a/packages/components/.stylelintrc.cjs
+++ b/packages/components/.stylelintrc.cjs
@@ -1,10 +1,7 @@
 // @ts-check
 
 // ⚠️ AUTO-GENERATED CODE - DO NOT EDIT
-const customFunctions = [
-  "get-trailing-text-input-padding",
-  "scale-duration"
-];
+const customFunctions = ["get-trailing-text-input-padding", "scale-duration"];
 // ⚠️ END OF AUTO-GENERATED CODE
 
 const scssPatternRules = [

--- a/packages/components/src/components/shell-panel/shell-panel.scss
+++ b/packages/components/src/components/shell-panel/shell-panel.scss
@@ -126,6 +126,21 @@
   --calcite-internal-shell-panel-max-height: var(--calcite-shell-panel-max-height, 40vh);
 }
 
+:host([display-mode="float-all"][height="s"]),
+:host([display-mode="float-all"][height-scale="s"]) .content {
+  block-size: var(--calcite-shell-panel-height, 20vh);
+}
+
+:host([display-mode="float-all"][height="m"]),
+:host([display-mode="float-all"][height-scale="m"]) .content {
+  block-size: var(--calcite-shell-panel-height, 30vh);
+}
+
+:host([display-mode="float-all"][height="l"]),
+:host([display-mode="float-all"][height-scale="l"]) .content {
+  block-size: var(--calcite-shell-panel-height, 40vh);
+}
+
 .container {
   @apply text-n1
   pointer-events-none
@@ -149,7 +164,6 @@
 }
 
 .float-all {
-  min-block-size: var(--calcite-internal-shell-panel-min-height);
   max-block-size: var(--calcite-internal-shell-panel-max-height, calc(100% - 1rem));
   box-shadow: var(--calcite-shell-panel-shadow, var(--calcite-shadow-sm));
   border-radius: var(--calcite-shell-panel-corner-radius, var(--calcite-corner-radius-round));

--- a/packages/components/src/components/shell/shell.stories.ts
+++ b/packages/components/src/components/shell/shell.stories.ts
@@ -2892,6 +2892,35 @@ export const embeddedSlotsInteractive = (args: ShellSlottedElementsStoryArgs): s
   </calcite-shell>
 `;
 
+export const floatAllHeights = (): string => html`
+  <h3>layout="vertical" & display-mode="float-all" & height="s"</h3>
+  <div style="position:relative; height: 180px">
+    <calcite-shell>
+      <calcite-shell-panel layout="vertical" display-mode="float-all" height="s">
+        <calcite-panel heading="Example" description="example" closable> </calcite-panel>
+      </calcite-shell-panel>
+    </calcite-shell>
+  </div>
+  <br />
+  <h3>layout="horizontal" & display-mode="float-all" & height-scale="m"</h3>
+  <div style="position:relative; height: 280px">
+    <calcite-shell>
+      <calcite-shell-panel layout="horizontal" display-mode="float-all" height-scale="m">
+        <calcite-panel heading="Example" description="example" closable> </calcite-panel>
+      </calcite-shell-panel>
+    </calcite-shell>
+  </div>
+  <br/ >
+  <h3>layout="vertical" & display-mode="float-all" & height="l"</h3>
+  <div style="position:relative; height: 350px">
+    <calcite-shell>
+      <calcite-shell-panel layout="vertical" display-mode="float-all" height="l">
+        <calcite-panel heading="Example" description="example" closable> </calcite-panel>
+      </calcite-shell-panel>
+    </calcite-shell>
+  </div>
+`;
+
 embeddedSlotsInteractive.args = {
   dialogPlacement: "center",
   dialogHeight: "300px",


### PR DESCRIPTION
**Related Issue:** [#13448](https://github.com/Esri/calcite-design-system/issues/13448)

## Summary
When `layout="vertical/horizontal"` and `display-mode="float-all"`, adjust component's height based on `height/height-scale="s/m/l"`.
