### PR TITLE
fix(action): support `transparent` and `highlight` `active` background colors

### DIFF
--- a/packages/components/src/components/action/action.scss
+++ b/packages/components/src/components/action/action.scss
@@ -206,7 +206,7 @@
 }
 
 :host([appearance="transparent"]) {
-  &[active] .button {
+  &:host([active]) .button {
     background-color: var(
       --calcite-action-background-color-press,
       var(--calcite-action-background-color-pressed, var(--calcite-color-transparent-press))
@@ -232,7 +232,7 @@
   }
 }
 
-:host([selection-appearance="highlight"][active]) .button {
+:host([selection-appearance="highlight"]):host([active]) .button {
   background-color: var(--calcite-color-surface-highlight);
   color: var(--calcite-color-text-highlight);
 }


### PR DESCRIPTION
**Related Issue:** #13690

## Summary
Fixes the background color not changing when a `appearance="transparent"` Action is `active`, while maintaining the correct background color change for `active` Actions when `selection-appearance="highlight"`.

Regression introduced in #13686, and fixes https://github.com/Esri/calcite-design-system/pull/13686#issuecomment-3749700724
