### PR TITLE
feat(dialog, sheet): add `topLayerDisabled` prop

### DIFF
--- a/packages/components/src/components/alert/alert.tsx
+++ b/packages/components/src/components/alert/alert.tsx
@@ -168,13 +168,6 @@ export class Alert extends LitElement {
   /** Specifies the size of the component. */
   @property({ reflect: true }) scale: Scale = "m";
 
-  /**
-   * When true, disables top layer placement when the component is open.
-   *
-   * @mdn [Top Layer](https://developer.mozilla.org/en-US/docs/Glossary/Top_layer)
-   */
-  @property({ reflect: true }) topLayerDisabled = false;
-
   //#endregion
 
   //#region Public Methods

--- a/packages/components/src/components/alert/alert.tsx
+++ b/packages/components/src/components/alert/alert.tsx
@@ -168,6 +168,13 @@ export class Alert extends LitElement {
   /** Specifies the size of the component. */
   @property({ reflect: true }) scale: Scale = "m";
 
+  /**
+   * When true, disables top layer placement when the component is open.
+   *
+   * @mdn [Top Layer](https://developer.mozilla.org/en-US/docs/Glossary/Top_layer)
+   */
+  @property({ reflect: true }) topLayerDisabled = false;
+
   //#endregion
 
   //#region Public Methods

--- a/packages/components/src/components/dialog/dialog.tsx
+++ b/packages/components/src/components/dialog/dialog.tsx
@@ -241,6 +241,8 @@ export class Dialog extends LitElement {
   /**
    * When true, disables top layer placement when the component is open.
    *
+   * Only set this if you need complex z-index control or if top layer placement causes conflicts with third-party components.
+   *
    * @mdn [Top Layer](https://developer.mozilla.org/en-US/docs/Glossary/Top_layer)
    */
   @property({ reflect: true }) topLayerDisabled = false;

--- a/packages/components/src/components/dialog/dialog.tsx
+++ b/packages/components/src/components/dialog/dialog.tsx
@@ -239,6 +239,13 @@ export class Dialog extends LitElement {
   @property({ reflect: true }) scale: Scale = "m";
 
   /**
+   * When true, disables top layer placement when the component is open.
+   *
+   * @mdn [Top Layer](https://developer.mozilla.org/en-US/docs/Glossary/Top_layer)
+   */
+  @property({ reflect: true }) topLayerDisabled = false;
+
+  /**
    * Specifies the width of the component.
    *
    * @deprecated in v3.0.0, removal target v6.0.0 - Use the `width` property instead.

--- a/packages/components/src/components/sheet/sheet.tsx
+++ b/packages/components/src/components/sheet/sheet.tsx
@@ -217,6 +217,13 @@ export class Sheet extends LitElement {
   /** When `true`, the component is resizable. */
   @property({ reflect: true }) resizable = false;
 
+  /**
+   * When true, disables top layer placement when the component is open.
+   *
+   * @mdn [Top Layer](https://developer.mozilla.org/en-US/docs/Glossary/Top_layer)
+   */
+  @property({ reflect: true }) topLayerDisabled = false;
+
   /** When `position` is `"inline-start"` or `"inline-end"`, specifies the width of the component. */
   /**
    * When `position` is `"inline-start"` or `"inline-end"`, specifies the width of the component.

--- a/packages/components/src/components/sheet/sheet.tsx
+++ b/packages/components/src/components/sheet/sheet.tsx
@@ -220,6 +220,8 @@ export class Sheet extends LitElement {
   /**
    * When true, disables top layer placement when the component is open.
    *
+   * Only set this if you need complex z-index control or if top layer placement causes conflicts with third-party components.
+   *
    * @mdn [Top Layer](https://developer.mozilla.org/en-US/docs/Glossary/Top_layer)
    */
   @property({ reflect: true }) topLayerDisabled = false;

--- a/packages/components/src/controllers/useTopLayer.ts
+++ b/packages/components/src/controllers/useTopLayer.ts
@@ -30,6 +30,8 @@ export interface TopLayerComponent extends LitElement {
   /**
    * When true, disables top layer placement when the component is open.
    *
+   * Only set this if you need complex z-index control or if top layer placement causes conflicts with third-party components.
+   *
    * @mdn [Top Layer](https://developer.mozilla.org/en-US/docs/Glossary/Top_layer)
    */
   topLayerDisabled?: boolean;

--- a/packages/components/src/tests/commonTests/browser/top-layer.ts
+++ b/packages/components/src/tests/commonTests/browser/top-layer.ts
@@ -42,16 +42,26 @@ export async function topLayer(setup: () => ReturnType<typeof mount>, options?: 
 
     const componentOpen = waitForEvent(el, `${getEventPrefix(el)}Open`);
     el[openProp] = true;
-
     await componentOpen;
     await waitForNextTick();
+
     expect(isInTopLayer(topLayerEl)).toBe(true);
 
     const componentClose = waitForEvent(el, `${getEventPrefix(el)}Close`);
     el[openProp] = false;
-
     await componentClose;
     await waitForNextTick();
+
     expect(isInTopLayer(topLayerEl)).toBe(false);
+
+    if ("topLayerDisabled" in el) {
+      const componentOpen = waitForEvent(el, `${getEventPrefix(el)}Open`);
+      el.topLayerDisabled = true;
+      el[openProp] = true;
+      await componentOpen;
+      await waitForNextTick();
+
+      expect(isInTopLayer(topLayerEl)).toBe(false);
+    }
   });
 }


### PR DESCRIPTION
**Related Issue:** #13560 

## Summary

Adds prop to opt-out of [top layer](https://developer.mozilla.org/en-US/docs/Glossary/Top_layer) placement when components are open.
