### PR TITLE
fix(action-group): skip ARIA attributes when selectionMode is `none`

### DIFF
--- a/packages/components/src/components/action-group/action-group.browser.e2e.tsx
+++ b/packages/components/src/components/action-group/action-group.browser.e2e.tsx
@@ -1,6 +1,7 @@
 import { h } from "@arcgis/lumina";
-import { describe } from "vitest";
+import { describe, it, expect } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
+import { userEvent } from "vitest/browser";
 import {
   defaults,
   reflects,
@@ -91,5 +92,32 @@ describe("calcite-action-group", () => {
 
   describe("translation support", () => {
     t9n(() => mount("calcite-action-group"));
+  });
+
+  describe("actions have no ARIA attributes when selectionMode is 'none'", () => {
+    it("does not activate actions or set ARIA attributes", async () => {
+      const { el } = await mount<"calcite-action-group">(
+        <calcite-action-group selection-mode="none">
+          <calcite-action icon="plus" text="Add" />
+          <calcite-action icon="save" text="Save" />
+        </calcite-action-group>,
+      );
+
+      const [action1, action2] = el.querySelectorAll("calcite-action");
+
+      await userEvent.click(action1);
+      expect(action1.active).toBe(false);
+      expect(action2.active).toBe(false);
+
+      await userEvent.click(action2);
+      expect(action1.active).toBe(false);
+      expect(action2.active).toBe(false);
+
+      expect(action1.getAttribute("aria-checked")).toBeNull();
+      expect(action1.getAttribute("role")).toBeNull();
+
+      expect(action2.getAttribute("aria-checked")).toBeNull();
+      expect(action2.getAttribute("role")).toBeNull();
+    });
   });
 });

--- a/packages/components/src/components/action-group/action-group.tsx
+++ b/packages/components/src/components/action-group/action-group.tsx
@@ -57,7 +57,7 @@ export class ActionGroup extends LitElement {
   private focusSetter = useSetFocus<this>()(this);
 
   @queryAssignedElements({ selector: "calcite-action" })
-  private actions: Action["el"][];
+  private actions!: Action["el"][];
 
   //#endregion
 
@@ -158,7 +158,6 @@ export class ActionGroup extends LitElement {
   constructor() {
     super();
     this.listen("click", this.handleActionClick);
-    this.setRoleOnActions();
   }
 
   override willUpdate(changes: PropertyValues<this>): void {
@@ -238,18 +237,16 @@ export class ActionGroup extends LitElement {
   }
 
   private setRoleOnActions(): void {
-    if (this.selectionMode !== "none") {
-      this.actions?.forEach((action) => {
-        action.aria = {
-          ...action.aria,
-          role:
-            this.selectionMode === "single" || this.selectionMode === "single-persist"
-              ? "radio"
-              : "checkbox",
-        };
-        this.setActionAriaChecked(action, action.active);
-      });
-    }
+    this.actions.forEach((action) => {
+      action.aria = {
+        ...action.aria,
+        role:
+          this.selectionMode === "single" || this.selectionMode === "single-persist"
+            ? "radio"
+            : "checkbox",
+      };
+      this.setActionAriaChecked(action, action.active);
+    });
   }
 
   private setActionAriaChecked(action: Action["el"], checked: boolean): void {
@@ -261,10 +258,10 @@ export class ActionGroup extends LitElement {
 
   private clearActionAriaAttributes(): void {
     if (this.selectionMode === "none") {
-      this.actions?.forEach((action) => {
+      this.actions.forEach((action) => {
         if (action.aria) {
-          delete action.aria.checked;
-          delete action.aria.role;
+          action.aria.checked = undefined;
+          action.aria.role = undefined;
           action.aria = { ...action.aria };
         }
       });

--- a/packages/components/src/components/action-group/action-group.tsx
+++ b/packages/components/src/components/action-group/action-group.tsx
@@ -168,7 +168,11 @@ export class ActionGroup extends LitElement {
     Docs: https://webgis.esri.com/arcgis-components/?path=/docs/lumina-transition-from-stencil--docs#watching-for-property-changes */
 
     if (this.hasUpdated || changes.has("selectionMode")) {
-      this.setRoleOnActions();
+      if (this.selectionMode !== "none") {
+        this.setRoleOnActions();
+      } else if (this.selectionMode === "none") {
+        this.clearActionAriaAttributes();
+      }
     }
 
     if (changes.has("expanded")) {
@@ -234,16 +238,18 @@ export class ActionGroup extends LitElement {
   }
 
   private setRoleOnActions(): void {
-    this.actions?.forEach((action) => {
-      action.aria = {
-        ...action.aria,
-        role:
-          this.selectionMode === "single" || this.selectionMode === "single-persist"
-            ? "radio"
-            : "checkbox",
-      };
-      this.setActionAriaChecked(action, action.active);
-    });
+    if (this.selectionMode !== "none") {
+      this.actions?.forEach((action) => {
+        action.aria = {
+          ...action.aria,
+          role:
+            this.selectionMode === "single" || this.selectionMode === "single-persist"
+              ? "radio"
+              : "checkbox",
+        };
+        this.setActionAriaChecked(action, action.active);
+      });
+    }
   }
 
   private setActionAriaChecked(action: Action["el"], checked: boolean): void {
@@ -251,6 +257,18 @@ export class ActionGroup extends LitElement {
       ...action.aria,
       checked: checked ? "true" : "false",
     };
+  }
+
+  private clearActionAriaAttributes(): void {
+    if (this.selectionMode === "none") {
+      this.actions?.forEach((action) => {
+        if (action.aria) {
+          delete action.aria.checked;
+          delete action.aria.role;
+          action.aria = { ...action.aria };
+        }
+      });
+    }
   }
 
   //#endregion


### PR DESCRIPTION
**Related Issue:** [#13483](https://github.com/Esri/calcite-design-system/issues/13483)

## Summary
Removes ARIA attributes from actions and prevents setting them when selectionMode is "none".