### PR TITLE
feat(shell-panel): add border for resize handle

### DIFF
--- a/packages/components/src/components/shell-panel/shell-panel.e2e.ts
+++ b/packages/components/src/components/shell-panel/shell-panel.e2e.ts
@@ -605,6 +605,39 @@ describe("calcite-shell-panel", () => {
     expect(expandSpy).toHaveReceivedEventTimes(1);
     expect(collapseSpy).toHaveReceivedEventTimes(1);
   });
+  describe("border on resize handle", () => {
+    it("check for border on resize handle in overlay display modes", async () => {
+      const page = await newE2EPage();
+      await page.setContent(`
+      <calcite-shell>
+        <calcite-shell-panel resizable display-mode="overlay">
+          <calcite-panel closable>
+          </calcite-panel>
+        </calcite-shell-panel>
+      </calcite-shell>`);
+      const resizeHandleBar = await page.find(`calcite-shell-panel >>> .${CSS.resizeHandleBar}`);
+      const style = await resizeHandleBar.getComputedStyle();
+      expect(style.borderBlockStart).toBe("1px solid rgb(235, 235, 235)");
+      expect(style.borderInlineEnd).toBe("1px solid rgb(235, 235, 235)");
+      expect(style.borderBlockEnd).toBe("1px solid rgb(235, 235, 235)");
+    });
+
+    it("should not have a border when display mode is float-content", async () => {
+      const page = await newE2EPage();
+      await page.setContent(`
+      <calcite-shell>
+        <calcite-shell-panel resizable display-mode="float-content">
+          <calcite-panel closable>
+          </calcite-panel>
+        </calcite-shell-panel>
+      </calcite-shell>`);
+      const resizeHandleBar = await page.find(`calcite-shell-panel >>> .${CSS.resizeHandleBar}`);
+      const style = await resizeHandleBar.getComputedStyle();
+      expect(style.borderBlockStart).toBe("0px none rgb(148, 148, 148)");
+      expect(style.borderInlineEnd).toBe("0px none rgb(148, 148, 148)");
+      expect(style.borderBlockEnd).toBe("0px none rgb(148, 148, 148)");
+    });
+  });
 
   describe("themed", () => {
     describe("default", () => {

--- a/packages/components/src/components/shell-panel/shell-panel.scss
+++ b/packages/components/src/components/shell-panel/shell-panel.scss
@@ -533,9 +533,9 @@ slot[name="action-bar"]::slotted(calcite-action-bar),
 :host([display-mode="float-all"]),
 :host([display-mode="overlay"]) {
   .resize-handle-bar {
-    border-block-start: 1px solid var(--calcite-color-border-3);
-    border-inline-end: 1px solid var(--calcite-color-border-3);
-    border-block-end: 1px solid var(--calcite-color-border-3);
+    border-block-start: var(--calcite-border-width-sm) solid var(--calcite-color-border-3);
+    border-inline-end: var(--calcite-border-width-sm) solid var(--calcite-color-border-3);
+    border-block-end: var(--calcite-border-width-sm) solid var(--calcite-color-border-3);
   }
 }
 

--- a/packages/components/src/components/shell-panel/shell-panel.scss
+++ b/packages/components/src/components/shell-panel/shell-panel.scss
@@ -529,4 +529,14 @@ slot[name="action-bar"]::slotted(calcite-action-bar),
   border-block-end: 0;
 }
 
+:host([display-mode="dock"]),
+:host([display-mode="float-all"]),
+:host([display-mode="overlay"]) {
+  .resize-handle-bar {
+    border-block-start: 1px solid var(--calcite-color-border-3);
+    border-inline-end: 1px solid var(--calcite-color-border-3);
+    border-block-end: 1px solid var(--calcite-color-border-3);
+  }
+}
+
 @include includes.base-component();


### PR DESCRIPTION
**Related Issue:** [#12178](https://github.com/Esri/calcite-design-system/issues/12178)

## Summary
Adds a border to the resize handle container for dock, float-all, and overlay display modes.