### PR TITLE
feat(accordion-item): update header to use semantic button instead of div

### DIFF
--- a/packages/components/src/components/accordion-item/accordion-item.e2e.ts
+++ b/packages/components/src/components/accordion-item/accordion-item.e2e.ts
@@ -153,7 +153,7 @@ describe("calcite-accordion-item", () => {
     });
   });
 
-  it("properly uses ARIA and roles", async () => {
+  it("properly uses ARIA and types", async () => {
     // this test covers a11y relationships not reported by axe-core/accessible test helper
 
     const page = await newE2EPage();
@@ -163,7 +163,7 @@ describe("calcite-accordion-item", () => {
 
     expect(headerContent.getAttribute("aria-expanded")).toBe("false");
     expect(headerContent.getAttribute("aria-controls")).toBe(IDS.section);
-    expect(headerContent.getAttribute("role")).toBe("button");
+    expect(headerContent.getAttribute("type")).toBe("button");
 
     const content = await page.find(`calcite-accordion-item >>> .${CSS.content}`);
 

--- a/packages/components/src/components/accordion-item/accordion-item.scss
+++ b/packages/components/src/components/accordion-item/accordion-item.scss
@@ -153,6 +153,7 @@
   -webkit-appearance: none;
   box-shadow: none;
   outline: none;
+  font-family: inherit;
 }
 
 .content {

--- a/packages/components/src/components/accordion-item/accordion-item.scss
+++ b/packages/components/src/components/accordion-item/accordion-item.scss
@@ -146,6 +146,13 @@
     --calcite-internal-accordion-item-padding,
     var(--calcite-internal-accordion-item-spacing-unit, theme("spacing.2") 0.75rem)
   );
+
+  background: none;
+  border: none;
+  appearance: none;
+  -webkit-appearance: none;
+  box-shadow: none;
+  outline: none;
 }
 
 .content {

--- a/packages/components/src/components/accordion-item/accordion-item.tsx
+++ b/packages/components/src/components/accordion-item/accordion-item.tsx
@@ -378,7 +378,7 @@ export class AccordionItem extends LitElement {
           {this.renderActionsStart()}
           <button
             aria-controls={IDS.section}
-            aria-expanded={expanded}
+            ariaExpanded={expanded}
             class={CSS.headerContent}
             id={IDS.sectionToggle}
             onClick={this.itemHeaderClickHandler}

--- a/packages/components/src/components/accordion-item/accordion-item.tsx
+++ b/packages/components/src/components/accordion-item/accordion-item.tsx
@@ -42,7 +42,7 @@ export class AccordionItem extends LitElement {
 
   //#region Private Properties
 
-  private headerRef = createRef<HTMLDivElement>();
+  private headerRef = createRef<HTMLButtonElement>();
 
   private focusSetter = useSetFocus<this>()(this);
 
@@ -376,15 +376,14 @@ export class AccordionItem extends LitElement {
           }}
         >
           {this.renderActionsStart()}
-          <div
+          <button
             aria-controls={IDS.section}
-            ariaExpanded={expanded}
+            aria-expanded={expanded}
             class={CSS.headerContent}
             id={IDS.sectionToggle}
             onClick={this.itemHeaderClickHandler}
             ref={this.headerRef}
-            role="button"
-            tabIndex="0"
+            type="button"
           >
             <div class={CSS.headerContainer}>
               {this.renderContentStart()}
@@ -412,7 +411,7 @@ export class AccordionItem extends LitElement {
               scale={getIconScale(this.scale)}
               title={expandIconTitle}
             />
-          </div>
+          </button>
           {this.renderActionsEnd()}
         </div>
         <section aria-labelledby={IDS.sectionToggle} class={CSS.content} id={IDS.section}>


### PR DESCRIPTION
**Related Issue:** [#4123](https://github.com/Esri/calcite-design-system/issues/4123)

## Summary
Update `header` to use semantic `button` instead of `div`.
