### PR TITLE
revert(button): remove stateful background color css tokens

### DIFF
--- a/packages/components/src/components/button/button.e2e.ts
+++ b/packages/components/src/components/button/button.e2e.ts
@@ -538,21 +538,6 @@ describe("calcite-button", () => {
           shadowSelector: "button",
           targetProp: "backgroundColor",
         },
-        "--calcite-button-background-color-hover": {
-          shadowSelector: "button",
-          targetProp: "backgroundColor",
-          state: "hover",
-        },
-        "--calcite-button-background-color-focus": {
-          shadowSelector: "button",
-          targetProp: "backgroundColor",
-          state: "focus",
-        },
-        "--calcite-button-background-color-press": {
-          shadowSelector: "button",
-          targetProp: "backgroundColor",
-          state: { press: { attribute: "type", value: "button" } },
-        },
         "--calcite-button-border-color": {
           shadowSelector: "button",
           targetProp: "borderColor",
@@ -576,21 +561,6 @@ describe("calcite-button", () => {
         "--calcite-button-background-color": {
           shadowSelector: "button",
           targetProp: "backgroundColor",
-        },
-        "--calcite-button-background-color-hover": {
-          shadowSelector: "button",
-          targetProp: "backgroundColor",
-          state: "hover",
-        },
-        "--calcite-button-background-color-focus": {
-          shadowSelector: "button",
-          targetProp: "backgroundColor",
-          state: "focus",
-        },
-        "--calcite-button-background-color-press": {
-          shadowSelector: "button",
-          targetProp: "backgroundColor",
-          state: { press: { attribute: "type", value: "button" } },
         },
         "--calcite-button-border-color": {
           shadowSelector: "button",
@@ -620,21 +590,6 @@ describe("calcite-button", () => {
           shadowSelector: "button",
           targetProp: "backgroundColor",
         },
-        "--calcite-button-background-color-hover": {
-          shadowSelector: "button",
-          targetProp: "backgroundColor",
-          state: "hover",
-        },
-        "--calcite-button-background-color-focus": {
-          shadowSelector: "button",
-          targetProp: "backgroundColor",
-          state: "focus",
-        },
-        "--calcite-button-background-color-press": {
-          shadowSelector: "button",
-          targetProp: "backgroundColor",
-          state: { press: { attribute: "type", value: "button" } },
-        },
         "--calcite-button-border-color": {
           shadowSelector: "button",
           targetProp: "borderColor",
@@ -658,21 +613,6 @@ describe("calcite-button", () => {
         "--calcite-button-background-color": {
           shadowSelector: "button",
           targetProp: "backgroundColor",
-        },
-        "--calcite-button-background-color-hover": {
-          shadowSelector: "button",
-          targetProp: "backgroundColor",
-          state: "hover",
-        },
-        "--calcite-button-background-color-focus": {
-          shadowSelector: "button",
-          targetProp: "backgroundColor",
-          state: "focus",
-        },
-        "--calcite-button-background-color-press": {
-          shadowSelector: "button",
-          targetProp: "backgroundColor",
-          state: { press: { attribute: "type", value: "button" } },
         },
         "--calcite-button-border-color": {
           shadowSelector: "button",
@@ -698,21 +638,6 @@ describe("calcite-button", () => {
           shadowSelector: "button",
           targetProp: "backgroundColor",
         },
-        "--calcite-button-background-color-hover": {
-          shadowSelector: "button",
-          targetProp: "backgroundColor",
-          state: "hover",
-        },
-        "--calcite-button-background-color-focus": {
-          shadowSelector: "button",
-          targetProp: "backgroundColor",
-          state: "focus",
-        },
-        "--calcite-button-background-color-press": {
-          shadowSelector: "button",
-          targetProp: "backgroundColor",
-          state: { press: { attribute: "type", value: "button" } },
-        },
         "--calcite-button-border-color": {
           shadowSelector: "button",
           targetProp: "borderColor",
@@ -737,21 +662,6 @@ describe("calcite-button", () => {
           shadowSelector: "button",
           targetProp: "backgroundColor",
         },
-        "--calcite-button-background-color-hover": {
-          shadowSelector: "button",
-          targetProp: "backgroundColor",
-          state: "hover",
-        },
-        "--calcite-button-background-color-focus": {
-          shadowSelector: "button",
-          targetProp: "backgroundColor",
-          state: "focus",
-        },
-        "--calcite-button-background-color-press": {
-          shadowSelector: "button",
-          targetProp: "backgroundColor",
-          state: { press: { attribute: "type", value: "button" } },
-        },
         "--calcite-button-border-color": {
           shadowSelector: "button",
           targetProp: "borderColor",
@@ -775,21 +685,6 @@ describe("calcite-button", () => {
         "--calcite-button-background-color": {
           shadowSelector: "button",
           targetProp: "backgroundColor",
-        },
-        "--calcite-button-background-color-hover": {
-          shadowSelector: "button",
-          targetProp: "backgroundColor",
-          state: "hover",
-        },
-        "--calcite-button-background-color-focus": {
-          shadowSelector: "button",
-          targetProp: "backgroundColor",
-          state: "focus",
-        },
-        "--calcite-button-background-color-press": {
-          shadowSelector: "button",
-          targetProp: "backgroundColor",
-          state: { press: { attribute: "type", value: "button" } },
         },
         "--calcite-button-border-color": {
           shadowSelector: "button",

--- a/packages/components/src/components/button/button.scss
+++ b/packages/components/src/components/button/button.scss
@@ -4,9 +4,6 @@
  * These properties can be overridden using the component's tag as selector.
  *
  * @prop --calcite-button-background-color: Specifies the component's background color.
- * @prop --calcite-button-background-color-hover: Specifies the component's background color when hovered.
- * @prop --calcite-button-background-color-focus: Specifies the component's background color when focused.
- * @prop --calcite-button-background-color-press: Specifies the component's background color when active.
  * @prop --calcite-button-border-color: Specifies the component's border color.
  * @prop --calcite-button-corner-radius: Specifies the component's corner radius.
  * @prop --calcite-button-icon-color: Specifies the component's `iconStart` and `iconEnd` color.
@@ -108,22 +105,16 @@
 
     &:hover {
       @apply no-underline;
-      background-color: var(
-        --calcite-button-background-color-hover,
-        var(--calcite-internal-button-background-color-hover, var(--calcite-color-transparent))
-      );
+      background-color: var(--calcite-internal-button-background-color-hover, var(--calcite-color-transparent));
     }
 
     &:focus {
       @apply focus-outset;
-      background-color: var(--calcite-button-background-color-focus, var(--calcite-internal-button-background-color));
+      background-color: var(--calcite-internal-button-background-color);
     }
 
     &:active {
-      background-color: var(
-        --calcite-button-background-color-press,
-        var(--calcite-internal-button-background-color-press, var(--calcite-color-transparent))
-      );
+      background-color: var(--calcite-internal-button-background-color-press, var(--calcite-color-transparent));
     }
 
     span {


### PR DESCRIPTION
**Related Issue:** #13548

## Summary

This PR reverts the public css background color tokens for hover, focus and press states.

BEGIN_COMMIT_OVERRIDE
omitted from changelog
END_COMMIT_OVERRIDE