### PR TITLE
chore(linting): warn on CSS selector locator usage

### DIFF
--- a/packages/components/eslint.config.mjs
+++ b/packages/components/eslint.config.mjs
@@ -115,6 +115,22 @@ export default tseslint.config(
   },
 
   {
+    files: ["**/*.browser.*.tsx"],
+    extends: [calciteCoreConfig],
+    rules: {
+      "no-restricted-properties": [
+        "warn",
+        {
+          object: "page",
+          property: "getBySelector",
+          message:
+            "Prefer using more specific locators when possible for better test reliability – see https://vitest.dev/api/browser/locators",
+        },
+      ],
+    },
+  },
+
+  {
     plugins: {
       unicorn: unicornPlugin,
     },


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Warns on `page.getBySelector` usage to promote [better alternatives](https://vitest.dev/api/browser/locators).