### PR TITLE
feat(autocomplete): add token for max menu height

### DIFF
--- a/packages/components/src/components/autocomplete/autocomplete.e2e.ts
+++ b/packages/components/src/components/autocomplete/autocomplete.e2e.ts
@@ -109,7 +109,7 @@ describe("calcite-autocomplete", () => {
   });
 
   describe("theme", () => {
-    themed("calcite-autocomplete", {
+    themed("<calcite-autocomplete open></calcite-autocomplete>", {
       "--calcite-autocomplete-background-color": {
         shadowSelector: `.${CSS.contentAnimation}`,
         targetProp: "backgroundColor",
@@ -121,6 +121,10 @@ describe("calcite-autocomplete", () => {
       "--calcite-autocomplete-text-color": {
         shadowSelector: `.${CSS.contentAnimation}`,
         targetProp: "color",
+      },
+      "--calcite-autocomplete-menu-max-size-y": {
+        shadowSelector: `.${CSS.contentAnimation}`,
+        targetProp: "maxBlockSize",
       },
       "--calcite-autocomplete-input-prefix-size": {
         shadowSelector: `.${CSS.input}`,

--- a/packages/components/src/components/autocomplete/autocomplete.scss
+++ b/packages/components/src/components/autocomplete/autocomplete.scss
@@ -6,7 +6,7 @@
  * @prop --calcite-autocomplete-background-color: Specifies the background color of the component.
  * @prop --calcite-autocomplete-corner-radius: Specifies the component's corner radius.
  * @prop --calcite-autocomplete-text-color: Specifies the text color of the component.
- * @prop --calcite-autocomplete-menu-max-size-y: Specifies the maximum height of the component.
+ * @prop --calcite-autocomplete-menu-max-size-y: Specifies the maximum height of the component's menu.
  *
  * @prop --calcite-autocomplete-input-prefix-size: Specifies the Input's prefix width, when present.
  * @prop --calcite-autocomplete-input-suffix-size: Specifies the Input's suffix width, when present.

--- a/packages/components/src/components/autocomplete/autocomplete.scss
+++ b/packages/components/src/components/autocomplete/autocomplete.scss
@@ -6,6 +6,7 @@
  * @prop --calcite-autocomplete-background-color: Specifies the background color of the component.
  * @prop --calcite-autocomplete-corner-radius: Specifies the component's corner radius.
  * @prop --calcite-autocomplete-text-color: Specifies the text color of the component.
+ * @prop --calcite-autocomplete-menu-max-size-y: Specifies the maximum height of the component.
  *
  * @prop --calcite-autocomplete-input-prefix-size: Specifies the Input's prefix width, when present.
  * @prop --calcite-autocomplete-input-suffix-size: Specifies the Input's suffix width, when present.
@@ -93,9 +94,9 @@
 @include floating-ui.floating-ui-elem-anim(".floating-ui-container");
 
 .content-container .calcite-floating-ui-anim {
-  @apply max-h-menu
-    overflow-y-auto
+  @apply overflow-y-auto
     w-full;
+  max-block-size: var(--calcite-autocomplete-menu-max-size-y, theme("maxHeight.menu"));
   color: var(--calcite-autocomplete-text-color, var(--calcite-color-text-1));
   background-color: var(--calcite-autocomplete-background-color, var(--calcite-color-foreground-1));
   border-radius: var(--calcite-autocomplete-corner-radius, var(--calcite-corner-radius-round));


### PR DESCRIPTION
**Related Issue:** #13227

## Summary

This PR adds a new CSS custom property token to control the maximum height of the autocomplete component's menu, addressing issue #13227.

- Adds `--calcite-autocomplete-menu-max-size-y` token with fallback to theme's menu max-height
- Refactors menu styling to use CSS custom property instead of Tailwind utility class
- Adds e2e test coverage for the new token


