### PR TITLE
fix(flow-item): back button action uses the provided scale

### DIFF
--- a/packages/components/src/components/flow-item/flow-item.stories.ts
+++ b/packages/components/src/components/flow-item/flow-item.stories.ts
@@ -301,3 +301,22 @@ export const withAlertsSlot = (): string => html`
     </calcite-alert>
   </calcite-flow-item>
 `;
+
+export const scales = (): string =>
+  html`<style>
+      calcite-flow {
+        height: auto !important;
+      }
+    </style>
+    <calcite-flow>
+      <calcite-flow-item heading="Profile" scale="s"> </calcite-flow-item>
+      <calcite-flow-item selected heading="Education" scale="s"> </calcite-flow-item>
+    </calcite-flow>
+    <calcite-flow>
+      <calcite-flow-item heading="Profile" scale="m"> </calcite-flow-item>
+      <calcite-flow-item selected heading="Education" scale="m"> </calcite-flow-item>
+    </calcite-flow>
+    <calcite-flow>
+      <calcite-flow-item heading="Profile" scale="l"> </calcite-flow-item>
+      <calcite-flow-item selected heading="Education" scale="l"> </calcite-flow-item>
+    </calcite-flow>`;

--- a/packages/components/src/components/flow-item/flow-item.tsx
+++ b/packages/components/src/components/flow-item/flow-item.tsx
@@ -277,7 +277,7 @@ export class FlowItem extends LitElement {
         key="flow-back-button"
         onClick={backButtonClick}
         ref={this.backButtonRef}
-        scale="s"
+        scale={this.scale}
         slot={SLOTS.headerActionsStart}
         text={label}
         title={label}


### PR DESCRIPTION
**Related Issue:** #10777

## Summary

This PR updates the back button action to use the scale set on its parent flow-item.