### PR TITLE
feat(carousel): add `paginationStatus` to messages

### DIFF
--- a/packages/components/src/components/carousel/assets/t9n/messages.en.json
+++ b/packages/components/src/components/carousel/assets/t9n/messages.en.json
@@ -4,5 +4,6 @@
   "play": "Play",
   "pause": "Pause",
   "carousel": "Carousel",
-  "carouselItemProgress": "Progress indicator for Carousel Item"
+  "carouselItemProgress": "Progress indicator for Carousel Item",
+  "paginationStatus": "Item {current} of {total}"
 }

--- a/packages/components/src/components/carousel/assets/t9n/messages.json
+++ b/packages/components/src/components/carousel/assets/t9n/messages.json
@@ -4,5 +4,6 @@
   "play": "Play",
   "pause": "Pause",
   "carousel": "Carousel",
-  "carouselItemProgress": "Progress indicator for Carousel Item"
+  "carouselItemProgress": "Progress indicator for Carousel Item",
+  "paginationStatus": "Item {current} of {total}"
 }


### PR DESCRIPTION
**Related Issue:** #11131

## Summary
Adds the `paginationStatus` string to messages for use with the `aria-live` information when `paginationDisabled`.

Required before #13704 can be installed.
