### PR TITLE
fix(alert): disable `dismissProgress` animation when reduced motion preferred

### DIFF
--- a/packages/components/src/components/alert/alert.scss
+++ b/packages/components/src/components/alert/alert.scss
@@ -314,7 +314,7 @@ $alert-durations:
   $duration: list.nth($alert-duration, 2);
 
   :host([auto-close-duration="#{$name}"]) .dismiss-progress:after {
-    animation: dismissProgress $duration ease-out;
+    animation: dismissProgress calc($duration * var(--calcite-internal-duration-factor)) ease-out;
   }
   :host(:hover[auto-close-duration="#{$name}"]) .dismiss-progress:after,
   :host(:focus[auto-close-duration="#{$name}"]) .dismiss-progress:after {


### PR DESCRIPTION
**Related Issue:** #6358

## Summary
Disables the `dismissProgress` animation when reduced motion is preferred by multiplying the animation duration by `--calcite-internal-duration-factor`.
