### PR TITLE
fix(list-item): don't vertically stretch slotted action and dropdown component trigger buttons

### DIFF
--- a/packages/components/src/components/list-item/list-item.scss
+++ b/packages/components/src/components/list-item/list-item.scss
@@ -429,8 +429,6 @@
   ::slotted(calcite-action-menu),
   ::slotted(calcite-sort-handle),
   ::slotted(calcite-dropdown) {
-    @apply self-stretch;
-
     color: inherit;
   }
 }
@@ -467,7 +465,7 @@
 .close {
   calcite-action,
   ::slotted(calcite-action) {
-    @apply self-stretch items-center;
+    @apply items-center;
   }
 }
 

--- a/packages/components/src/components/list/list.stories.ts
+++ b/packages/components/src/components/list/list.stories.ts
@@ -5313,7 +5313,19 @@ export const onlyLabelVersusOnlyDescription_TestOnly = (): string => html`
 export const actionsSlots = (): string => html`
   <calcite-list ${listAttributes()}>
     <calcite-list-item label="This has no description.">
-      <calcite-handle slot="actions-start"></calcite-handle>
+      <calcite-action-menu appearance="transparent" slot="actions-start">
+        <calcite-action appearance="transparent" text="Plus" icon="plus" text-enabled></calcite-action>
+        <calcite-action appearance="transparent" text="Minus" icon="minus" text-enabled></calcite-action>
+        <calcite-action appearance="transparent" text="Table" icon="table" text-enabled></calcite-action>
+      </calcite-action-menu>
+      <calcite-dropdown slot="actions-start">
+        <calcite-action appearance="transparent" icon="plus" slot="trigger"></calcite-action>
+        <calcite-dropdown-group selection-mode="single" group-title="Sort by">
+          <calcite-dropdown-item>Relevance</calcite-dropdown-item>
+          <calcite-dropdown-item>Date modified</calcite-dropdown-item>
+          <calcite-dropdown-item>Title</calcite-dropdown-item>
+        </calcite-dropdown-group>
+      </calcite-dropdown>
       <calcite-action
         slot="actions-start"
         appearance="transparent"

--- a/packages/components/src/components/list/list.stories.ts
+++ b/packages/components/src/components/list/list.stories.ts
@@ -10,7 +10,8 @@ import { List } from "./list";
 const { selectionMode, interactionMode, selectionAppearance, scale } = ATTRIBUTES;
 
 interface ListStoryArgs
-  extends Pick<
+  extends
+    Pick<
       List,
       | "disabled"
       | "displayMode"
@@ -5309,7 +5310,7 @@ export const onlyLabelVersusOnlyDescription_TestOnly = (): string => html`
   </calcite-list>
 `;
 
-export const stretchSlottedContent = (): string => html`
+export const actionsSlots = (): string => html`
   <calcite-list ${listAttributes()}>
     <calcite-list-item label="This has no description.">
       <calcite-handle slot="actions-start"></calcite-handle>


### PR DESCRIPTION
**Related Issue:** #10777

## Summary

This PR fixes an issue where slotted action menus and dropdown trigger buttons were stretching vertically to fill the list item's container height, which doesn't conform to the updated Action 5 design requirements.

Before:
<img width="407" height="155" alt="image" src="https://github.com/user-attachments/assets/5dab646d-9d78-41b2-8252-f3c231f49847" />

After:
<img width="399" height="163" alt="image" src="https://github.com/user-attachments/assets/7b3ba4ac-52ed-4b5a-9fcb-b23f4b6955b1" />
