### PR TITLE
fix(action): allow background color to be changed with transparent appearance

### DIFF
--- a/packages/components/src/components/action/action.e2e.ts
+++ b/packages/components/src/components/action/action.e2e.ts
@@ -233,6 +233,24 @@ describe("calcite-action", () => {
   });
 
   describe("themed", () => {
+    describe("transparent", () => {
+      themed(html`<calcite-action appearance="transparent"></calcite-action>`, {
+        "--calcite-action-background-color": {
+          shadowSelector: `.${CSS.button}`,
+          targetProp: "backgroundColor",
+        },
+        "--calcite-action-background-color-hover": {
+          shadowSelector: `.${CSS.button}`,
+          targetProp: "backgroundColor",
+          state: "hover",
+        },
+        "--calcite-action-background-color-press": {
+          shadowSelector: `.${CSS.button}`,
+          targetProp: "backgroundColor",
+          state: { press: { attribute: "class", value: CSS.button } },
+        },
+      });
+    });
     describe("solid", () => {
       themed(html`<calcite-action appearance="solid"></calcite-action>`, {
         "--calcite-action-background-color": {

--- a/packages/components/src/components/action/action.e2e.ts
+++ b/packages/components/src/components/action/action.e2e.ts
@@ -11,7 +11,6 @@ describe("calcite-action", () => {
       "--calcite-action-background-color": {
         shadowSelector: `.${CSS.button}`,
         targetProp: "backgroundColor",
-        expectedValue: "rgba(0, 0, 0, 0)",
       },
       "--calcite-action-background-color-hover": {
         shadowSelector: `.${CSS.button}`,

--- a/packages/components/src/components/action/action.e2e.ts
+++ b/packages/components/src/components/action/action.e2e.ts
@@ -6,30 +6,6 @@ import { html } from "../../../support/formatting";
 import { CSS } from "./resources";
 
 describe("calcite-action", () => {
-  describe("default", () => {
-    themed(html`calcite-action`, {
-      "--calcite-action-background-color": {
-        shadowSelector: `.${CSS.button}`,
-        targetProp: "backgroundColor",
-      },
-      "--calcite-action-background-color-hover": {
-        shadowSelector: `.${CSS.button}`,
-        targetProp: "backgroundColor",
-        state: "hover",
-      },
-      "--calcite-action-background-color-pressed": {
-        shadowSelector: `.${CSS.button}`,
-        targetProp: "backgroundColor",
-        state: { press: { attribute: "class", value: CSS.button } },
-      },
-      "--calcite-action-background-color-press": {
-        shadowSelector: `.${CSS.button}`,
-        targetProp: "backgroundColor",
-        state: { press: { attribute: "class", value: CSS.button } },
-      },
-    });
-  });
-
   describe("aria property", () => {
     it("should set aria properties on internal button element", async () => {
       const page = await newE2EPage();
@@ -232,8 +208,8 @@ describe("calcite-action", () => {
   });
 
   describe("themed", () => {
-    describe("transparent", () => {
-      themed(html`<calcite-action appearance="transparent"></calcite-action>`, {
+    describe("background color", () => {
+      themed(html`<calcite-action></calcite-action>`, {
         "--calcite-action-background-color": {
           shadowSelector: `.${CSS.button}`,
           targetProp: "backgroundColor",
@@ -250,25 +226,7 @@ describe("calcite-action", () => {
         },
       });
     });
-    describe("solid", () => {
-      themed(html`<calcite-action appearance="solid"></calcite-action>`, {
-        "--calcite-action-background-color": {
-          shadowSelector: `.${CSS.button}`,
-          targetProp: "backgroundColor",
-        },
-        "--calcite-action-background-color-hover": {
-          shadowSelector: `.${CSS.button}`,
-          targetProp: "backgroundColor",
-          state: "hover",
-        },
-        "--calcite-action-background-color-press": {
-          shadowSelector: `.${CSS.button}`,
-          targetProp: "backgroundColor",
-          state: { press: { attribute: "class", value: CSS.button } },
-        },
-      });
-    });
-    describe("text", () => {
+    describe("text color", () => {
       themed(
         html`<calcite-action
           scale="s"
@@ -363,7 +321,12 @@ describe("calcite-action", () => {
       });
     });
     describe("deprecated", () => {
-      themed(html`<calcite-action appearance="solid"></calcite-action>`, {
+      themed(html`<calcite-action appearance="transparent"></calcite-action>`, {
+        "--calcite-action-background-color-pressed": {
+          shadowSelector: `.${CSS.button}`,
+          targetProp: "backgroundColor",
+          state: { press: { attribute: "class", value: CSS.button } },
+        },
         "--calcite-action-corner-radius-end-end": [
           {
             shadowSelector: `.${CSS.button}`,
@@ -489,10 +452,151 @@ describe("calcite-action", () => {
           targetProp: "color",
           state: "hover",
         },
+      });
+      themed(html`<calcite-action appearance="solid"></calcite-action>`, {
+        "--calcite-action-background-color": {
+          shadowSelector: `.${CSS.button}`,
+          targetProp: "backgroundColor",
+        },
+        "--calcite-action-background-color-hover": {
+          shadowSelector: `.${CSS.button}`,
+          targetProp: "backgroundColor",
+          state: "hover",
+        },
+        "--calcite-action-background-color-press": {
+          shadowSelector: `.${CSS.button}`,
+          targetProp: "backgroundColor",
+          state: { press: { attribute: "class", value: CSS.button } },
+        },
         "--calcite-action-background-color-pressed": {
           shadowSelector: `.${CSS.button}`,
           targetProp: "backgroundColor",
           state: { press: { attribute: "class", value: CSS.button } },
+        },
+        "--calcite-action-corner-radius-end-end": [
+          {
+            shadowSelector: `.${CSS.button}`,
+            targetProp: "borderEndEndRadius",
+          },
+          {
+            targetProp: "borderEndEndRadius",
+          },
+          {
+            shadowSelector: `.${CSS.button}`,
+            targetProp: "borderEndStartRadius",
+          },
+          {
+            targetProp: "borderEndStartRadius",
+          },
+          {
+            shadowSelector: `.${CSS.button}`,
+            targetProp: "borderStartEndRadius",
+          },
+          {
+            targetProp: "borderStartEndRadius",
+          },
+          {
+            shadowSelector: `.${CSS.button}`,
+            targetProp: "borderStartStartRadius",
+          },
+          {
+            targetProp: "borderStartStartRadius",
+          },
+        ],
+        "--calcite-action-corner-radius-end-start": [
+          {
+            shadowSelector: `.${CSS.button}`,
+            targetProp: "borderEndEndRadius",
+          },
+          {
+            targetProp: "borderEndEndRadius",
+          },
+          {
+            shadowSelector: `.${CSS.button}`,
+            targetProp: "borderEndStartRadius",
+          },
+          {
+            targetProp: "borderEndStartRadius",
+          },
+          {
+            shadowSelector: `.${CSS.button}`,
+            targetProp: "borderStartEndRadius",
+          },
+          {
+            targetProp: "borderStartEndRadius",
+          },
+          {
+            shadowSelector: `.${CSS.button}`,
+            targetProp: "borderStartStartRadius",
+          },
+          {
+            targetProp: "borderStartStartRadius",
+          },
+        ],
+        "--calcite-action-corner-radius-start-end": [
+          {
+            shadowSelector: `.${CSS.button}`,
+            targetProp: "borderEndEndRadius",
+          },
+          {
+            targetProp: "borderEndEndRadius",
+          },
+          {
+            shadowSelector: `.${CSS.button}`,
+            targetProp: "borderEndStartRadius",
+          },
+          {
+            targetProp: "borderEndStartRadius",
+          },
+          {
+            shadowSelector: `.${CSS.button}`,
+            targetProp: "borderStartEndRadius",
+          },
+          {
+            targetProp: "borderStartEndRadius",
+          },
+          {
+            shadowSelector: `.${CSS.button}`,
+            targetProp: "borderStartStartRadius",
+          },
+          {
+            targetProp: "borderStartStartRadius",
+          },
+        ],
+        "--calcite-action-corner-radius-start-start": [
+          {
+            shadowSelector: `.${CSS.button}`,
+            targetProp: "borderEndEndRadius",
+          },
+          {
+            targetProp: "borderEndEndRadius",
+          },
+          {
+            shadowSelector: `.${CSS.button}`,
+            targetProp: "borderEndStartRadius",
+          },
+          {
+            targetProp: "borderEndStartRadius",
+          },
+          {
+            shadowSelector: `.${CSS.button}`,
+            targetProp: "borderStartEndRadius",
+          },
+          {
+            targetProp: "borderStartEndRadius",
+          },
+          {
+            shadowSelector: `.${CSS.button}`,
+            targetProp: "borderStartStartRadius",
+          },
+          {
+            targetProp: "borderStartStartRadius",
+          },
+        ],
+        "--calcite-action-text-color-pressed": {
+          shadowSelector: `.${CSS.button}`,
+          targetProp: "color",
+          state: "hover",
         },
       });
     });

--- a/packages/components/src/components/action/action.scss
+++ b/packages/components/src/components/action/action.scss
@@ -214,9 +214,10 @@
   }
 
   .button {
-    @apply bg-transparent
-      transition-shadow
+    @apply transition-shadow
       ease-in-out;
+
+    background-color: var(--calcite-action-background-color, var(--calcite-color-transparent));
 
     &:hover {
       background-color: var(--calcite-action-background-color-hover, var(--calcite-color-transparent-hover));

--- a/packages/components/src/components/action/action.tsx
+++ b/packages/components/src/components/action/action.tsx
@@ -98,7 +98,11 @@ export class Action extends LitElement implements FormOwner {
   /** Specifies the horizontal alignment of button elements with text content. */
   @property({ reflect: true }) alignment: Alignment;
 
-  /** Specifies the appearance of the component. */
+  /**
+   * Specifies the appearance of the component.
+   *
+   * @deprecated in v5.0.0, removal target v6.0.0 - No longer necessary.
+   */
   @property({ reflect: true }) appearance: Extract<"solid" | "transparent", Appearance> =
     "transparent";
 


### PR DESCRIPTION
**Related Issue:** #13462

## Summary

This PR allows `--calcite-action-background-color` to apply with `appearance="transparent"`.

deprecate(action): deprecate appearance property