### PR TITLE
ci: swap deprecated github-status-action with supported alternative

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Skip Chromatic
-        uses: Sibz/github-status-action@v1
+        uses: guibranco/github-status-action-v2@v1
         with:
           authToken: ${{ secrets.GITHUB_TOKEN }}
           context: UI Tests


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Replaces [Sibz/github-status-action](https://github.com/Sibz/github-status-action) with [guibranco/github-status-action-v2](https://github.com/guibranco/github-status-action-v2).