### PR TITLE
feat(stepper-item): reduce height and update styling for improved UX

### DIFF
--- a/packages/components/src/components/stepper-item/stepper-item.scss
+++ b/packages/components/src/components/stepper-item/stepper-item.scss
@@ -28,6 +28,7 @@
 // Internal CSS custom properties for component use only. Overwriting is not recommended.
 //
 // --calcite-internal-stepper-action-inline-size
+// --calcite-internal-stepper-item-header-padding
 // --calcite-internal-stepper-item-padding
 // --calcite-internal-stepper-item-spacing-unit-l
 // --calcite-internal-stepper-item-spacing-unit-m
@@ -41,6 +42,7 @@
   --calcite-internal-stepper-item-spacing-unit-m: theme("spacing.3");
   --calcite-internal-stepper-item-spacing-unit-l: theme("spacing.4");
   --calcite-internal-stepper-item-padding: var(--calcite-spacing-md);
+  --calcite-internal-stepper-item-header-padding: var(--calcite-spacing-md);
   --calcite-internal-stepper-action-inline-size: theme("spacing.8");
   @apply text-n1h;
   margin-inline-end: theme("margin.1");
@@ -54,6 +56,7 @@
   --calcite-internal-stepper-item-spacing-unit-m: theme("spacing.4");
   --calcite-internal-stepper-item-spacing-unit-l: theme("spacing.5");
   --calcite-internal-stepper-item-padding: var(--calcite-spacing-lg);
+  --calcite-internal-stepper-item-header-padding: var(--calcite-spacing-lg);
   --calcite-internal-stepper-action-inline-size: theme("spacing.10");
   @apply text-0h;
   margin-inline-end: theme("margin.2");
@@ -67,6 +70,7 @@
   --calcite-internal-stepper-item-spacing-unit-m: theme("spacing.5");
   --calcite-internal-stepper-item-spacing-unit-l: theme("spacing.6");
   --calcite-internal-stepper-item-padding: var(--calcite-spacing-xl);
+  --calcite-internal-stepper-item-header-padding: var(--calcite-spacing-xl);
   --calcite-internal-stepper-action-inline-size: theme("spacing.12");
   @apply text-1h;
   margin-inline-end: theme("margin.3");
@@ -113,20 +117,22 @@
   @apply focus-outset;
 }
 
-// .stepper-item-header / content
-:host .stepper-item-header {
-  @apply flex cursor-pointer items-start;
-
-  &:active {
-    background-color: var(--calcite-stepper-item-background-color-press, var(--calcite-color-foreground-3));
-  }
-}
-
 :host .stepper-item-content,
 :host .stepper-item-header {
   padding-block: var(--calcite-internal-stepper-item-spacing-unit-l);
   padding-inline-end: var(--calcite-internal-stepper-item-spacing-unit-m);
   text-align: start;
+}
+
+// .stepper-item-header / content
+:host .stepper-item-header {
+  @apply flex cursor-pointer items-start;
+
+  padding-block: var(--calcite-internal-stepper-item-header-padding);
+
+  &:active {
+    background-color: var(--calcite-stepper-item-background-color-press, var(--calcite-color-foreground-3));
+  }
 }
 
 :host .stepper-item-header * {
@@ -231,12 +237,14 @@
   border-block-start-color: theme("backgroundColor.brand");
   & .stepper-item-heading {
     color: var(--calcite-stepper-item-selected-header-text-color, var(--calcite-color-text-1));
+    font-weight: var(--calcite-font-weight-medium);
   }
   & .stepper-item-description {
     color: var(--calcite-stepper-item-description-text-color-hover, var(--calcite-color-text-2));
   }
   & .stepper-item-number {
     color: var(--calcite-stepper-item-selected-icon-color, theme("backgroundColor.brand"));
+    font-weight: var(--calcite-font-weight-medium);
   }
 
   & .stepper-item-icon {

--- a/packages/components/src/components/stepper-item/stepper-item.scss
+++ b/packages/components/src/components/stepper-item/stepper-item.scss
@@ -169,9 +169,9 @@
   @apply flex w-full;
 }
 
-:host .stepper-item-heading,
-:host .stepper-item-description,
-:host .stepper-item-number {
+.stepper-item-heading,
+.stepper-item-description,
+.stepper-item-number {
   line-height: var(--calcite-font-line-height-relative-snug);
 }
 

--- a/packages/components/src/components/stepper-item/stepper-item.scss
+++ b/packages/components/src/components/stepper-item/stepper-item.scss
@@ -144,12 +144,12 @@
 // stepper item icon
 :host .stepper-item-icon {
   margin-inline-end: var(--calcite-internal-stepper-item-spacing-unit-m);
-  @apply mt-px
-    inline-flex
+  @apply inline-flex
     h-3
     flex-shrink-0
     self-start;
 
+  margin-block-start: var(--calcite-spacing-base);
   color: var(--calcite-stepper-item-icon-color, var(--calcite-color-border-input));
 }
 

--- a/packages/components/src/components/stepper-item/stepper-item.scss
+++ b/packages/components/src/components/stepper-item/stepper-item.scss
@@ -28,6 +28,7 @@
 // Internal CSS custom properties for component use only. Overwriting is not recommended.
 //
 // --calcite-internal-stepper-action-inline-size
+// --calcite-internal-stepper-item-padding
 // --calcite-internal-stepper-item-spacing-unit-l
 // --calcite-internal-stepper-item-spacing-unit-m
 // --calcite-internal-stepper-item-spacing-unit-s
@@ -39,11 +40,12 @@
   --calcite-internal-stepper-item-spacing-unit-s: theme("spacing.1");
   --calcite-internal-stepper-item-spacing-unit-m: theme("spacing.3");
   --calcite-internal-stepper-item-spacing-unit-l: theme("spacing.4");
+  --calcite-internal-stepper-item-padding: var(--calcite-spacing-md);
   --calcite-internal-stepper-action-inline-size: theme("spacing.8");
   @apply text-n1h;
   margin-inline-end: theme("margin.1");
   .stepper-item-description {
-    @apply text-n2h;
+    font-size: var(--calcite-font-size-relative-sm);
   }
 }
 
@@ -51,11 +53,12 @@
   --calcite-internal-stepper-item-spacing-unit-s: theme("spacing.2");
   --calcite-internal-stepper-item-spacing-unit-m: theme("spacing.4");
   --calcite-internal-stepper-item-spacing-unit-l: theme("spacing.5");
+  --calcite-internal-stepper-item-padding: var(--calcite-spacing-lg);
   --calcite-internal-stepper-action-inline-size: theme("spacing.10");
   @apply text-0h;
   margin-inline-end: theme("margin.2");
   .stepper-item-description {
-    @apply text-n1h;
+    font-size: var(--calcite-font-size-relative-base);
   }
 }
 
@@ -63,11 +66,12 @@
   --calcite-internal-stepper-item-spacing-unit-s: theme("spacing.3");
   --calcite-internal-stepper-item-spacing-unit-m: theme("spacing.5");
   --calcite-internal-stepper-item-spacing-unit-l: theme("spacing.6");
+  --calcite-internal-stepper-item-padding: var(--calcite-spacing-xl);
   --calcite-internal-stepper-action-inline-size: theme("spacing.12");
   @apply text-1h;
   margin-inline-end: theme("margin.3");
   .stepper-item-description {
-    @apply text-0h;
+    font-size: var(--calcite-font-size-relative-md);
   }
 }
 
@@ -93,6 +97,8 @@
     border-solid
     no-underline
     outline-none;
+
+  padding-block: var(--calcite-internal-stepper-item-padding);
 
   &:active {
     background-color: var(--calcite-stepper-item-background-color-press, var(--calcite-color-foreground-3));
@@ -162,18 +168,25 @@
 :host .stepper-item-description {
   @apply flex w-full;
 }
+
+:host .stepper-item-heading,
+:host .stepper-item-description,
+:host .stepper-item-number {
+  line-height: var(--calcite-font-line-height-relative-snug);
+}
+
 :host .stepper-item-heading {
-  @apply mb-1 font-medium;
-  color: var(--calcite-stepper-item-header-text-color, var(--calcite-color-text-2));
+  font-weight: var(--calcite-font-weight-normal);
+  color: var(--calcite-stepper-item-header-text-color, var(--calcite-color-text-1));
 }
 :host .stepper-item-description {
   color: var(--calcite-stepper-item-description-text-color, var(--calcite-color-text-3));
 }
 
 :host .stepper-item-number {
-  @apply font-medium;
+  font-weight: var(--calcite-font-weight-normal);
   margin-inline-end: var(--calcite-internal-stepper-item-spacing-unit-m);
-  color: var(--calcite-stepper-item-description-text-color, var(--calcite-color-text-3));
+  color: var(--calcite-stepper-item-description-text-color, var(--calcite-color-text-1));
 }
 
 @include includes.disabled();

--- a/packages/components/src/components/stepper-item/stepper-item.scss
+++ b/packages/components/src/components/stepper-item/stepper-item.scss
@@ -29,7 +29,6 @@
 //
 // --calcite-internal-stepper-action-inline-size
 // --calcite-internal-stepper-item-header-padding
-// --calcite-internal-stepper-item-padding
 // --calcite-internal-stepper-item-spacing-unit-l
 // --calcite-internal-stepper-item-spacing-unit-m
 // --calcite-internal-stepper-item-spacing-unit-s
@@ -41,7 +40,6 @@
   --calcite-internal-stepper-item-spacing-unit-s: theme("spacing.1");
   --calcite-internal-stepper-item-spacing-unit-m: theme("spacing.3");
   --calcite-internal-stepper-item-spacing-unit-l: theme("spacing.4");
-  --calcite-internal-stepper-item-padding: var(--calcite-spacing-md);
   --calcite-internal-stepper-item-header-padding: var(--calcite-spacing-md);
   --calcite-internal-stepper-action-inline-size: theme("spacing.8");
   @apply text-n1h;
@@ -55,7 +53,6 @@
   --calcite-internal-stepper-item-spacing-unit-s: theme("spacing.2");
   --calcite-internal-stepper-item-spacing-unit-m: theme("spacing.4");
   --calcite-internal-stepper-item-spacing-unit-l: theme("spacing.5");
-  --calcite-internal-stepper-item-padding: var(--calcite-spacing-lg);
   --calcite-internal-stepper-item-header-padding: var(--calcite-spacing-lg);
   --calcite-internal-stepper-action-inline-size: theme("spacing.10");
   @apply text-0h;
@@ -69,7 +66,6 @@
   --calcite-internal-stepper-item-spacing-unit-s: theme("spacing.3");
   --calcite-internal-stepper-item-spacing-unit-m: theme("spacing.5");
   --calcite-internal-stepper-item-spacing-unit-l: theme("spacing.6");
-  --calcite-internal-stepper-item-padding: var(--calcite-spacing-xl);
   --calcite-internal-stepper-item-header-padding: var(--calcite-spacing-xl);
   --calcite-internal-stepper-action-inline-size: theme("spacing.12");
   @apply text-1h;
@@ -101,8 +97,6 @@
     border-solid
     no-underline
     outline-none;
-
-  padding-block: var(--calcite-internal-stepper-item-padding);
 
   &:active {
     background-color: var(--calcite-stepper-item-background-color-press, var(--calcite-color-foreground-3));


### PR DESCRIPTION
**Related Issue:** [#10720](https://github.com/Esri/calcite-design-system/issues/10720)

## Summary
- Remove `margin-top` on `description`.
- Change `heading`, `description`, and `number`:
    - line-height: `--calcite-font-line-height-relative-snug`
- Change default styling for `number` and `heading`:
    - font-weight: `--calcite-font-weight-normal`
    - color: `--calcite-color-text-1`
- Reduce `padding-block`:
    - small: `--calcite-spacing-md`
    - medium: `--calcite-spacing-lg`
    - large: `--calcite-spacing-xl`
