### PR TITLE
feat(alert): remove title slot bottom margin on large scale

### DIFF
--- a/packages/components/src/components/alert/alert.scss
+++ b/packages/components/src/components/alert/alert.scss
@@ -222,7 +222,7 @@ $border-style: 1px solid var(--calcite-color-border-3);
 
 :host([scale="l"]) {
   @include includes.slotted("title", "*") {
-    @apply text-1-wrap mb-1;
+    @apply text-1-wrap;
   }
   @include includes.slotted("message", "*") {
     @apply text-0-wrap;


### PR DESCRIPTION
**Related Issue:** [#11597](https://github.com/Esri/calcite-design-system/issues/11597)

## Summary
Remove title slot bottom margin on large scale.
