### PR TITLE
docs: prepare for API Extractor

### DIFF
--- a/packages/components/.storybook/utils.ts
+++ b/packages/components/.storybook/utils.ts
@@ -10,7 +10,7 @@ export const modesDarkDefault = {
  * This helper creates a story that captures all breakpoints across all scales for testing.
  *
  * @param singleStoryHtml – HTML story template with placeholders for `scale` attributes (e.g., `{scale}`). You can additionally use `.breakpoint-stories-container` and `.breakpoint-story-container` to style breakpoint story containers.
- * @param [focused] – when specified, creates a single story for the provided breakpoint and scale.
+ * @param focused – when specified, creates a single story for the provided breakpoint and scale.
  *   This should only be used if multiple stories cannot be displayed side-by-side.
  * @param focused.breakpoint
  * @param focused.scale

--- a/packages/components/src/components/autocomplete/autocomplete.tsx
+++ b/packages/components/src/components/autocomplete/autocomplete.tsx
@@ -348,7 +348,6 @@ export class Autocomplete
    * Updates the position of the component.
    *
    * @param delayed - `true` if the placement should be updated after the component is finished rendering.
-   * @returns {Promise<void>}
    */
   @method()
   async reposition(delayed = false): Promise<void> {
@@ -378,7 +377,7 @@ export class Autocomplete
    *   behavior: "auto" // Specifies whether the scrolling should animate smoothly (smooth), or happen instantly in a single jump (auto, the default value).
    * });
    * @param options - allows specific coordinates to be defined.
-   * @returns - promise that resolves once the content is scrolled to.
+   * @returns promise that resolves once the content is scrolled to.
    */
   @method()
   async scrollContentTo(options?: ScrollToOptions): Promise<void> {
@@ -387,8 +386,6 @@ export class Autocomplete
 
   /**
    * Selects the text of the component's `value`.
-   *
-   * @returns {Promise<void>}
    */
   @method()
   async selectText(): Promise<void> {
@@ -401,7 +398,6 @@ export class Autocomplete
    * @param options - When specified an optional object customizes the component's focusing process. When `preventScroll` is `true`, scrolling will not occur on the component.
    *
    * @mdn [focus(options)](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus#options)
-   * @returns {Promise<void>}
    */
   @method()
   async setFocus(options?: FocusOptions): Promise<void> {

--- a/packages/components/src/components/avatar/utils.ts
+++ b/packages/components/src/components/avatar/utils.ts
@@ -27,8 +27,7 @@ export function stringToHex(string: string): string {
 /**
  * The function splits the string into two halves, reverses each half, and then concatenates them.
  *
- * @param {string} string - The input string to be mixed.
- * @returns {string} - The mixed string.
+ * @param string - The input string to be mixed.
  */
 function mixStringDeterministically(string: string): string {
   const midPoint = Math.floor(string.length / 2);

--- a/packages/components/src/components/block-group/block-group.tsx
+++ b/packages/components/src/components/block-group/block-group.tsx
@@ -138,7 +138,6 @@ export class BlockGroup extends LitElement implements SortableComponent {
    * @param options - When specified an optional object customizes the component's focusing process. When `preventScroll` is `true`, scrolling will not occur on the component.
    *
    * @mdn [focus(options)](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus#options)
-   * @returns {Promise<void>}
    */
   @method()
   async setFocus(options?: FocusOptions): Promise<void> {

--- a/packages/components/src/components/color-picker/utils.ts
+++ b/packages/components/src/components/color-picker/utils.ts
@@ -145,6 +145,7 @@ export function hexToRGB(hex: string, hasAlpha = false): RGB | RGBA {
 const enumify = <T extends { [index: string]: U }, U extends string>(x: T) => x;
 type Enumify<T> = T[keyof T];
 
+/** @public */
 export const CSSColorMode = enumify({
   HEX: "hex",
   HEXA: "hexa",
@@ -153,8 +154,10 @@ export const CSSColorMode = enumify({
   HSL_CSS: "hsl-css",
   HSLA_CSS: "hsla-css",
 });
+/** @public */
 type CSSColorMode = Enumify<typeof CSSColorMode>;
 
+/** @public */
 export const ObjectColorMode = enumify({
   RGB: "rgb",
   RGBA: "rgba",
@@ -163,6 +166,7 @@ export const ObjectColorMode = enumify({
   HSV: "hsv",
   HSVA: "hsva",
 });
+/** @public */
 type ObjectColorMode = Enumify<typeof ObjectColorMode>;
 
 export type SupportedMode = CSSColorMode | ObjectColorMode;

--- a/packages/components/src/components/date-picker-month-header/date-picker-month-header.tsx
+++ b/packages/components/src/components/date-picker-month-header/date-picker-month-header.tsx
@@ -37,6 +37,7 @@ declare global {
   }
 }
 
+/** @private */
 export class DatePickerMonthHeader extends LitElement {
   // #region Static Members
 

--- a/packages/components/src/components/dialog/dialog.tsx
+++ b/packages/components/src/components/dialog/dialog.tsx
@@ -271,7 +271,7 @@ export class Dialog extends LitElement {
    *   behavior: "auto" // Specifies whether the scrolling should animate smoothly (smooth), or happen instantly in a single jump (auto, the default value).
    * });
    * @param options - allows specific coordinates to be defined.
-   * @returns - promise that resolves once the content is scrolled to.
+   * @returns promise that resolves once the content is scrolled to.
    */
   @method()
   async scrollContentTo(options?: ScrollToOptions): Promise<void> {
@@ -284,7 +284,7 @@ export class Dialog extends LitElement {
    * @param options - When specified an optional object customizes the component's focusing process. When `preventScroll` is `true`, scrolling will not occur on the component.
    *
    * @mdn [focus(options)](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus#options)
-   * @returns {Promise<void>} - A promise that is resolved when the operation has completed.
+   * @returns A promise that is resolved when the operation has completed.
    */
   @method()
   async setFocus(options?: FocusOptions): Promise<void> {

--- a/packages/components/src/components/filter/filter.tsx
+++ b/packages/components/src/components/filter/filter.tsx
@@ -117,8 +117,7 @@ export class Filter extends LitElement {
    *
    * This method can be useful because filtering is delayed and asynchronous.
    *
-   * @param {string} value - The filter text value.
-   * @returns {Promise<void>}
+   * @param value - The filter text value.
    */
   @method()
   async filter(value: string = this.value): Promise<void> {

--- a/packages/components/src/components/flow-item/flow-item.tsx
+++ b/packages/components/src/components/flow-item/flow-item.tsx
@@ -154,7 +154,7 @@ export class FlowItem extends LitElement {
    *   behavior: "auto" // Specifies whether the scrolling should animate smoothly (smooth), or happen instantly in a single jump (auto, the default value).
    * });
    * @param options - allows specific coordinates to be defined.
-   * @returns - promise that resolves once the content is scrolled to.
+   * @returns promise that resolves once the content is scrolled to.
    */
   @method()
   async scrollContentTo(options?: ScrollToOptions): Promise<void> {

--- a/packages/components/src/components/input-date-picker/utils.ts
+++ b/packages/components/src/components/input-date-picker/utils.ts
@@ -2,9 +2,6 @@ import { datePartsFromISO } from "../../utils/date";
 
 /**
  * Specifies if an ISO string date (YYYY-MM-DD) has two digit year.
- *
- * @param {string} value
- * @returns {boolean}
  */
 export function isTwoDigitYear(value: string): boolean {
   if (!value) {
@@ -16,9 +13,6 @@ export function isTwoDigitYear(value: string): boolean {
 
 /**
  * Returns a normalized year to current century from a given two digit year number.
- *
- * @param {number} twoDigitYear
- * @returns {string}
  */
 export function normalizeToCurrentCentury(twoDigitYear: number): number {
   const currentYear = new Date().getFullYear();

--- a/packages/components/src/components/list/list.tsx
+++ b/packages/components/src/components/list/list.tsx
@@ -325,7 +325,6 @@ export class List extends LitElement implements SortableComponent {
    * @param options - When specified an optional object customizes the component's focusing process. When `preventScroll` is `true`, scrolling will not occur on the component.
    *
    * @mdn [focus(options)](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus#options)
-   * @returns {Promise<void>}
    */
   @method()
   async setFocus(options?: FocusOptions): Promise<void> {

--- a/packages/components/src/components/panel/panel.tsx
+++ b/packages/components/src/components/panel/panel.tsx
@@ -192,7 +192,7 @@ export class Panel extends LitElement {
    *   behavior: "auto" // Specifies whether the scrolling should animate smoothly (smooth), or happen instantly in a single jump (auto, the default value).
    * });
    * @param options - allows specific coordinates to be defined.
-   * @returns - promise that resolves once the content is scrolled to.
+   * @returns promise that resolves once the content is scrolled to.
    */
   @method()
   async scrollContentTo(options?: ScrollToOptions): Promise<void> {

--- a/packages/components/src/components/sheet/sheet.tsx
+++ b/packages/components/src/components/sheet/sheet.tsx
@@ -133,8 +133,6 @@ export class Sheet extends LitElement {
 
   /**
    * Passes a function to run before the component closes.
-   *
-   * @returns {Promise<void>}
    */
   @property() beforeClose: (el: Sheet["el"]) => Promise<void>;
 

--- a/packages/components/src/components/slider/slider.tsx
+++ b/packages/components/src/components/slider/slider.tsx
@@ -695,7 +695,7 @@ export class Slider extends LitElement implements LabelableComponent, FormCompon
   /**
    * Set prop value(s) if changed at the component level
    *
-   * @param {object} values - a set of key/value pairs delineating what properties in the component to update
+   * @param values - a set of key/value pairs delineating what properties in the component to update
    */
   private setValue(
     values: Partial<{

--- a/packages/components/src/components/tooltip/tooltip.e2e.ts
+++ b/packages/components/src/components/tooltip/tooltip.e2e.ts
@@ -68,7 +68,7 @@ describe("calcite-tooltip", () => {
    * Helps assert the canceled Esc key press when closing tooltips
    * Must be called before the tooltip is closed via keyboard.
    *
-   * @param {E2EPage} page - The E2EPage
+   * @param page - The E2EPage
    */
   async function setUpEscapeKeyCancelListener(page: E2EPage): Promise<void> {
     await page.evaluate(() => {

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -7,6 +7,7 @@
 import { Runtime } from "@arcgis/lumina";
 import { setAssetPath as runtimeSetAssetPath } from "./runtime";
 
+/** @public */
 declare module "csstype" {
   interface Properties {
     [index: `--calcite-${string}`]: any;

--- a/packages/components/src/tests/commonTests/accessible.ts
+++ b/packages/components/src/tests/commonTests/accessible.ts
@@ -19,7 +19,7 @@ type AxeOwningWindow = GlobalTestProps<{ axe: typeof axe }>;
  * describe("accessible"), () => {
  *    accessible(`<calcite-tree></calcite-tree>`);
  * });
- * @param {ComponentTestSetup} componentTestSetup - A component tag, html, or the tag and e2e page for setting up a test
+ * @param componentTestSetup - A component tag, html, or the tag and e2e page for setting up a test
  */
 export function accessible(componentTestSetup: ComponentTestSetup): void {
   it("is accessible", async () => {

--- a/packages/components/src/tests/commonTests/browser/cancelable.ts
+++ b/packages/components/src/tests/commonTests/browser/cancelable.ts
@@ -11,7 +11,7 @@ import { UseCancelable } from "../../../controllers/useCancelable";
  *   cancelable("calcite-action-bar");
  * });
  *
- * @param {ComponentTag} componentTag - The tag name of the component to test.
+ * @param componentTag - The tag name of the component to test.
  */
 export function cancelable(componentTag: ComponentTag): void {
   describe(`cancelable behavior`, () => {

--- a/packages/components/src/tests/commonTests/focusTrap.ts
+++ b/packages/components/src/tests/commonTests/focusTrap.ts
@@ -30,7 +30,7 @@ interface FocusTrapOptions {
  *   });
  * });
  *
- * @param {string} componentTestSetup
+ * @param componentTestSetup
  * @param options
  */
 export function focusTrap(componentTestSetup: ComponentTestSetup, options: FocusTrapOptions): void {

--- a/packages/components/src/tests/commonTests/formAssociated.ts
+++ b/packages/components/src/tests/commonTests/formAssociated.ts
@@ -61,8 +61,8 @@ interface FormAssociatedOptions {
  *
  * Note that this helper should be used within a describe block.
  *
- * @param {string} componentTagOrHtml - the component tag or HTML markup to test against
- * @param {FormAssociatedOptions} options - form associated options
+ * @param componentTagOrHtml - the component tag or HTML markup to test against
+ * @param options - form associated options
  */
 export function formAssociated(
   componentTagOrHtml: TagOrHTML | TagOrHTMLWithBeforeContent,

--- a/packages/components/src/tests/commonTests/hidden.ts
+++ b/packages/components/src/tests/commonTests/hidden.ts
@@ -12,7 +12,7 @@ import { ComponentTestSetup } from "./interfaces";
  * describe("honors hidden attribute", () => {
  *    hidden("calcite-accordion")
  * });
- * @param {string} componentTagOrHTML - the component tag or HTML markup to test against
+ * @param componentTagOrHTML - the component tag or HTML markup to test against
  */
 export async function hidden(componentTestSetup: ComponentTestSetup): Promise<void> {
   it("is hidden", async () => {

--- a/packages/components/src/tests/commonTests/labelable.ts
+++ b/packages/components/src/tests/commonTests/labelable.ts
@@ -82,8 +82,8 @@ export interface LabelableOptions extends Pick<FocusableOptions, "focusTargetSel
  * describe("labelable", () => {
  *    async () => labelable("calcite-button")
  * })
- * @param {string} componentTagOrHtml - The component tag or HTML used to test label support.
- * @param {LabelableOptions} [options] - Labelable options.
+ * @param componentTagOrHtml - The component tag or HTML used to test label support.
+ * @param options - Labelable options.
  */
 export function labelable(
   componentTagOrHtml: TagOrHTML | TagOrHTMLWithBeforeContent,

--- a/packages/components/src/tests/commonTests/openClose.ts
+++ b/packages/components/src/tests/commonTests/openClose.ts
@@ -39,8 +39,8 @@ const defaultOptions: OpenCloseOptions = {
  *     }
  *   });
  * });
- * @param {ComponentTestSetup} componentTestSetup - A component tag, html, or the tag and e2e page for setting up a test.
- * @param {object} [options] - Additional options to assert.
+ * @param componentTestSetup - A component tag, html, or the tag and e2e page for setting up a test.
+ * @param options - Additional options to assert.
  */
 export function openClose(componentTestSetup: ComponentTestSetup, options?: OpenCloseOptions): void {
   const effectiveOptions = { ...defaultOptions, ...options };

--- a/packages/components/src/tests/utils/puppeteer.ts
+++ b/packages/components/src/tests/utils/puppeteer.ts
@@ -29,9 +29,9 @@ type MouseInitEvent = Pick<
 /**
  * Drag and drop utility based on https://github.com/puppeteer/puppeteer/issues/1366#issuecomment-615887204
  *
- * @param {E2EPage} page - the e2e page
- * @param {DragAndDropSelector} dragStartSelector - Selector for the drag's start
- * @param {DragAndDropSelector} dragEndSelector - Selector for the drag's end
+ * @param page - the e2e page
+ * @param dragStartSelector - Selector for the drag's start
+ * @param dragEndSelector - Selector for the drag's end
  */
 export async function dragAndDrop(
   page: E2EPage,
@@ -119,8 +119,7 @@ export async function dragAndDrop(
 
 /**
  *
- * @param {E2EElement} input - the element to select text from
- * @returns {Promise<void>}
+ * @param input - the element to select text from
  */
 export function selectText(input: E2EElement): Promise<void> {
   // workaround for selecting text based on https://github.com/puppeteer/puppeteer/issues/1313#issuecomment-436932478
@@ -130,9 +129,9 @@ export function selectText(input: E2EElement): Promise<void> {
 /**
  * Helper to get an E2EElement's x,y coordinates.
  *
- * @param {E2EPage} page - the e2e page
- * @param {string} elementSelector - the element selector
- * @param {string} shadowSelector - the shadowRoot selector
+ * @param page - the e2e page
+ * @param elementSelector - the element selector
+ * @param shadowSelector - the shadowRoot selector
  * @deprecated Use `getElementRect` instead.
  */
 export async function getElementXY(
@@ -155,10 +154,10 @@ export async function getElementXY(
 /**
  * Helper to get an E2EElement's DOMRect object.
  *
- * @param {E2EPage} page - the e2e page
- * @param {string} elementSelector - the element selector
- * @param {string} shadowSelector - the shadowRoot selector
- * @returns {Promise<DOMRect>} Promise with DOMRect object.
+ * @param page - the e2e page
+ * @param elementSelector - the element selector
+ * @param shadowSelector - the shadowRoot selector
+ * @returns Promise with DOMRect object.
  */
 export async function getElementRect(
   page: E2EPage,
@@ -188,7 +187,7 @@ export async function getElementRect(
  *
  * await visualizeMouseCursor(page);
  * await page.waitForChanges();
- * @param {E2EPage} page - the e2e page
+ * @param page - the e2e page
  */
 export async function visualizeMouseCursor(page: E2EPage): Promise<void> {
   await page.evaluate(() => {
@@ -284,7 +283,7 @@ export async function waitForAnimationFrame(page: E2EPage): Promise<void> {
 /**
  * Creates an E2E page for tests that need to create and set up elements programmatically.
  *
- * @returns {Promise<E2EPage>} an e2e page
+ * @returns an e2e page
  */
 export async function newProgrammaticE2EPage(): Promise<E2EPage> {
   const page = await newE2EPage();
@@ -349,9 +348,9 @@ type GetFocusedElementProp = {
 /**
  * This helps get serializable properties from the focused element.
  *
- * @param {E2EPage} page - the E2E test page
- * @param {string} prop - the property to get from the focused element (note: must be serializable)
- * @param {GetFocusedElementProp} options – additional configuration options
+ * @param page - the E2E test page
+ * @param prop - the property to get from the focused element (note: must be serializable)
+ * @param options – additional configuration options
  */
 export async function getFocusedElementProp<T extends HTMLElement = HTMLElement, K extends keyof T = keyof T>(
   page: E2EPage,
@@ -441,7 +440,6 @@ export async function createSelectedItemsAsserter(
  * @param options.componentTag  - the component tag
  * @param options.shadowInputTypeSelector - the shadow input type selector
  * @param options.position - the expected caret position
- * @returns {Promise<void>}
  */
 export async function assertCaretPosition({
   page,
@@ -472,7 +470,7 @@ export async function assertCaretPosition({
  * This utils helps to get the element handle from an E2EElement.
  *
  * @param element - the E2E element
- * @returns {Promise<ElementHandle>} - the element handle
+ * @returns the element handle
  */
 export async function toElementHandle(element: E2EElement): Promise<ElementHandle> {
   return element.handle;

--- a/packages/components/src/tests/utils/timing.ts
+++ b/packages/components/src/tests/utils/timing.ts
@@ -2,8 +2,6 @@
  * Helper function to wait for the next animation frame.
  *
  * If you need to run this within a Puppeteer browser context, please see the `waitForAnimationFrame` function in the `puppeteer` module.
- *
- * @returns {Promise<void>}
  */
 export async function waitForAnimationFrame(): Promise<void> {
   return new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));

--- a/packages/components/src/utils/date.ts
+++ b/packages/components/src/utils/date.ts
@@ -292,8 +292,8 @@ export function getDaysDiff(date1: Date, date2: Date): number {
 /**
  * Set time of the day to the end.
  *
- * @param {Date} date Date.
- * @returns {Date} Date with time set to end of day .
+ * @param date Date.
+ * @returns Date with time set to end of day .
  */
 export function setEndOfDay(date: Date): Date {
   date.setHours(23, 59, 59, 999);
@@ -305,7 +305,6 @@ export function setEndOfDay(date: Date): Date {
  *
  * @param date1
  * @param date2
- * @returns {boolean}
  */
 export function hasSameMonthAndYear(date1: Date, date2: Date): boolean {
   return date1 && date2 && date1.getMonth() === date2.getMonth() && date1.getFullYear() === date2.getFullYear();

--- a/packages/components/src/utils/dom.ts
+++ b/packages/components/src/utils/dom.ts
@@ -19,8 +19,8 @@ export const tabbableOptions = {
  *
  * If it already has an ID, it will be preserved, otherwise a unique one will be generated and assigned.
  *
- * @param {Element} el An element.
- * @returns {string} The element's ID.
+ * @param el An element.
+ * @returns The element's ID.
  */
 export function ensureId(el: Element): string {
   if (!el) {
@@ -33,8 +33,8 @@ export function ensureId(el: Element): string {
 /**
  * This helper returns an array from a NodeList.
  *
- * @param {NodeList} nodeList A NodeList.
- * @returns {Element[]} An array of elements.
+ * @param nodeList A NodeList.
+ * @returns An array of elements.
  */
 export function nodeListToArray<T extends Element>(nodeList: HTMLCollectionOf<T> | NodeListOf<T> | T[]): T[] {
   return Array.isArray(nodeList) ? nodeList : Array.from(nodeList);
@@ -45,8 +45,8 @@ export type Direction = "ltr" | "rtl";
 /**
  * This helper returns the Calcite "mode" of an element.
  *
- * @param {HTMLElement} el An element.
- * @returns {"light"|"dark"} The Calcite mode.
+ * @param el An element.
+ * @returns The Calcite mode.
  */
 export function getModeName(el: HTMLElement): "light" | "dark" {
   const closestElWithMode = closestElementCrossShadowBoundary(
@@ -63,8 +63,8 @@ export function getModeName(el: HTMLElement): "light" | "dark" {
 /**
  * This helper returns the direction of a HTML element.
  *
- * @param {HTMLElement} el An element.
- * @returns {Direction} The direction.
+ * @param el An element.
+ * @returns The direction.
  */
 export function getElementDir(el: HTMLElement): Direction {
   const prop = "dir";
@@ -76,8 +76,8 @@ export function getElementDir(el: HTMLElement): Direction {
 /**
  * This helper returns the computed width in pixels of a rendered HTMLElement.
  *
- * @param {HTMLElement} el An element.
- * @returns {number} The element's width.
+ * @param el An element.
+ * @returns The element's width.
  */
 export function getElementWidth(el: HTMLElement): number {
   if (!el) {
@@ -89,8 +89,8 @@ export function getElementWidth(el: HTMLElement): number {
 /**
  * This helper returns the rootNode of an element.
  *
- * @param {Element} el An element.
- * @returns {Document|ShadowRoot} The element's root node.
+ * @param el An element.
+ * @returns The element's root node.
  */
 export function getRootNode(el: Element): Document | ShadowRoot {
   return el.getRootNode() as Document | ShadowRoot;
@@ -99,8 +99,8 @@ export function getRootNode(el: Element): Document | ShadowRoot {
 /**
  * This helper returns the node's shadowRoot root node if it exists.
  *
- * @param {Element} el The element.
- * @returns {ShadowRoot|null} The element's root node ShadowRoot.
+ * @param el The element.
+ * @returns The element's root node ShadowRoot.
  */
 export function getShadowRootNode(el: Element): ShadowRoot | null {
   const rootNode = getRootNode(el);
@@ -112,8 +112,8 @@ export function getShadowRootNode(el: Element): ShadowRoot | null {
  *
  * See https://stackoverflow.com/questions/118241/calculate-text-width-with-javascript
  *
- * @param {string} text The string of text to measure.
- * @param {string} font The CSS font attribute's value, which should include size and face, e.g. "12px Arial".
+ * @param text The string of text to measure.
+ * @param font The CSS font attribute's value, which should include size and face, e.g. "12px Arial".
  */
 export function getTextWidth(text: string, font: string): number {
   if (!text) {
@@ -128,8 +128,8 @@ export function getTextWidth(text: string, font: string): number {
 /**
  * This helper returns the host of a ShadowRoot.
  *
- * @param {Document | ShadowRoot} root A root element.
- * @returns {Element | null} The host element.
+ * @param root A root element.
+ * @returns  The host element.
  */
 export function getHost(root: Document | ShadowRoot): Element | null {
   return (root as ShadowRoot).host || null;
@@ -139,12 +139,6 @@ export function getHost(root: Document | ShadowRoot): Element | null {
  * This helper queries an element's rootNode and any ancestor rootNodes.
  *
  * If both an 'id' and 'selector' are supplied, 'id' will take precedence over 'selector'.
- *
- * @param {Element} el An element.
- * @param root0
- * @param root0.selector
- * @param root0.id
- * @returns {Element} An element.
  */
 export function queryElementRoots<T extends Element = Element>(
   el: Element,
@@ -186,9 +180,9 @@ export function queryElementRoots<T extends Element = Element>(
  *
  * Based on https://stackoverflow.com/q/54520554/194216
  *
- * @param {Element} element The starting element.
- * @param {string} selector The selector.
- * @returns {Element} The targeted element.
+ * @param element The starting element.
+ * @param selector The selector.
+ * @returns The targeted element.
  */
 export function closestElementCrossShadowBoundary<TagName extends keyof HTMLElementTagNameMap>(
   element: Element,
@@ -212,9 +206,9 @@ export function closestElementCrossShadowBoundary<T extends Element = Element>(
  *
  * Returning early or undefined in `onVisit` will continue traversing up the DOM tree. Otherwise, traversal will halt with the returned value as the result of the function
  *
- * @param {Element} element An element.
- * @param {(node: Node) => Element} onVisit The callback.
- * @returns {Element} The result.
+ * @param element An element.
+ * @param onVisit The callback.
+ * @returns The result.
  */
 export function walkUpAncestry<T = any>(element: Element, onVisit: (node: Node) => T): T {
   return visit(element, onVisit);
@@ -244,8 +238,8 @@ export interface SetFocusable extends LitElement {
 /**
  * This helper returns true when an element has a setFocus method.
  *
- * @param {Element} el An element.
- * @returns {boolean} Whether the element is focusable.
+ * @param el An element.
+ * @returns Whether the element is focusable.
  */
 export function isCalciteFocusable(el: FocusableElement): el is SetFocusable {
   return typeof (el as SetFocusable)?.setFocus === "function";
@@ -254,7 +248,7 @@ export function isCalciteFocusable(el: FocusableElement): el is SetFocusable {
 /**
  * This helper focuses an element using the `setFocus` method if available and falls back to using the `focus` method if not available.
  *
- * @param {Element} el An element.
+ * @param el An element.
  * @param includeContainer When true, the container element will be considered as well. Note, this is only applicable when `setFocus` is not applicable.
  * @param strategy The focus strategy to use when finding the first focusable element. Defaults to "tabbable".
  * @param context The element invoking the focus – use when the host is focusable to short-circuit the focus call.
@@ -284,8 +278,8 @@ export async function focusElement(
 /**
  * Helper to get the first tabbable element.
  *
- * @param {HTMLElement} element The html element containing tabbable elements.
- * @param {boolean} includeContainer When true, the container element will be considered as well.
+ * @param element The html element containing tabbable elements.
+ * @param includeContainer When true, the container element will be considered as well.
  *
  * @returns the first tabbable element.
  */
@@ -300,8 +294,8 @@ export function getFirstTabbable(element: HTMLElement, includeContainer?: boolea
 /**
  * Helper to focus the first tabbable element.
  *
- * @param {HTMLElement} element The html element containing tabbable elements.
- * @param {boolean} includeContainer When true, the container element will be considered as well.
+ * @param element The html element containing tabbable elements.
+ * @param includeContainer When true, the container element will be considered as well.
  * @param options - When specified an optional object customizes the component's focusing process. When `preventScroll` is `true`, scrolling will not occur on the component.
  *
  * @mdn [focus(options)](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus#options)
@@ -313,8 +307,8 @@ export function focusFirstTabbable(element: HTMLElement, includeContainer?: bool
 /**
  * Helper to get the first focusable element.
  *
- * @param {HTMLElement} element The html element containing focusable elements.
- * @param {boolean} includeContainer When true, the container element will be considered as well.
+ * @param element The html element containing focusable elements.
+ * @param includeContainer When true, the container element will be considered as well.
  *
  * @returns the first focusable element.
  *
@@ -331,8 +325,8 @@ function getFirstFocusable(element: HTMLElement, includeContainer?: boolean): HT
 /**
  * Helper to focus the first focusable element.
  *
- * @param {HTMLElement} element The html element containing focusable elements.
- * @param {boolean} includeContainer When true, the container element will be considered as well.
+ * @param element The html element containing focusable elements.
+ * @param includeContainer When true, the container element will be considered as well.
  *
  * @internal
  */
@@ -343,9 +337,9 @@ function focusFirstFocusable(element: HTMLElement, includeContainer?: boolean, o
 /**
  * Filters direct children.
  *
- * @param {Element} el An element.
- * @param {string} selector The selector.
- * @returns {Element[]} An array of elements.
+ * @param el An element.
+ * @param selector The selector.
+ * @returns An array of elements.
  */
 export function filterDirectChildren<T extends Element>(el: Element, selector: string): T[] {
   return Array.from(el.children).filter((child): child is T => child.matches(selector));
@@ -354,9 +348,9 @@ export function filterDirectChildren<T extends Element>(el: Element, selector: s
 /**
  * Filters an array of HTML elements by the provided css selector string.
  *
- * @param {Element[]} elements An array of elements, such as one returned by HTMLSlotElement.assignedElements().
- * @param {string} selector The CSS selector string to filter the returned elements by.
- * @returns {Element[]} A filtered array of elements.
+ * @param elements An array of elements, such as one returned by HTMLSlotElement.assignedElements().
+ * @param selector The CSS selector string to filter the returned elements by.
+ * @returns A filtered array of elements.
  */
 export function filterElementsBySelector<T extends Element>(elements: Element[], selector: string): T[] {
   return elements.filter((element): element is T => element.matches(selector));
@@ -365,10 +359,10 @@ export function filterElementsBySelector<T extends Element>(elements: Element[],
 /**
  * Set a default icon from a defined set or allow an override with an icon name string
  *
- * @param {Record<string, string>} iconObject The icon object.
- * @param {string | boolean} iconValue The icon value.
- * @param {string} matchedValue The matched value.
- * @returns {string|undefined} The resulting icon value.
+ * @param iconObject The icon object.
+ * @param iconValue The icon value.
+ * @param matchedValue The matched value.
+ * @returns The resulting icon value.
  */
 export function setRequestedIcon(
   iconObject: Record<string, IconName>,
@@ -385,9 +379,9 @@ export function setRequestedIcon(
 /**
  * This helper returns true when two rectangles intersect.
  *
- * @param {DOMRect} rect1 The first rectangle.
- * @param {DOMRect} rect2 The second rectangle.
- * @returns {boolean} The result.
+ * @param rect1 The first rectangle.
+ * @param rect2 The second rectangle.
+ * @returns The result.
  */
 export function intersects(rect1: DOMRect, rect2: DOMRect): boolean {
   return !(
@@ -403,8 +397,8 @@ export function intersects(rect1: DOMRect, rect2: DOMRect): boolean {
  *
  * It should only be used for aria attributes that require a string value of "true" or "false".
  *
- * @param {boolean} value The value.
- * @returns {string} The string conversion of a boolean value ("true" | "false").
+ * @param value The value.
+ * @returns The string conversion of a boolean value ("true" | "false").
  */
 export function toAriaBoolean(value: boolean): string {
   return Boolean(value).toString();
@@ -417,8 +411,8 @@ export function toAriaBoolean(value: boolean): string {
  * <slot onSlotchange={(event) => this.mySlotHasContent = slotChangeHasContent(event)} />}
  * ```
  *
- * @param {Event} event The event.
- * @returns {boolean} Whether the slot has any content.
+ * @param event The event.
+ * @returns Whether the slot has any content.
  */
 export function slotChangeHasContent(event: Event): boolean {
   return slotChangeHasAssignedElement(event) || slotChangeHasTextContent(event);
@@ -431,8 +425,8 @@ export function slotChangeHasContent(event: Event): boolean {
  * <slot onSlotchange={(event) => this.mySlotText = slotChangeGetTextContent(event)} />}
  * ```
  *
- * @param {Event} event The event.
- * @returns {string} The slots text.
+ * @param event The event.
+ * @returns The slots text.
  */
 export function slotChangeGetTextContent(event: Event): string {
   return slotChangeGetAssignedNodes(event)
@@ -445,8 +439,8 @@ export function slotChangeGetTextContent(event: Event): string {
 /**
  * This helper checks if an element has visible content.
  *
- * @param {HTMLElement} element The element to check.
- * @returns {boolean} True if the element has visible content, otherwise false.
+ * @param element The element to check.
+ * @returns True if the element has visible content, otherwise false.
  */
 export function hasVisibleContent(element: HTMLElement): boolean {
   for (const node of element.childNodes) {
@@ -464,8 +458,8 @@ export function hasVisibleContent(element: HTMLElement): boolean {
  * <slot onSlotchange={(event) => this.mySlotHasTextContent = slotChangeHasTextContent(event)} />}
  * ```
  *
- * @param {Event} event The event.
- * @returns {boolean} Whether the slot has any text content.
+ * @param event The event.
+ * @returns Whether the slot has any text content.
  */
 export function slotChangeHasTextContent(event: Event): boolean {
   return !!slotChangeGetTextContent(event);
@@ -478,8 +472,8 @@ export function slotChangeHasTextContent(event: Event): boolean {
  * <slot onSlotchange={(event) => this.mySlotHasNode = slotChangeHasAssignedNode(event)} />}
  * ```
  *
- * @param {Event} event The event.
- * @returns {boolean} Whether the slot has any assigned nodes.
+ * @param event The event.
+ * @returns Whether the slot has any assigned nodes.
  */
 export function slotChangeHasAssignedNode(event: Event): boolean {
   return !!slotChangeGetAssignedNodes(event).length;
@@ -492,8 +486,8 @@ export function slotChangeHasAssignedNode(event: Event): boolean {
  * <slot onSlotchange={(event) => this.mySlotNodes = slotChangeGetAssignedNodes(event)} />}
  * ```
  *
- * @param {Event} event The event.
- * @returns {boolean} Whether the slot has any assigned nodes.
+ * @param event The event.
+ * @returns Whether the slot has any assigned nodes.
  */
 export function slotChangeGetAssignedNodes(event: Event): Node[] {
   return (event.currentTarget as HTMLSlotElement).assignedNodes({
@@ -508,8 +502,8 @@ export function slotChangeGetAssignedNodes(event: Event): Node[] {
  * <slot onSlotchange={(event) => this.mySlotHasElement = slotChangeHasAssignedElement(event)} />}
  * ```
  *
- * @param {Event} event The event.
- * @returns {boolean} Whether the slot has any assigned elements.
+ * @param event The event.
+ * @returns Whether the slot has any assigned elements.
  */
 export function slotChangeHasAssignedElement(event: Event): boolean {
   return !!slotChangeGetAssignedElements(event).length;
@@ -522,9 +516,9 @@ export function slotChangeHasAssignedElement(event: Event): boolean {
  * <slot onSlotchange={(event) => this.mySlotElements = slotChangeGetAssignedElements(event)} />}
  * ```
  *
- * @param {Event} event The event.
- * @param {string} selector The CSS selector string to filter the returned elements by.
- * @returns {Element[]} An array of elements.
+ * @param event The event.
+ * @param selector The CSS selector string to filter the returned elements by.
+ * @returns An array of elements.
  */
 export function slotChangeGetAssignedElements<T extends Element>(event: Event, selector?: string): T[] | null {
   return getSlotAssignedElements(event.currentTarget as HTMLSlotElement, selector);
@@ -533,9 +527,9 @@ export function slotChangeGetAssignedElements<T extends Element>(event: Event, s
 /**
  * This helper returns the assigned elements on a `slot` element, filtered by an optional css selector.
  *
- * @param {HTMLSlotElement} slot The slot element.
- * @param {string} selector CSS selector string to filter the returned elements by.
- * @returns {Element[]} An array of elements.
+ * @param slot The slot element.
+ * @param selector CSS selector string to filter the returned elements by.
+ * @returns An array of elements.
  */
 export function getSlotAssignedElements<T extends Element>(slot: HTMLSlotElement, selector?: string): T[] | null {
   const assignedElements = slot.assignedElements({
@@ -549,8 +543,8 @@ export function getSlotAssignedElements<T extends Element>(slot: HTMLSlotElement
  *
  * See https://www.w3.org/TR/pointerevents/#the-button-property.
  *
- * @param {PointerEvent} event The pointer event.
- * @returns {boolean} The value.
+ * @param event The pointer event.
+ * @returns The value.
  */
 export function isPrimaryPointerButton(event: PointerEvent): boolean {
   return !!(event.isPrimary && event.button === 0);
@@ -559,8 +553,8 @@ export function isPrimaryPointerButton(event: PointerEvent): boolean {
 /**
  * This helper returns true if the mouse event was triggered by a keyboard click.
  *
- * @param {MouseEvent} event The mouse event.
- * @returns {boolean} The value.
+ * @param event The mouse event.
+ * @returns The value.
  */
 export function isKeyboardTriggeredClick(event: MouseEvent): boolean {
   // we assume event.detail = 0 is a keyboard click
@@ -574,13 +568,13 @@ export type FocusElementInGroupDestination = "first" | "last" | "next" | "previo
 /**
  * This helper sets focus on and returns a destination element from within a group of provided elements.
  *
- * @param {Element[]} elements An array of elements.
- * @param {Element} currentElement The current element.
- * @param {FocusElementInGroupDestination} destination The target destination element to focus.
- * @param {boolean} cycle Should navigation cycle through elements or stop at extent - defaults to true.
- * @param {boolean} includeContainer Determines whether the container element should be considered as well - defaults to true.
+ * @param elements An array of elements.
+ * @param currentElement The current element.
+ * @param destination The target destination element to focus.
+ * @param cycle Should navigation cycle through elements or stop at extent - defaults to true.
+ * @param includeContainer Determines whether the container element should be considered as well - defaults to true.
  * @param targetAsContext
- * @returns {Element} The focused element
+ * @returns The focused element
  */
 export const focusElementInGroup = <T extends Element = Element>(
   elements: Element[],
@@ -709,8 +703,8 @@ export async function nextFrame(): Promise<void> {
  * - If the value ends with "vh", it calculates the pixel value based on the viewport height.
  * - For unsupported units or invalid values, it returns 0.
  *
- * @param {string} value - The CSS style value to convert (e.g., "10px", "50vw", "30vh").
- * @returns {number} The pixel equivalent of the provided value.
+ * @param value - The CSS style value to convert (e.g., "10px", "50vw", "30vh").
+ * @returns The pixel equivalent of the provided value.
  */
 export function getStylePixelValue(value: string): number {
   if (value.endsWith("px")) {

--- a/packages/components/src/utils/floating-ui.ts
+++ b/packages/components/src/utils/floating-ui.ts
@@ -421,7 +421,6 @@ export function getEffectivePlacement(placement: LogicalPlacement, isRTL = false
  * @param options.arrowEl - A customizable arrow element.
  * @param options.type - The type of floating UI.
  * @param delayed - Reposition the component after a delay.
- * @returns {Promise<void>}
  */
 export async function reposition(
   component: FloatingUIComponent,
@@ -564,7 +563,6 @@ export function hideFloatingUI(component: FloatingUIComponent): void {
  * Helper to set up floating element interactions on connectedCallback.
  *
  * @param component - A floating-ui component.
- * @returns {Promise<void>}
  */
 export async function connectFloatingUI(component: FloatingUIComponent): Promise<void> {
   const { floatingEl, referenceEl } = component;

--- a/packages/components/src/utils/locale.ts
+++ b/packages/components/src/utils/locale.ts
@@ -70,7 +70,7 @@ export const getSupportedNumberingSystem = (numberingSystem: string): NumberingS
  * @see https://github.com/Esri/calcite-design-system/issues/9387
  *
  * @param locale – the BCP 47 locale code
- * @returns {string} a BCP 47 locale code
+ * @returns a BCP 47 locale code
  */
 export function getDateFormatSupportedLocale(locale: string): string {
   switch (locale) {

--- a/packages/components/src/utils/math.ts
+++ b/packages/components/src/utils/math.ts
@@ -9,7 +9,7 @@ const decimalNumberRegex = new RegExp(/(?:\.(\d+))?(?:[eE]([+-]?\d+))?$/);
  *
  * @param decimal - decimal value
  * @param value
- * @returns {number} the amount of decimal places in a number
+ * @returns the amount of decimal places in a number
  */
 export const decimalPlaces = (value: number | string): number => {
   const match = ("" + value).match(decimalNumberRegex);
@@ -42,7 +42,7 @@ export function remap(value: number, fromMin: number, fromMax: number, toMin: nu
  * @param value
  * @param range
  * @param threshold
- * @returns -1 if close to lower edge, 1 if close to upper edge, 0 otherwise.
+ * @returns if close to lower edge, 1 if close to upper edge, 0 otherwise.
  */
 export function closeToRangeEdge(value: number, range: number, threshold: number): number {
   return value < threshold ? -1 : value > range - threshold ? 1 : 0;

--- a/packages/components/src/utils/math.ts
+++ b/packages/components/src/utils/math.ts
@@ -42,7 +42,7 @@ export function remap(value: number, fromMin: number, fromMax: number, toMin: nu
  * @param value
  * @param range
  * @param threshold
- * @returns if close to lower edge, 1 if close to upper edge, 0 otherwise.
+ * @returns -1 if close to lower edge, 1 if close to upper edge, 0 otherwise.
  */
 export function closeToRangeEdge(value: number, range: number, threshold: number): number {
   return value < threshold ? -1 : value > range - threshold ? 1 : 0;

--- a/packages/components/src/utils/number.ts
+++ b/packages/components/src/utils/number.ts
@@ -190,8 +190,8 @@ export function sanitizeExponentialNumberString(numberString: string, func: (s: 
  * Converts an exponential notation numberString into decimal notation.
  * BigInt doesn't support exponential notation, so this is required to maintain precision
  *
- * @param {string} numberString - pre-validated exponential or decimal number
- * @returns {string} numberString in decimal notation
+ * @param numberString - pre-validated exponential or decimal number
+ * @returns numberString in decimal notation
  */
 export function expandExponentialNumberString(numberString: string): string {
   const exponentialParts = numberString.split(/[eE]/);
@@ -242,10 +242,10 @@ function stringContainsNumbers(string: string): boolean {
  * Adds localized trailing decimals zero values to the number string.
  * BigInt conversion to string removes the trailing decimal zero values (Ex: 1.000 is returned as 1). This method helps adding them back.
  *
- * @param {string} localizedValue - localized number string value
- * @param {string} value - current value in the input field
- * @param {NumberStringFormat} formatter - numberStringFormatter instance to localize the number value
- * @returns {string} localized number string value
+ * @param localizedValue - localized number string value
+ * @param value - current value in the input field
+ * @param formatter - numberStringFormatter instance to localize the number value
+ * @returns localized number string value
  */
 export function addLocalizedTrailingDecimalZeros(
   localizedValue: string,

--- a/packages/components/src/utils/sortableComponent.ts
+++ b/packages/components/src/utils/sortableComponent.ts
@@ -89,7 +89,7 @@ export interface SortableComponentItem {
 /**
  * Helper to keep track of a SortableComponent. This should be called in the `connectedCallback` lifecycle method as well as any other method necessary to rebuild the sortable instance.
  *
- * @param {SortableComponent} component - The sortable component.
+ * @param component - The sortable component.
  */
 export function connectSortableComponent(component: SortableComponent): void {
   if (dragActive(component)) {
@@ -161,7 +161,7 @@ export function connectSortableComponent(component: SortableComponent): void {
 /**
  * Helper to remove track of a SortableComponent. This should be called in the `disconnectedCallback` lifecycle method.
  *
- * @param {SortableComponent} component - The sortable component.
+ * @param component - The sortable component.
  */
 export function disconnectSortableComponent(component: SortableComponent): void {
   if (dragActive(component)) {
@@ -180,7 +180,7 @@ const dragState: { active: boolean } = { active: false };
  * Helper to determine if dragging is currently active.
  *
  * @param component The sortable component.
- * @returns {boolean} a boolean value.
+ * @returns a boolean value.
  */
 export function dragActive(component: SortableComponent): boolean {
   return component.dragEnabled && dragState.active;

--- a/packages/tailwind-preset/src/utils.ts
+++ b/packages/tailwind-preset/src/utils.ts
@@ -3,8 +3,8 @@
  *
  * When the flag is 0, it will not be inverted. When 1, it will invert it (multiplied by -1)
  *
- * @param {string} value - the CSS value to invert
- * @param {string} flagPropName - the boolean CSS prop (value must be 0 or 1)
+ * @param value - the CSS value to invert
+ * @param flagPropName - the boolean CSS prop (value must be 0 or 1)
  */
 export function invert(value: string, flagPropName: string): string {
   return `calc(


### PR DESCRIPTION
TLDR: Refactor JSDoc tags in your package to make them more doc-friendly.

## Context

Lumina is preparing to switch to a new doc engine ([@arcgis/api-extractor](https://devtopia.esri.com/WebGIS/arcgis-web-components/pull/10377/
)).

Main impact on Lumina consumers: you will be able to document interfaces, types, non-component classes, functions, variables, mixins and type parameters. The developers site team is working on the docs UI for these features for 5.0. API Extractor is already being used by JSAPI in 5.0.

Even for non-public Lumina components, we are looking to improve internal docs capabilities.

The upcoming change will only affect docs and types, not runtime code. **We will make a CDC announcement once it takes effect**.

## Changes

To catch doc bugs, reduce doc duplication, and give you more control over what is publicly exposed, API Extractor does more validation as part of build. For 5.0, we disabled most of the new validations to make migration smooth. After 5.0, we will offer a small codemod to auto-fix some of the discovered doc bugs.

This PR makes JSDoc changes in your package that make it compatible with API Extractor. For extra assurance, I reviewed the diff of your package's public .d.ts types and .json docs that will happen as a result of moving from previous to the new doc engine.

No further changes are needed from your side for 5.0. This PR can be merged before the switch to the new doc engine.