### PR TITLE
feat(carousel): add `paginationDisabled` property

### DIFF
--- a/packages/components/src/components/carousel/carousel.e2e.ts
+++ b/packages/components/src/components/carousel/carousel.e2e.ts
@@ -43,6 +43,17 @@ describe("calcite-carousel", () => {
     );
   });
 
+  describe("accessible with pagination disabled", () => {
+    accessible(
+      html`<calcite-carousel label="Carousel example" pagination-disabled
+        ><calcite-carousel-item label="Carousel Item 1"><p>carousel item content</p></calcite-carousel-item
+        ><calcite-carousel-item label="Carousel Item 2"
+          ><p>carousel item content</p></calcite-carousel-item
+        ></calcite-carousel
+      >`,
+    );
+  });
+
   describe("first render", () => {
     it("should not render arrow items when requested", async () => {
       const page = await newE2EPage();
@@ -789,6 +800,26 @@ describe("calcite-carousel", () => {
 
       const pagination = await page.find(`calcite-carousel >>> .${CSS.pagination}`);
       expect(pagination).not.toBeNull();
+    });
+
+    it("pagination should be replaced with aria-live info when paginationDisabled is true", async () => {
+      const page = await newE2EPage();
+      await page.setContent(
+        html`<calcite-carousel label="Carousel example" pagination-disabled
+          ><calcite-carousel-item label="Carousel Item 1"><p>first item default selected</p></calcite-carousel-item
+          ><calcite-carousel-item label="Carousel Item 2"
+            ><p>carousel item content</p></calcite-carousel-item
+          ></calcite-carousel
+        >`,
+      );
+
+      const pagination = await page.find(`calcite-carousel >>> .${CSS.pagination}`);
+      const paginationItems = await pagination.find(`.${CSS.paginationItems}`);
+      expect(paginationItems).toBeNull();
+
+      const paginationAriaLive = await pagination.find(`.${CSS.paginationAriaLive}`);
+      const ariaTextContent = paginationAriaLive.textContent;
+      expect(ariaTextContent).toBe("Item 1 of 2");
     });
   });
 

--- a/packages/components/src/components/carousel/carousel.scss
+++ b/packages/components/src/components/carousel/carousel.scss
@@ -158,6 +158,10 @@ calcite-carousel-item:not([selected]) {
   opacity: 0;
 }
 
+.pagination-aria-live {
+  @apply sr-only;
+}
+
 .pagination {
   @apply flex
   flex-row

--- a/packages/components/src/components/carousel/carousel.stories.ts
+++ b/packages/components/src/components/carousel/carousel.stories.ts
@@ -8,7 +8,7 @@ const { arrowType } = ATTRIBUTES;
 
 type CarouselStoryArgs = Pick<
   Carousel,
-  "controlOverlay" | "disabled" | "autoplayDuration" | "autoplay" | "label" | "arrowType"
+  "controlOverlay" | "disabled" | "autoplayDuration" | "autoplay" | "label" | "arrowType" | "paginationDisabled"
 >;
 
 export default {
@@ -20,6 +20,7 @@ export default {
     autoplay: false,
     label: "Example carousel label",
     arrowType: arrowType.defaultValue,
+    paginationDisabled: false,
   },
   argTypes: {
     arrowType: {
@@ -34,6 +35,7 @@ export const simple = (args: CarouselStoryArgs): string =>
     <calcite-carousel
       ${boolean("control-overlay", args.controlOverlay)}
       ${boolean("disabled", args.disabled)}
+      ${boolean("pagination-disabled", args.paginationDisabled)}
       autoplay-duration="${args.autoplayDuration}"
       ${args.autoplay ? "autoplay" : ""}
       label="${args.label}"
@@ -82,6 +84,7 @@ export const simpleSingleItem = (args: CarouselStoryArgs): string =>
     <calcite-carousel
       ${boolean("control-overlay", args.controlOverlay)}
       ${boolean("disabled", args.disabled)}
+      ${boolean("pagination-disabled", args.paginationDisabled)}
       autoplay-duration="${args.autoplayDuration}"
       ${args.autoplay ? "autoplay" : ""}
       label="${args.label}"
@@ -102,6 +105,7 @@ export const simpleManyItems = (args: CarouselStoryArgs): string =>
     <calcite-carousel
       ${boolean("control-overlay", args.controlOverlay)}
       ${boolean("disabled", args.disabled)}
+      ${boolean("pagination-disabled", args.paginationDisabled)}
       autoplay-duration="${args.autoplayDuration}"
       ${args.autoplay ? "autoplay" : ""}
       label="${args.label}"
@@ -178,6 +182,7 @@ export const simpleManyItemsNarrow = (args: CarouselStoryArgs): string =>
     <calcite-carousel
       ${boolean("control-overlay", args.controlOverlay)}
       ${boolean("disabled", args.disabled)}
+      ${boolean("pagination-disabled", args.paginationDisabled)}
       autoplay-duration="${args.autoplayDuration}"
       ${args.autoplay ? "autoplay" : ""}
       label="${args.label}"
@@ -254,6 +259,7 @@ export const simpleManyItemsVeryNarrow = (args: CarouselStoryArgs): string =>
     <calcite-carousel
       ${boolean("control-overlay", args.controlOverlay)}
       ${boolean("disabled", args.disabled)}
+      ${boolean("pagination-disabled", args.paginationDisabled)}
       autoplay-duration="${args.autoplayDuration}"
       ${args.autoplay ? "autoplay" : ""}
       label="${args.label}"

--- a/packages/components/src/components/carousel/carousel.tsx
+++ b/packages/components/src/components/carousel/carousel.tsx
@@ -690,8 +690,8 @@ export class Carousel extends LitElement {
     return (
       <div ariaLive="off" class={CSS.paginationAriaLive} role="status">
         {messages.paginationStatus
-          .replace("{current}", `${selectedIndex + 1}`)
-          .replace("{total}", `${items.length}`)}
+          .replace("{current}", numberStringFormatter.localize(`${selectedIndex + 1}`))
+          .replace("{total}", numberStringFormatter.localize(`${items.length}`))}
       </div>
     );
   }

--- a/packages/components/src/components/carousel/carousel.tsx
+++ b/packages/components/src/components/carousel/carousel.tsx
@@ -679,6 +679,10 @@ export class Carousel extends LitElement {
       items,
     } = this;
 
+    if (messages._loading) {
+      return;
+    }
+
     numberStringFormatter.numberFormatOptions = {
       locale: effectiveLocale,
     };

--- a/packages/components/src/components/carousel/carousel.tsx
+++ b/packages/components/src/components/carousel/carousel.tsx
@@ -11,6 +11,7 @@ import {
 import { guid } from "../../utils/guid";
 import { createObserver } from "../../utils/observers";
 import { breakpoints } from "../../utils/responsive";
+import { numberStringFormatter } from "../../utils/locale";
 import { getRoundRobinIndex } from "../../utils/array";
 import { useT9n } from "../../controllers/useT9n";
 import type { Action } from "../action/action";
@@ -671,10 +672,22 @@ export class Carousel extends LitElement {
   }
 
   private renderPaginationAriaLive(): JsxNode {
-    const { selectedIndex, items } = this;
+    const {
+      messages,
+      messages: { _lang: effectiveLocale },
+      selectedIndex,
+      items,
+    } = this;
+
+    numberStringFormatter.numberFormatOptions = {
+      locale: effectiveLocale,
+    };
+
     return (
       <div ariaLive="off" class={CSS.paginationAriaLive} role="status">
-        {`Item ${selectedIndex + 1} of ${items.length}`}
+        {messages.paginationStatus
+          .replace("{current}", `${selectedIndex + 1}`)
+          .replace("{total}", `${items.length}`)}
       </div>
     );
   }

--- a/packages/components/src/components/carousel/carousel.tsx
+++ b/packages/components/src/components/carousel/carousel.tsx
@@ -148,7 +148,7 @@ export class Carousel extends LitElement {
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /**
-   * When `true`, pagination controls are hidden.
+   * When `true`, the component's pagination controls are hidden.
    */
   @property() paginationDisabled: boolean = false;
 

--- a/packages/components/src/components/carousel/carousel.tsx
+++ b/packages/components/src/components/carousel/carousel.tsx
@@ -148,6 +148,11 @@ export class Carousel extends LitElement {
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /**
+   * When `true`, pagination controls are hidden.
+   */
+  @property() paginationDisabled: boolean = false;
+
+  /**
    * Made into a prop for testing purposes only
    *
    * @private
@@ -612,7 +617,7 @@ export class Carousel extends LitElement {
           this.hasMultiple &&
           this.renderRotationControl()}
         {this.arrowType === "inline" && this.hasMultiple && this.renderArrow("previous")}
-        {this.renderPaginationItems()}
+        {this.paginationDisabled ? this.renderPaginationAriaLive() : this.renderPaginationItems()}
         {this.arrowType === "inline" && this.hasMultiple && this.renderArrow("next")}
       </div>
     );
@@ -661,6 +666,15 @@ export class Carousel extends LitElement {
             </button>
           );
         })}
+      </div>
+    );
+  }
+
+  private renderPaginationAriaLive(): JsxNode {
+    const { selectedIndex, items } = this;
+    return (
+      <div ariaLive="off" class={CSS.paginationAriaLive} role="status">
+        {`Item ${selectedIndex + 1} of ${items.length}`}
       </div>
     );
   }

--- a/packages/components/src/components/carousel/resources.ts
+++ b/packages/components/src/components/carousel/resources.ts
@@ -10,6 +10,7 @@ export const CSS = {
   itemContainerForward: "item-container--forward",
   itemContainerBackward: "item-container--backward",
   pagination: "pagination",
+  paginationAriaLive: "pagination-aria-live",
   paginationItems: "pagination-items",
   paginationItem: "pagination-item",
   paginationItemIndividual: "pagination-item--individual",


### PR DESCRIPTION
**Related Issue:** #11131

## Summary
Adds `paginationDisabled` prop to support more custom/programmatic setups and the previous single-item behavior (changed by #12270).
