### PR TITLE
fix: ensure top layer placement when open component is reconnected

### DIFF
--- a/packages/components/src/controllers/useTopLayer.browser.spec.tsx
+++ b/packages/components/src/controllers/useTopLayer.browser.spec.tsx
@@ -3,6 +3,7 @@ import { mount } from "@arcgis/lumina-compiler/testing";
 import { h, JsxNode, LitElement, property } from "@arcgis/lumina";
 import { createRef } from "lit/directives/ref.js";
 import { isInTopLayer } from "../tests/utils/dom";
+import { waitForAnimationFrame } from "../tests/utils/timing";
 import { useTopLayer } from "./useTopLayer";
 
 describe("useTopLayer", () => {
@@ -27,15 +28,15 @@ describe("useTopLayer", () => {
 
     const { component } = await mount(Test);
 
-    expect(isInTopLayer(component.overlayRef.value!)).toBe(false);
+    expect(isInTopLayer(component.overlayRef.value)).toBe(false);
 
     await component.topLayer.show();
 
-    expect(isInTopLayer(component.overlayRef.value!)).toBe(true);
+    expect(isInTopLayer(component.overlayRef.value)).toBe(true);
 
     await component.topLayer.hide();
 
-    expect(isInTopLayer(component.overlayRef.value!)).toBe(false);
+    expect(isInTopLayer(component.overlayRef.value)).toBe(false);
   });
 
   it("allows disabling top layer placement", async () => {
@@ -61,35 +62,35 @@ describe("useTopLayer", () => {
 
     const { el, component } = await mount(Test);
 
-    expect(isInTopLayer(component.overlayRef.value!)).toBe(false);
+    expect(isInTopLayer(component.overlayRef.value)).toBe(false);
 
     await component.topLayer.show();
 
-    expect(isInTopLayer(component.overlayRef.value!)).toBe(true);
+    expect(isInTopLayer(component.overlayRef.value)).toBe(true);
 
     await component.topLayer.hide();
 
-    expect(isInTopLayer(component.overlayRef.value!)).toBe(false);
+    expect(isInTopLayer(component.overlayRef.value)).toBe(false);
 
     el.topLayerDisabled = true;
 
     await component.topLayer.show();
 
-    expect(isInTopLayer(component.overlayRef.value!)).toBe(false);
+    expect(isInTopLayer(component.overlayRef.value)).toBe(false);
 
     await component.topLayer.hide();
 
-    expect(isInTopLayer(component.overlayRef.value!)).toBe(false);
+    expect(isInTopLayer(component.overlayRef.value)).toBe(false);
 
     el.topLayerDisabled = false;
 
     await component.topLayer.show();
 
-    expect(isInTopLayer(component.overlayRef.value!)).toBe(true);
+    expect(isInTopLayer(component.overlayRef.value)).toBe(true);
 
     await component.topLayer.hide();
 
-    expect(isInTopLayer(component.overlayRef.value!)).toBe(false);
+    expect(isInTopLayer(component.overlayRef.value)).toBe(false);
   });
 
   it("allows conditionally disabling top layer placement", async () => {
@@ -120,55 +121,55 @@ describe("useTopLayer", () => {
 
     const { component } = await mount(Test);
 
-    expect(isInTopLayer(component.overlayRef.value!)).toBe(false);
+    expect(isInTopLayer(component.overlayRef.value)).toBe(false);
 
     await component.topLayer.show();
 
-    expect(isInTopLayer(component.overlayRef.value!)).toBe(true);
+    expect(isInTopLayer(component.overlayRef.value)).toBe(true);
 
     await component.topLayer.hide();
 
-    expect(isInTopLayer(component.overlayRef.value!)).toBe(false);
+    expect(isInTopLayer(component.overlayRef.value)).toBe(false);
 
     component.someInternalProp = true;
 
     await component.topLayer.show();
 
-    expect(isInTopLayer(component.overlayRef.value!)).toBe(false);
+    expect(isInTopLayer(component.overlayRef.value)).toBe(false);
 
     await component.topLayer.hide();
 
-    expect(isInTopLayer(component.overlayRef.value!)).toBe(false);
+    expect(isInTopLayer(component.overlayRef.value)).toBe(false);
 
     component.someInternalProp = false;
 
     await component.topLayer.show();
 
-    expect(isInTopLayer(component.overlayRef.value!)).toBe(true);
+    expect(isInTopLayer(component.overlayRef.value)).toBe(true);
 
     await component.topLayer.hide();
 
-    expect(isInTopLayer(component.overlayRef.value!)).toBe(false);
+    expect(isInTopLayer(component.overlayRef.value)).toBe(false);
 
     component.topLayerDisabled = true;
 
     await component.topLayer.show();
 
-    expect(isInTopLayer(component.overlayRef.value!)).toBe(false);
+    expect(isInTopLayer(component.overlayRef.value)).toBe(false);
 
     await component.topLayer.hide();
 
-    expect(isInTopLayer(component.overlayRef.value!)).toBe(false);
+    expect(isInTopLayer(component.overlayRef.value)).toBe(false);
 
     component.someInternalProp = true;
 
     await component.topLayer.show();
 
-    expect(isInTopLayer(component.overlayRef.value!)).toBe(false);
+    expect(isInTopLayer(component.overlayRef.value)).toBe(false);
 
     await component.topLayer.hide();
 
-    expect(isInTopLayer(component.overlayRef.value!)).toBe(false);
+    expect(isInTopLayer(component.overlayRef.value)).toBe(false);
   });
 
   it("removes target from top layer when disabled while shown", async () => {
@@ -201,25 +202,25 @@ describe("useTopLayer", () => {
 
     await component.topLayer.show();
 
-    expect(isInTopLayer(component.overlayRef.value!)).toBe(true);
+    expect(isInTopLayer(component.overlayRef.value)).toBe(true);
 
     el.topLayerDisabled = true;
 
     await component.topLayer.show();
 
-    expect(isInTopLayer(component.overlayRef.value!)).toBe(false);
+    expect(isInTopLayer(component.overlayRef.value)).toBe(false);
 
     el.topLayerDisabled = false;
 
     await component.topLayer.show();
 
-    expect(isInTopLayer(component.overlayRef.value!)).toBe(true);
+    expect(isInTopLayer(component.overlayRef.value)).toBe(true);
 
     component.someInternalProp = true;
 
     await component.topLayer.show();
 
-    expect(isInTopLayer(component.overlayRef.value!)).toBe(false);
+    expect(isInTopLayer(component.overlayRef.value)).toBe(false);
   });
 
   it("does not toggle popover API if target element is missing popover attribute", async () => {
@@ -241,14 +242,51 @@ describe("useTopLayer", () => {
 
     const { component } = await mount(Test);
 
-    expect(isInTopLayer(component.overlayRef.value!)).toBe(false);
+    expect(isInTopLayer(component.overlayRef.value)).toBe(false);
 
     await expect(component.topLayer.show()).resolves.toBeUndefined();
 
-    expect(isInTopLayer(component.overlayRef.value!)).toBe(false);
+    expect(isInTopLayer(component.overlayRef.value)).toBe(false);
 
     await expect(component.topLayer.hide()).resolves.toBeUndefined();
 
-    expect(isInTopLayer(component.overlayRef.value!)).toBe(false);
+    expect(isInTopLayer(component.overlayRef.value)).toBe(false);
+  });
+
+  it("ensures top layer placement when an open component is removed then added back to the DOM", async () => {
+    class Test extends LitElement {
+      overlayRef = createRef<HTMLDivElement>();
+
+      topLayer = useTopLayer({
+        target: this.overlayRef,
+      })(this);
+
+      render(): JsxNode {
+        return (
+          <div>
+            <div popover="manual" ref={this.overlayRef}>
+              overlay
+            </div>
+          </div>
+        );
+      }
+    }
+
+    const { el, component, container } = await mount(Test);
+
+    expect(isInTopLayer(component.overlayRef.value)).toBe(false);
+
+    await component.topLayer.show();
+
+    expect(isInTopLayer(component.overlayRef.value)).toBe(true);
+
+    el.remove();
+
+    expect(isInTopLayer(component.overlayRef.value)).toBe(false);
+
+    container.append(el);
+    await waitForAnimationFrame();
+
+    expect(isInTopLayer(component.overlayRef.value)).toBe(true);
   });
 });

--- a/packages/components/src/controllers/useTopLayer.ts
+++ b/packages/components/src/controllers/useTopLayer.ts
@@ -40,7 +40,15 @@ export interface TopLayerComponent extends LitElement {
 export const useTopLayer = <T extends TopLayerComponent>(
   options: UseTopLayerOptions,
 ): ReturnType<typeof makeGenericController<UseTopLayer, T>> => {
-  return makeGenericController<UseTopLayer, T>((component) => {
+  return makeGenericController<UseTopLayer, T>((component, controller) => {
+    let opened = false;
+
+    controller.onConnected(() => {
+      if (opened) {
+        togglePopover(true);
+      }
+    });
+
     async function togglePopover(open: boolean): Promise<void> {
       await component.componentOnReady();
       const nativePopoverEl = typeof options.target === "function" ? options.target() : options.target.value;
@@ -53,10 +61,12 @@ export const useTopLayer = <T extends TopLayerComponent>(
         options.disabledOverride?.() || ("topLayerDisabled" in component && component.topLayerDisabled === true);
 
       if (isDisabled || !open) {
+        opened = false;
         nativePopoverEl.hidePopover();
         return;
       }
 
+      opened = true;
       nativePopoverEl.showPopover();
     }
 

--- a/packages/components/src/tests/utils/dom.ts
+++ b/packages/components/src/tests/utils/dom.ts
@@ -1,6 +1,6 @@
 /**
  * Determines whether the given element is placed in the top layer.
  */
-export function isInTopLayer(el: Element): boolean {
-  return el.hasAttribute("popover") && el.matches(":popover-open");
+export function isInTopLayer(el: Element | undefined): boolean {
+  return !!el?.hasAttribute("popover") && el.matches(":popover-open");
 }


### PR DESCRIPTION
**Related Issue:** #13621 

## Summary

This fixes an issue where stacking order would be incorrect whenever open components using top-layer are reconnected.

BEGIN_COMMIT_OVERRIDE
omitted from changelog
END_COMMIT_OVERRIDE