### PR TITLE
fix(alert): enable visibilty of `dismiss-progress` element

### DIFF
--- a/packages/components/src/components/alert/alert.scss
+++ b/packages/components/src/components/alert/alert.scss
@@ -71,6 +71,7 @@ $border-style: 1px solid var(--calcite-color-border-3);
     transition:
       opacity var(--calcite-internal-animation-timing-slow) animation.$easing-function,
       all var(--calcite-animation-timing) ease-in-out;
+    overflow: visible;
   }
 
   &--bottom,


### PR DESCRIPTION
**Related Issue:** #13581

## Summary
Adds `overflow: visible` to the Alert's `.container` so the `dismiss-progress` element can be visible. Since the Popover change in #12904, the `dismiss-progress` element is treated as overflowing the `.container` element (since it has rounded corners) and is thus hidden.

There are other potential fixes for this, such as using a box-shadow instead of border, etc., but this is a very simple fix as long as no one sees problems with allowing overflow.

Happy to also look into visual snapshots for this animation if that is reasonable.
