### PR TITLE
feat(alert): use filled status icon for consistency

### DIFF
--- a/packages/components/src/components/alert/alert.e2e.ts
+++ b/packages/components/src/components/alert/alert.e2e.ts
@@ -86,6 +86,16 @@ describe("calcite-alert", () => {
     expect(icon).not.toBeNull();
   });
 
+  it("renders filled status icon when kind and icon are set", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <calcite-alert kind="danger" icon>
+    ${alertContent}
+    </calcite-alert>`);
+    const icon = await page.find(`calcite-alert >>> .${CSS.icon} calcite-icon`);
+    expect(await icon.getProperty("icon")).toBe("exclamationMarkTriangleF");
+  });
+
   it("closes on time based on alert duration", async () => {
     const page = await newE2EPage();
     await page.setContent(html`

--- a/packages/components/src/components/alert/alert.tsx
+++ b/packages/components/src/components/alert/alert.tsx
@@ -17,7 +17,7 @@ import { getIconScale } from "../../utils/component";
 import { NumberingSystem, NumberStringFormat } from "../../utils/locale";
 import { toggleOpenClose } from "../../utils/openCloseComponent";
 import { Kind, Scale } from "../interfaces";
-import { KindIconsFilled } from "../resources";
+import { KindIcons, KindIconsFilled } from "../resources";
 import { IconName } from "../icon/interfaces";
 import { useT9n } from "../../controllers/useT9n";
 import { useSetFocus } from "../../controllers/useSetFocus";
@@ -395,7 +395,11 @@ export class Alert extends LitElement {
     const { open, autoClose, label, placement, active, openAlertCount } = this;
     const role = autoClose ? "alert" : "alertdialog";
     const hidden = !open;
-    const effectiveIcon = setRequestedIcon(KindIconsFilled, this.icon, this.kind);
+    const effectiveIcon = setRequestedIcon(
+      this.kind === "brand" ? KindIcons : KindIconsFilled,
+      this.icon,
+      this.kind,
+    );
     const hasQueuedAlerts = openAlertCount > 1;
     /* TODO: [MIGRATION] This used <Host> before. In Stencil, <Host> props overwrite user-provided props. If you don't wish to overwrite user-values, replace "=" here with "??=" */
     this.el.inert = hidden;

--- a/packages/components/src/components/alert/alert.tsx
+++ b/packages/components/src/components/alert/alert.tsx
@@ -17,7 +17,7 @@ import { getIconScale } from "../../utils/component";
 import { NumberingSystem, NumberStringFormat } from "../../utils/locale";
 import { toggleOpenClose } from "../../utils/openCloseComponent";
 import { Kind, Scale } from "../interfaces";
-import { KindIcons } from "../resources";
+import { KindIconsFilled } from "../resources";
 import { IconName } from "../icon/interfaces";
 import { useT9n } from "../../controllers/useT9n";
 import { useSetFocus } from "../../controllers/useSetFocus";
@@ -395,7 +395,7 @@ export class Alert extends LitElement {
     const { open, autoClose, label, placement, active, openAlertCount } = this;
     const role = autoClose ? "alert" : "alertdialog";
     const hidden = !open;
-    const effectiveIcon = setRequestedIcon(KindIcons, this.icon, this.kind);
+    const effectiveIcon = setRequestedIcon(KindIconsFilled, this.icon, this.kind);
     const hasQueuedAlerts = openAlertCount > 1;
     /* TODO: [MIGRATION] This used <Host> before. In Stencil, <Host> props overwrite user-provided props. If you don't wish to overwrite user-values, replace "=" here with "??=" */
     this.el.inert = hidden;


### PR DESCRIPTION
**Related Issue:** [#12464](https://github.com/Esri/calcite-design-system/issues/12464) 

## Summary
Use filled status icons for info, danger, warning, and success alerts to improve clarity and consistency.