### PR TITLE
feat(accordion-item): update heading and description styling for system consistency for 5.0

### DIFF
--- a/packages/components/src/components/accordion-item/accordion-item.scss
+++ b/packages/components/src/components/accordion-item/accordion-item.scss
@@ -30,6 +30,7 @@
 // --calcite-internal-accordion-item-action-slot-spacing
 // --calcite-internal-accordion-item-active-icon-rotation
 // --calcite-internal-accordion-item-active-icon-rotation-rtl
+// --calcite-internal-accordion-item-description-font-size
 // --calcite-internal-accordion-item-flex-direction
 // --calcite-internal-accordion-item-header-background-color-hover
 // --calcite-internal-accordion-item-header-background-color-press
@@ -50,12 +51,15 @@
 
 :host([scale="s"]) {
   --calcite-internal-accordion-item-action-slot-spacing: var(--calcite-spacing-xxs);
+  --calcite-internal-accordion-item-description-font-size: var(--calcite-font-size--3);
 }
 :host([scale="m"]) {
   --calcite-internal-accordion-item-action-slot-spacing: var(--calcite-spacing-xxs);
+  --calcite-internal-accordion-item-description-font-size: var(--calcite-font-size--2);
 }
 :host([scale="l"]) {
   --calcite-internal-accordion-item-action-slot-spacing: var(--calcite-spacing-xs);
+  --calcite-internal-accordion-item-description-font-size: var(--calcite-font-size--1);
 }
 
 :host {
@@ -221,6 +225,7 @@
 .heading,
 .description {
   @apply flex w-full;
+  line-height: var(--calcite-font-line-height-relative-snug);
 }
 
 .heading {
@@ -280,7 +285,7 @@
 }
 
 .description {
-  @apply mt-1;
+  font-size: var(--calcite-internal-accordion-item-description-font-size);
 }
 
 .content {
@@ -294,9 +299,10 @@
       --calcite-accordion-item-heading-text-color,
       var(
         --calcite-accordion-text-color-hover,
-        var(--calcite-accordion-item-text-color-hover, var(--calcite-color-text-2))
+        var(--calcite-accordion-item-text-color-hover, var(--calcite-color-text-1))
       )
     );
+    font-weight: var(--calcite-font-weight-normal);
   }
 }
 


### PR DESCRIPTION
**Related Issue:** [#12306](https://github.com/Esri/calcite-design-system/issues/12306)

## Summary

- Remove `margin-top` on `description`.
- Change `heading` and `description` `line-height`'s to `--calcite-font-line-height-relative-snug`.
- Reduce `font-size` of `description`:
    - small: `--calcite-font-size--3`
    - medium: `--calcite-font-size--2`
    - large: `--calcite-font-size--1`
- Change `heading` style when collapsed:
    - font-weight: `--calcite-font-weight-normal`
    - color: `--calcite-color-text-1`
