### PR TITLE
chore(linting): override unicorn/filename-case for controller files

### DIFF
--- a/packages/components/eslint.config.mjs
+++ b/packages/components/eslint.config.mjs
@@ -152,4 +152,10 @@ export default tseslint.config(
       ],
     },
   },
+  {
+    files: ["src/controllers/**/*.{js,jsx,ts,tsx}"],
+    rules: {
+      "unicorn/filename-case": "off",
+    },
+  },
 );

--- a/packages/eslint-config/core.js
+++ b/packages/eslint-config/core.js
@@ -98,9 +98,12 @@ export default tseslint.config(
       ],
       radix: ["error", "as-needed"],
 
-      "unicorn/filename-case": ["error", {
-        case: "kebabCase",
-      }],
+      "unicorn/filename-case": [
+        "error",
+        {
+          case: "kebabCase",
+        },
+      ],
       "unicorn/prefer-ternary": "error",
       "unicorn/prevent-abbreviations": [
         "error",
@@ -122,9 +125,14 @@ export default tseslint.config(
           checkFilenames: false,
         },
       ],
-    }
+    },
   },
-
+  {
+    files: ["src/controllers/**/*.{js,jsx,ts,tsx}"],
+    rules: {
+      "unicorn/filename-case": "off",
+    },
+  },
   {
     files: ["**/*.{ts,tsx}"],
     rules: {
@@ -144,7 +152,7 @@ export default tseslint.config(
             "render",
           ],
         },
-      ]
+      ],
     },
   },
 );


### PR DESCRIPTION
**Related Issue:** #10139

## Summary
Override unicorn/filename-case for controller files to allow for camelCase. 