### PR TITLE
docs: add api consistency across components

### DIFF
--- a/packages/components/src/components/pagination/pagination.tsx
+++ b/packages/components/src/components/pagination/pagination.tsx
@@ -81,7 +81,7 @@ export class Pagination extends LitElement {
   /** When `true`, number values are displayed with a group separator corresponding to the language and country format. */
   @property({ reflect: true }) groupSeparator = false;
 
-  /** Use this property to override individual strings used by the component. */
+  /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /** Specifies the Unicode numeral system used by the component for localization. */

--- a/packages/components/src/components/panel/panel.scss
+++ b/packages/components/src/components/panel/panel.scss
@@ -9,7 +9,7 @@
  * @prop --calcite-panel-description-text-color: Specifies the text color of the component's `description`.
  * @prop --calcite-panel-border-color: Specifies the component's border color.
  * @prop --calcite-panel-background-color: Specifies the component's background color.
- * @prop --calcite-panel-header-background-color: Specifies the background color of the component's `heading`.
+ * @prop --calcite-panel-header-background-color: Specifies the background color of the component's header.
  * @prop --calcite-panel-header-action-background-color: Specifies the background color of the component's `closable`, `collapsible`, and elements slotted in `header-menu-actions`.
  * @prop --calcite-panel-header-action-background-color-hover: Specifies the background color of the component's `closable`, `collapsible`, and elements slotted in `header-menu-actions` when hovered.
  * @prop --calcite-panel-header-action-background-color-press: Specifies the background color of the component's `closable`, `collapsible`, and elements slotted in `header-menu-actions` when pressed.

--- a/packages/components/src/components/panel/panel.scss
+++ b/packages/components/src/components/panel/panel.scss
@@ -9,12 +9,12 @@
  * @prop --calcite-panel-description-text-color: Specifies the text color of the component's `description`.
  * @prop --calcite-panel-border-color: Specifies the component's border color.
  * @prop --calcite-panel-background-color: Specifies the component's background color.
- * @prop --calcite-panel-header-background-color: Specifies the background color of the component's header.
- * @prop --calcite-panel-header-action-background-color: Specifies the background color of Panel's `closable`, `collapsible`, and elements slotted in `header-menu-actions`.
- * @prop --calcite-panel-header-action-background-color-hover: Specifies the background color of Panel's `closable`, `collapsible`, and elements slotted in `header-menu-actions` when hovered.
- * @prop --calcite-panel-header-action-background-color-press: Specifies the background color of Panel's `closable`, `collapsible`, and elements slotted in `header-menu-actions` when pressed.
- * @prop --calcite-panel-header-action-text-color: Specifies the text color of Panel's `closable`, `collapsible`, and elements slotted in `header-menu-actions`.
- * @prop --calcite-panel-header-action-text-color-press: Specifies the text color of Panel's `closable`, `collapsible`, and elements slotted in `header-menu-actions` when pressed or hovered.
+ * @prop --calcite-panel-header-background-color: Specifies the background color of the component's `heading`.
+ * @prop --calcite-panel-header-action-background-color: Specifies the background color of the component's `closable`, `collapsible`, and elements slotted in `header-menu-actions`.
+ * @prop --calcite-panel-header-action-background-color-hover: Specifies the background color of the component's `closable`, `collapsible`, and elements slotted in `header-menu-actions` when hovered.
+ * @prop --calcite-panel-header-action-background-color-press: Specifies the background color of the component's `closable`, `collapsible`, and elements slotted in `header-menu-actions` when pressed.
+ * @prop --calcite-panel-header-action-text-color: Specifies the text color of the component's `closable`, `collapsible`, and elements slotted in `header-menu-actions`.
+ * @prop --calcite-panel-header-action-text-color-press: Specifies the text color of the component's `closable`, `collapsible`, and elements slotted in `header-menu-actions` when pressed or hovered.
  * @prop --calcite-panel-footer-background-color: Specifies the background color of the component's footer.
  * @prop --calcite-panel-space: Specifies the padding of the component's `"unnamed (default)"` slot.
  * @prop --calcite-panel-header-content-space: Specifies the padding of the `"header-content"` slot.

--- a/packages/components/src/components/panel/panel.tsx
+++ b/packages/components/src/components/panel/panel.tsx
@@ -133,13 +133,13 @@ export class Panel extends LitElement {
   /** When `true`, the component is collapsible. */
   @property({ reflect: true }) collapsible = false;
 
-  /** A description for the component. */
+  /** Specifies the component's description text. */
   @property() description: string;
 
   /** When `true`, interaction is prevented and the component is displayed with lower opacity. */
   @property({ reflect: true }) disabled = false;
 
-  /** The component header text. */
+  /** Specifies the component's header text. */
   @property() heading: string;
 
   /** Specifies the heading level of the component's `heading` for proper document structure, without affecting visual styling. */

--- a/packages/components/src/components/panel/panel.tsx
+++ b/packages/components/src/components/panel/panel.tsx
@@ -35,7 +35,7 @@ declare global {
  * @slot - A slot for adding custom content.
  * @slot action-bar - A slot for adding a `calcite-action-bar` to the component.
  * @slot alerts - A slot for adding `calcite-alert`s to the component.
- * @slot content-bottom - A slot for adding content below the unnamed (default) slot and above the footer slot (if populated)
+ * @slot content-bottom - A slot for adding content below the unnamed (default) slot and above the footer slot (if populated).
  * @slot content-top - A slot for adding content above the unnamed (default) slot and below the action-bar slot (if populated).
  * @slot header-actions-start - A slot for adding actions or content to the start side of the header.
  * @slot header-actions-end - A slot for adding actions or content to the end side of the header.
@@ -43,8 +43,8 @@ declare global {
  * @slot header-menu-actions - A slot for adding an overflow menu with actions inside a `calcite-dropdown`.
  * @slot fab - A slot for adding a `calcite-fab` (floating action button) to perform an action.
  * @slot footer - A slot for adding custom content to the component's footer. Should not be used with the `"footer-start"` or `"footer-end"` slots.
- * @slot footer-end - A slot for adding a trailing footer custom content. Should not be used with the `"footer"` slot.
- * @slot footer-start - A slot for adding a leading footer custom content. Should not be used with the `"footer"` slot.
+ * @slot footer-end - A slot for adding custom content to a trailing footer. Should not be used with the `"footer"` slot.
+ * @slot footer-start - A slot for adding custom content to a leading footer. Should not be used with the `"footer"` slot.
  */
 export class Panel extends LitElement {
   //#region Static Members
@@ -124,7 +124,7 @@ export class Panel extends LitElement {
     }
   }
 
-  /** When `collapsible` is present, specifies the direction of the collapse icon. */
+  /** When `collapsible` is `true`, specifies the direction of the collapse icon. */
   @property() collapseDirection: CollapseDirection = "down";
 
   /** When `true`, hides the component's content area. */
@@ -163,7 +163,7 @@ export class Panel extends LitElement {
   /** Determines where the action menu will be positioned. */
   @property({ reflect: true }) menuPlacement: LogicalPlacement = defaultEndMenuPlacement;
 
-  /** Use this property to override individual strings used by the component. */
+  /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /**

--- a/packages/components/src/components/popover/popover.tsx
+++ b/packages/components/src/components/popover/popover.tsx
@@ -139,8 +139,8 @@ export class Popover extends LitElement implements FloatingUIComponent {
    *
    * `"allowOutsideClick`" allows outside clicks,
    * `"initialFocus"` enables initial focus,
-   * `"returnFocusOnDeactivate"` returns focus when not active, and
-   * `"extraContainers"` specifies additional focusable elements external to the trap (e.g., 3rd-party components appending elements to the document body).
+   * `"returnFocusOnDeactivate"` returns focus when not active,
+   * `"extraContainers"` specifies additional focusable elements external to the trap, such as 3rd-party components appending elements to the document body, and
    * `"setReturnFocus"` customizes the element to which focus is returned when the trap is deactivated. Return `false` to prevent focus return, or `undefined` to use the default behavior (returning focus to the element focused before activation).
    */
   @property() focusTrapOptions: Partial<FocusTrapOptions>;
@@ -158,7 +158,7 @@ export class Popover extends LitElement implements FloatingUIComponent {
    */
   @property() label: string;
 
-  /** Use this property to override individual strings used by the component. */
+  /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /**

--- a/packages/components/src/components/radio-button-group/radio-button-group.scss
+++ b/packages/components/src/components/radio-button-group/radio-button-group.scss
@@ -4,7 +4,7 @@
  * These properties can be overridden using the component's tag as selector.
  *
  * @prop --calcite-radio-button-group-gap: Specifies the space between slotted components in the component.
- * @prop --calcite-radio-button-input-message-spacing: Specifies the margin spacing at the top of the input-message component.
+ * @prop --calcite-radio-button-input-message-spacing: Specifies the margin spacing at the top of the `calcite-input-message`.
  */
 
 @use "../../styles/includes";

--- a/packages/components/src/components/radio-button-group/radio-button-group.tsx
+++ b/packages/components/src/components/radio-button-group/radio-button-group.tsx
@@ -69,10 +69,10 @@ export class RadioButtonGroup extends LitElement {
   /** When provided, displays label text on the component. */
   @property() labelText: string;
 
-  /** Defines the layout of the component. */
+  /** Specifies the layout of the component. */
   @property({ reflect: true }) layout: Extract<"horizontal" | "vertical", Layout> = "horizontal";
 
-  /** Use this property to override individual strings used by the component. */
+  /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /**

--- a/packages/components/src/components/rating/rating.scss
+++ b/packages/components/src/components/rating/rating.scss
@@ -7,9 +7,9 @@
  * @prop --calcite-rating-color-hover: Specifies the component's item color when hovered.
  * @prop --calcite-rating-color-press: Specifies the component's item color when active.
  * @prop --calcite-rating-color: Specifies the component's item color.
- * @prop --calcite-rating-average-color: Specifies the component's item color when average is set.
- * @prop --calcite-rating-average-text-color: Specifies the component's average text color.
- * @prop --calcite-rating-count-text-color: Specifies the component's count text color.
+ * @prop --calcite-rating-average-color: When `average` is set, specifies the component's item color.
+ * @prop --calcite-rating-average-text-color: When `average` is set, specifies the component's `average` text color.
+ * @prop --calcite-rating-count-text-color: Specifies the component's text color for `count`.
  */
 
 // AUTO-GENERATED — do not modify. Changes will be overwritten.

--- a/packages/components/src/components/rating/rating.tsx
+++ b/packages/components/src/components/rating/rating.tsx
@@ -110,7 +110,7 @@ export class Rating extends LitElement implements LabelableComponent, FormCompon
   /** When provided, displays label text on the component. */
   @property() labelText: string;
 
-  /** Use this property to override individual strings used by the component. */
+  /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /**

--- a/packages/components/src/components/scrim/scrim.scss
+++ b/packages/components/src/components/scrim/scrim.scss
@@ -3,7 +3,7 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-scrim-background: Specifies the background color of the scrim.
+ * @prop --calcite-scrim-background: Specifies the component's background color.
  */
 
 @use "../../styles/includes";

--- a/packages/components/src/components/scrim/scrim.tsx
+++ b/packages/components/src/components/scrim/scrim.tsx
@@ -52,7 +52,7 @@ export class Scrim extends LitElement {
   /** When `true`, a busy indicator is displayed. */
   @property({ reflect: true }) loading = false;
 
-  /** Use this property to override individual strings used by the component. */
+  /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
   //#endregion

--- a/packages/components/src/components/segmented-control/segmented-control.tsx
+++ b/packages/components/src/components/segmented-control/segmented-control.tsx
@@ -97,7 +97,7 @@ export class SegmentedControl extends LitElement implements LabelableComponent, 
   /** When provided, displays label text on the component. */
   @property() labelText: string;
 
-  /** Use this property to override individual strings used by the component. */
+  /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /**


### PR DESCRIPTION
**Related Issue:** #12833

## Summary
Adds API doc consistency to the following components:
- `pagination`
- `panel`
- `popover`
- `radio-button-group`
- `rating`
- `scrim`
- `segmented-control`