### PR TITLE
fix(action): resolve specificity conflict between `selection-mode="highlight"` and `appearance="transparent"`

### DIFF
--- a/packages/components/src/components/action/action.scss
+++ b/packages/components/src/components/action/action.scss
@@ -206,7 +206,7 @@
 }
 
 :host([appearance="transparent"]) {
-  &:host([active]) .button {
+  &[active] .button {
     background-color: var(
       --calcite-action-background-color-press,
       var(--calcite-action-background-color-pressed, var(--calcite-color-transparent-press))


### PR DESCRIPTION
**Related Issue:** #13462, #10758

## Summary
Fixes a specificity conflict with the `active` states of `selection-mode="highlight"` and `appearance="transparent"` (the new default). The highlight mode background is being overridden by the `transparent` active styles.

Introduced by https://github.com/Esri/calcite-design-system/pull/13466.

Please correct me if this `:host([active])` selector is needed, but it seems redundant to me.

cc @ashetland 
