### PR TITLE
fix(action-menu): clicking in between actions doesn't close popup

### DIFF
--- a/packages/components/src/components/action-menu/action-menu.e2e.ts
+++ b/packages/components/src/components/action-menu/action-menu.e2e.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { html } from "../../../support/formatting";
 import { accessible, themed } from "../../tests/commonTests";
 import { CSS as TooltipCSS, TOOLTIP_OPEN_DELAY_MS } from "../tooltip/resources";
-import { findAll, isElementFocused, skipAnimations, waitForAnimationFrame } from "../../tests/utils/puppeteer";
+import { findAll, getElementRect, isElementFocused, skipAnimations, waitForAnimationFrame } from "../../tests/utils/puppeteer";
 import type { Action } from "../action/action";
 import { mockConsole } from "../../tests/utils/logging";
 import { CSS, SLOTS } from "./resources";
@@ -88,6 +88,68 @@ describe("calcite-action-menu", () => {
   });
 
   it("should close menu if slotted action is clicked", async () => {
+    const page = await newE2EPage();
+    await page.setContent(html`
+      <calcite-action-menu>
+        <calcite-action id="triggerAction" slot="${SLOTS.trigger}" text="Add" icon="plus" text-enabled></calcite-action>
+        <calcite-action id="slottedAction" text="Add" icon="plus" text-enabled></calcite-action>
+        <calcite-action text="Add" icon="plus" text-enabled></calcite-action>
+      </calcite-action-menu>
+    `);
+    await skipAnimations(page);
+    await page.waitForChanges();
+    const actionMenu = await page.find("calcite-action-menu");
+
+    const openEventSpy = await actionMenu.spyOnEvent("calciteActionMenuOpen");
+    actionMenu.setProperty("open", true);
+    await page.waitForChanges();
+    await openEventSpy.next();
+
+    expect(await actionMenu.getProperty("open")).toBe(true);
+
+    const action = await page.find("#slottedAction");
+    await action.click();
+    await page.waitForChanges();
+    await waitForActionMenuClose(page);
+
+    expect(await actionMenu.getProperty("open")).toBe(false);
+
+    const focusTargetSelector = `#triggerAction`;
+    await isElementFocused(page, focusTargetSelector);
+  });
+
+  it("should not close menu if space between actions (action-menu) is clicked", async () => {
+    const page = await newE2EPage();
+    await page.setContent(html`
+      <calcite-action-menu>
+        <calcite-action id="triggerAction" slot="${SLOTS.trigger}" text="Add" icon="plus" text-enabled></calcite-action>
+        <span>Click Me</span>
+        <calcite-action id="slottedAction" text="Add" icon="plus" text-enabled></calcite-action>
+        <calcite-action text="Add" icon="plus" text-enabled></calcite-action>
+      </calcite-action-menu>
+    `);
+    await skipAnimations(page);
+    await page.waitForChanges();
+    const actionMenu = await page.find("calcite-action-menu");
+    const spanBetweenActions = await page.find("span");
+
+    const openEventSpy = await actionMenu.spyOnEvent("calciteActionMenuOpen");
+    actionMenu.setProperty("open", true);
+    await page.waitForChanges();
+    await openEventSpy.next();
+
+    expect(await actionMenu.getProperty("open")).toBe(true);
+
+    await spanBetweenActions.click();
+    await page.waitForChanges();
+
+    expect(await actionMenu.getProperty("open")).toBe(true);
+
+    const focusTargetSelector = `#triggerAction`;
+    await isElementFocused(page, focusTargetSelector);
+  });
+
+  it("when the mouse pressed down on a slotted action, it should update the menu's activeMenuItemIndex to that action", async () => {
     const page = await newE2EPage();
     await page.setContent(html`
       <calcite-action-menu>
@@ -483,6 +545,57 @@ describe("calcite-action-menu", () => {
 
       expect(await actionMenu.getProperty("open")).toBe(false);
       expect(clickSpy).toHaveReceivedEventTimes(1);
+    });
+
+    it("should move the focus ring to the active action on mousedown", async () => {
+      const page = await newE2EPage();
+      await page.setContent(
+        html`<calcite-action-menu>
+          <calcite-action id="first" text="Add" icon="plus" text-enabled></calcite-action>
+          <calcite-action id="second" text="Add" icon="minus" text-enabled></calcite-action>
+          <calcite-action id="third" text="Add" icon="banana" text-enabled></calcite-action>
+        </calcite-action-menu> `,
+      );
+      await skipAnimations(page);
+      const actionMenu = await page.find("calcite-action-menu");
+      const actions = await findAll(page, "calcite-action");
+
+      expect(await actionMenu.getProperty("open")).toBe(false);
+
+      await actionMenu.callMethod("setFocus");
+      await page.waitForChanges();
+      const openEventSpy = await actionMenu.spyOnEvent("calciteActionMenuOpen");
+      await page.keyboard.press("ArrowDown");
+      await page.waitForChanges();
+      await openEventSpy.next();
+
+      expect(await actionMenu.getProperty("open")).toBe(true);
+      expect(await actions[0].getProperty("activeDescendant")).toBe(true);
+      expect(await actions[1].getProperty("activeDescendant")).toBe(false);
+      expect(await actions[2].getProperty("activeDescendant")).toBe(false);
+
+      const secondActionPosition = await getElementRect(
+        page,
+        "#second",
+      );
+
+      await page.mouse.move(secondActionPosition.x, secondActionPosition.y);
+      await page.mouse.down();
+      await page.waitForChanges();
+
+      const firstButton = await page.find(`#first >>> button`);
+      const firstButtonStyle = await firstButton.getComputedStyle();
+      const secondButton = await page.find(`#second >>> button`);
+      const secondButtonStyle = await secondButton.getComputedStyle();
+
+      expect(firstButtonStyle["outlineWidth"]).toBe("0px");
+      expect(secondButtonStyle["outlineWidth"]).toBe("2px");
+
+      await page.mouse.up();
+      await page.waitForChanges();
+      await waitForActionMenuClose(page);
+
+      expect(await actionMenu.getProperty("open")).toBe(false);
     });
 
     it("should click the active action when clicked and close the menu", async () => {

--- a/packages/components/src/components/action-menu/action-menu.e2e.ts
+++ b/packages/components/src/components/action-menu/action-menu.e2e.ts
@@ -149,7 +149,7 @@ describe("calcite-action-menu", () => {
     await isElementFocused(page, focusTargetSelector);
   });
 
-  it("when the mouse pressed down on a slotted action, it should update the menu's activeMenuItemIndex to that action", async () => {
+  it("clicking a slotted action closes the popover", async () => {
     const page = await newE2EPage();
     await page.setContent(html`
       <calcite-action-menu>

--- a/packages/components/src/components/action-menu/action-menu.e2e.ts
+++ b/packages/components/src/components/action-menu/action-menu.e2e.ts
@@ -4,7 +4,13 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { html } from "../../../support/formatting";
 import { accessible, themed } from "../../tests/commonTests";
 import { CSS as TooltipCSS, TOOLTIP_OPEN_DELAY_MS } from "../tooltip/resources";
-import { findAll, getElementRect, isElementFocused, skipAnimations, waitForAnimationFrame } from "../../tests/utils/puppeteer";
+import {
+  findAll,
+  getElementRect,
+  isElementFocused,
+  skipAnimations,
+  waitForAnimationFrame,
+} from "../../tests/utils/puppeteer";
 import type { Action } from "../action/action";
 import { mockConsole } from "../../tests/utils/logging";
 import { CSS, SLOTS } from "./resources";
@@ -144,37 +150,6 @@ describe("calcite-action-menu", () => {
     await page.waitForChanges();
 
     expect(await actionMenu.getProperty("open")).toBe(true);
-
-    const focusTargetSelector = `#triggerAction`;
-    await isElementFocused(page, focusTargetSelector);
-  });
-
-  it("clicking a slotted action closes the popover", async () => {
-    const page = await newE2EPage();
-    await page.setContent(html`
-      <calcite-action-menu>
-        <calcite-action id="triggerAction" slot="${SLOTS.trigger}" text="Add" icon="plus" text-enabled></calcite-action>
-        <calcite-action id="slottedAction" text="Add" icon="plus" text-enabled></calcite-action>
-        <calcite-action text="Add" icon="plus" text-enabled></calcite-action>
-      </calcite-action-menu>
-    `);
-    await skipAnimations(page);
-    await page.waitForChanges();
-    const actionMenu = await page.find("calcite-action-menu");
-
-    const openEventSpy = await actionMenu.spyOnEvent("calciteActionMenuOpen");
-    actionMenu.setProperty("open", true);
-    await page.waitForChanges();
-    await openEventSpy.next();
-
-    expect(await actionMenu.getProperty("open")).toBe(true);
-
-    const action = await page.find("#slottedAction");
-    await action.click();
-    await page.waitForChanges();
-    await waitForActionMenuClose(page);
-
-    expect(await actionMenu.getProperty("open")).toBe(false);
 
     const focusTargetSelector = `#triggerAction`;
     await isElementFocused(page, focusTargetSelector);
@@ -574,10 +549,7 @@ describe("calcite-action-menu", () => {
       expect(await actions[1].getProperty("activeDescendant")).toBe(false);
       expect(await actions[2].getProperty("activeDescendant")).toBe(false);
 
-      const secondActionPosition = await getElementRect(
-        page,
-        "#second",
-      );
+      const secondActionPosition = await getElementRect(page, "#second");
 
       await page.mouse.move(secondActionPosition.x, secondActionPosition.y);
       await page.mouse.down();

--- a/packages/components/src/components/action-menu/action-menu.tsx
+++ b/packages/components/src/components/action-menu/action-menu.tsx
@@ -356,9 +356,11 @@ export class ActionMenu extends LitElement {
     el.open = this.open;
   }
 
-  private handleCalciteActionClick(): void {
-    this.open = false;
-    this.setFocus();
+  private handleCalciteActionClick(event): void {
+    if (event.target.tagName === "CALCITE-ACTION") {
+      this.open = false;
+      this.setFocus();
+    }
   }
 
   private updateTooltip(event: Event): void {

--- a/packages/components/src/components/action-menu/action-menu.tsx
+++ b/packages/components/src/components/action-menu/action-menu.tsx
@@ -367,7 +367,7 @@ export class ActionMenu extends LitElement {
 
   private handleCalciteActionClick(event): void {
     const composedPath = event.composedPath();
-    this.actionElements?.forEach((action) => {
+    this.actionElements?.some((action) => {
       if (composedPath.includes(action)) {
         this.open = false;
         this.setFocus();

--- a/packages/components/src/components/action-menu/action-menu.tsx
+++ b/packages/components/src/components/action-menu/action-menu.tsx
@@ -211,7 +211,7 @@ export class ActionMenu extends LitElement {
 
   override connectedCallback(): void {
     this.connectMenuButtonEl();
-    this.el.addEventListener("calciteActionMouseDown", this.actionMouseDownHandler);
+    this.el.addEventListener("calciteInternalActionMouseDown", this.actionMouseDownHandler);
   }
 
   override willUpdate(changes: PropertyValues<this>): void {
@@ -241,7 +241,7 @@ export class ActionMenu extends LitElement {
 
   override disconnectedCallback(): void {
     this.disconnectMenuButtonEl();
-    this.el.removeEventListener("calciteActionMouseDown", this.actionMouseDownHandler);
+    this.el.removeEventListener("calciteInternalActionMouseDown", this.actionMouseDownHandler);
   }
 
   //#endregion

--- a/packages/components/src/components/action-menu/action-menu.tsx
+++ b/packages/components/src/components/action-menu/action-menu.tsx
@@ -371,6 +371,7 @@ export class ActionMenu extends LitElement {
       if (composedPath.includes(action)) {
         this.open = false;
         this.setFocus();
+        return true;
       }
     });
   }

--- a/packages/components/src/components/action-menu/action-menu.tsx
+++ b/packages/components/src/components/action-menu/action-menu.tsx
@@ -250,8 +250,10 @@ export class ActionMenu extends LitElement {
 
   private actionMouseDownHandler = (event): void => {
     event.stopPropagation();
-    this.activeMenuItemIndex = this.actionElements?.findIndex((action) => { action === event.target });
-  }
+    this.activeMenuItemIndex = this.actionElements?.findIndex((action) => {
+      action === event.target;
+    });
+  };
 
   private expandedHandler(): void {
     this.open = false;
@@ -364,10 +366,13 @@ export class ActionMenu extends LitElement {
   }
 
   private handleCalciteActionClick(event): void {
-    if (event.target.tagName === "CALCITE-ACTION") {
-      this.open = false;
-      this.setFocus();
-    }
+    const composedPath = event.composedPath();
+    this.actionElements?.forEach((action) => {
+      if (composedPath.includes(action)) {
+        this.open = false;
+        this.setFocus();
+      }
+    });
   }
 
   private updateTooltip(event: Event): void {

--- a/packages/components/src/components/action-menu/action-menu.tsx
+++ b/packages/components/src/components/action-menu/action-menu.tsx
@@ -211,6 +211,7 @@ export class ActionMenu extends LitElement {
 
   override connectedCallback(): void {
     this.connectMenuButtonEl();
+    this.el.addEventListener("calciteActionMouseDown", this.actionMouseDownHandler);
   }
 
   override willUpdate(changes: PropertyValues<this>): void {
@@ -240,11 +241,17 @@ export class ActionMenu extends LitElement {
 
   override disconnectedCallback(): void {
     this.disconnectMenuButtonEl();
+    this.el.removeEventListener("calciteActionMouseDown", this.actionMouseDownHandler);
   }
 
   //#endregion
 
   //#region Private Methods
+
+  private actionMouseDownHandler = (event): void => {
+    event.stopPropagation();
+    this.activeMenuItemIndex = this.actionElements?.findIndex((action) => { action === event.target });
+  }
 
   private expandedHandler(): void {
     this.open = false;

--- a/packages/components/src/components/action-menu/action-menu.tsx
+++ b/packages/components/src/components/action-menu/action-menu.tsx
@@ -366,14 +366,10 @@ export class ActionMenu extends LitElement {
   }
 
   private handleCalciteActionClick(event): void {
-    const composedPath = event.composedPath();
-    this.actionElements?.some((action) => {
-      if (composedPath.includes(action)) {
-        this.open = false;
-        this.setFocus();
-        return true;
-      }
-    });
+    if (this.actionElements?.some((action) => event.composedPath().includes(action))) {
+      this.open = false;
+      this.setFocus();
+    }
   }
 
   private updateTooltip(event: Event): void {

--- a/packages/components/src/components/action/action.tsx
+++ b/packages/components/src/components/action/action.tsx
@@ -1,6 +1,6 @@
 // @ts-strict-ignore
 import { createRef } from "lit-html/directives/ref.js";
-import { LitElement, property, h, method, JsxNode, Fragment, LuminaJsx } from "@arcgis/lumina";
+import { LitElement, property, h, method, JsxNode, Fragment, LuminaJsx, createEvent } from "@arcgis/lumina";
 import { guid } from "../../utils/guid";
 import { createObserver } from "../../utils/observers";
 import { getIconScale } from "../../utils/component";
@@ -217,6 +217,13 @@ export class Action extends LitElement implements FormOwner {
 
   //#endregion
 
+  //#region Events
+
+  /** @internal Fires when the action's button is being pressed down. */
+  calciteActionMouseDown =  createEvent({ cancelable: false });
+
+  //#endregion
+
   //#region Private Methods
 
   private handleClick(): void {
@@ -226,6 +233,10 @@ export class Action extends LitElement implements FormOwner {
     } else if (type === "reset") {
       resetForm(this);
     }
+  }
+
+  private handleMouseDown(): void {
+    this.calciteActionMouseDown.emit();
   }
 
   //#endregion
@@ -379,6 +390,7 @@ export class Action extends LitElement implements FormOwner {
         disabled={disabled}
         id={buttonId}
         onClick={this.handleClick}
+        onMouseDown={this.handleMouseDown}
         ref={this.buttonRef}
         role={this.aria?.role}
       >

--- a/packages/components/src/components/action/action.tsx
+++ b/packages/components/src/components/action/action.tsx
@@ -1,6 +1,15 @@
 // @ts-strict-ignore
 import { createRef } from "lit-html/directives/ref.js";
-import { LitElement, property, h, method, JsxNode, Fragment, LuminaJsx, createEvent } from "@arcgis/lumina";
+import {
+  LitElement,
+  property,
+  h,
+  method,
+  JsxNode,
+  Fragment,
+  LuminaJsx,
+  createEvent,
+} from "@arcgis/lumina";
 import { guid } from "../../utils/guid";
 import { createObserver } from "../../utils/observers";
 import { getIconScale } from "../../utils/component";
@@ -220,7 +229,7 @@ export class Action extends LitElement implements FormOwner {
   //#region Events
 
   /** @internal Fires when the action's button is being pressed down. */
-  calciteActionMouseDown =  createEvent({ cancelable: false });
+  calciteInternalActionMouseDown = createEvent({ cancelable: false });
 
   //#endregion
 
@@ -236,7 +245,7 @@ export class Action extends LitElement implements FormOwner {
   }
 
   private handleMouseDown(): void {
-    this.calciteActionMouseDown.emit();
+    this.calciteInternalActionMouseDown.emit();
   }
 
   //#endregion


### PR DESCRIPTION
**Related Issue:** #13453 

## Summary

This fixes an issue where clicking inside the action menu's popover region outside the boundary of any of the action buttons resulted in the popover closing.  The visible focus ring will also now move to the action button that is being pressed down by the mouse instead of simultaneously showing the focus ring on the previously active action button.