### PR TITLE
docs: Align shared API reference descriptions across components

### DIFF
--- a/packages/components/src/components/accordion-item/accordion-item.tsx
+++ b/packages/components/src/components/accordion-item/accordion-item.tsx
@@ -82,7 +82,7 @@ export class AccordionItem extends LitElement {
   /** When `true`, expands the component and its contents. */
   @property({ reflect: true }) expanded = false;
 
-  /** Specifies heading text for the component. */
+  /** Specifies the component's heading text. */
   @property() heading: string;
 
   /** Specifies an icon to display at the end of the component. */

--- a/packages/components/src/components/accordion-item/accordion-item.tsx
+++ b/packages/components/src/components/accordion-item/accordion-item.tsx
@@ -98,7 +98,7 @@ export class AccordionItem extends LitElement {
    */
   @property() appearance: Extract<"solid" | "transparent", Appearance>;
 
-  /** Specifies the heading level of the component's `heading` for proper document structure, without affecting visual styling. */
+  /** Specifies the heading level number of the component's `heading` for proper document structure, without affecting visual styling. */
   @property({ type: Number, reflect: true }) headingLevel: HeadingLevel;
 
   /**

--- a/packages/components/src/components/accordion-item/accordion-item.tsx
+++ b/packages/components/src/components/accordion-item/accordion-item.tsx
@@ -125,7 +125,7 @@ export class AccordionItem extends LitElement {
    */
   @property({ reflect: true }) scale: Scale;
 
-  /** Use this property to override individual strings used by the component. */
+  /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
   //#endregion

--- a/packages/components/src/components/action-bar/action-bar.tsx
+++ b/packages/components/src/components/action-bar/action-bar.tsx
@@ -195,11 +195,11 @@ export class ActionBar extends LitElement {
   @property({ reflect: true }) overflowActionsDisabled = false;
 
   /**
-   * Determines the type of positioning to use for the overlaid content.
+   * Specifies the type of positioning to use for overlaid content, where:
    *
-   * Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout.
+   * `"absolute"` works for most cases - positioning the component inside of overflowing parent containers, which affects the container's layout, and
    *
-   * `"fixed"` should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
+   * `"fixed"` is used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
    */
   @property({ reflect: true }) overlayPositioning: OverlayPositioning = "absolute";
 

--- a/packages/components/src/components/action-bar/action-bar.tsx
+++ b/packages/components/src/components/action-bar/action-bar.tsx
@@ -188,7 +188,7 @@ export class ActionBar extends LitElement {
   @property({ reflect: true }) layout: Extract<"horizontal" | "vertical" | "grid", Layout> =
     "vertical";
 
-  /** Use this property to override individual strings used by the component. */
+  /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /** When `true`, disables automatically overflowing `calcite-action`s that won't fit into menus. */

--- a/packages/components/src/components/action-group/action-group.tsx
+++ b/packages/components/src/components/action-group/action-group.tsx
@@ -95,7 +95,7 @@ export class ActionGroup extends LitElement {
   /** Determines where the action menu will be positioned. */
   @property({ reflect: true }) menuPlacement: LogicalPlacement;
 
-  /** Use this property to override individual strings used by the component. */
+  /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /**

--- a/packages/components/src/components/action-group/action-group.tsx
+++ b/packages/components/src/components/action-group/action-group.tsx
@@ -75,7 +75,7 @@ export class ActionGroup extends LitElement {
   /** When `true`, expands the component and its contents. */
   @property({ reflect: true }) expanded = false;
 
-  /** Accessible name for the component. */
+  /** Specifies an accessible label for the component. */
   @property() label: string;
 
   /**

--- a/packages/components/src/components/action-group/action-group.tsx
+++ b/packages/components/src/components/action-group/action-group.tsx
@@ -86,7 +86,7 @@ export class ActionGroup extends LitElement {
   @property({ reflect: true }) layout: Extract<"horizontal" | "vertical" | "grid", Layout> =
     "vertical";
 
-  /** Specifies the component's fallback menu `placement` when it's initial or specified `placement` has insufficient space available. */
+  /** Specifies the component's fallback `menuPlacement` when it's initial or specified `menuPlacement` has insufficient space available. */
   @property() menuFlipPlacements: FlipPlacement[];
 
   /** When `true`, the `calcite-action-menu` is open. */

--- a/packages/components/src/components/action-group/action-group.tsx
+++ b/packages/components/src/components/action-group/action-group.tsx
@@ -99,10 +99,11 @@ export class ActionGroup extends LitElement {
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /**
-   * Determines the type of positioning to use for the overlaid content.
+   * Specifies the type of positioning to use for overlaid content, where:
    *
-   * Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout.
-   * `"fixed"` should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
+   * `"absolute"` works for most cases - positioning the component inside of overflowing parent containers, which affects the container's layout, and
+   *
+   * `"fixed"` is used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
    */
   @property({ reflect: true }) overlayPositioning: OverlayPositioning = "absolute";
 

--- a/packages/components/src/components/action-menu/action-menu.tsx
+++ b/packages/components/src/components/action-menu/action-menu.tsx
@@ -146,7 +146,7 @@ export class ActionMenu extends LitElement {
   /** When `true`, expands the component and its contents. */
   @property({ reflect: true }) expanded = false;
 
-  /** Specifies the component's fallback slotted content `placement` when it's initial or specified `placement` has insufficient space available. */
+  /** Specifies the component's fallback `placement` for slotted content when it's initial or specified `placement` has insufficient space available. */
   @property() flipPlacements: FlipPlacement[];
 
   /**

--- a/packages/components/src/components/action-menu/action-menu.tsx
+++ b/packages/components/src/components/action-menu/action-menu.tsx
@@ -170,10 +170,11 @@ export class ActionMenu extends LitElement {
   }
 
   /**
-   * Determines the type of positioning to use for the overlaid content.
+   * Specifies the type of positioning to use for overlaid content, where:
    *
-   * Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout.
-   * `"fixed"` should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
+   * `"absolute"` works for most cases - positioning the component inside of overflowing parent containers, which affects the container's layout, and
+   *
+   * `"fixed"` is used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
    */
   @property({ reflect: true }) overlayPositioning: OverlayPositioning = "absolute";
 

--- a/packages/components/src/components/action-menu/action-menu.tsx
+++ b/packages/components/src/components/action-menu/action-menu.tsx
@@ -150,7 +150,7 @@ export class ActionMenu extends LitElement {
   @property() flipPlacements: FlipPlacement[];
 
   /**
-   * Specifies the text string for the component.
+   * Specifies an accessible label for the component.
    *
    * @required
    */

--- a/packages/components/src/components/action-pad/action-pad.tsx
+++ b/packages/components/src/components/action-pad/action-pad.tsx
@@ -83,7 +83,7 @@ export class ActionPad extends LitElement {
   @property({ reflect: true }) layout: Extract<"horizontal" | "vertical" | "grid", Layout> =
     "vertical";
 
-  /** Use this property to override individual strings used by the component. */
+  /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /**

--- a/packages/components/src/components/action-pad/action-pad.tsx
+++ b/packages/components/src/components/action-pad/action-pad.tsx
@@ -87,11 +87,11 @@ export class ActionPad extends LitElement {
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /**
-   * Determines the type of positioning to use for the overlaid content.
+   * Specifies the type of positioning to use for overlaid content, where:
    *
-   * Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout.
+   * `"absolute"` works for most cases - positioning the component inside of overflowing parent containers, which affects the container's layout, and
    *
-   * `"fixed"` should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
+   * `"fixed"` is used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
    */
   @property({ reflect: true }) overlayPositioning: OverlayPositioning = "absolute";
 

--- a/packages/components/src/components/action/action.tsx
+++ b/packages/components/src/components/action/action.tsx
@@ -133,9 +133,9 @@ export class Action extends LitElement implements FormOwner {
   @property({ reflect: true }) dragHandle = false;
 
   /**
-   * The `id` of the form that will be associated with the component.
+   * Specifies the `id` of the component's associated form.
    *
-   * When not set, the component will be associated with its ancestor form element, if any.
+   * When not set, the component is associated with its ancestor form element, if one exists.
    */
   @property({ reflect: true }) form: string;
 

--- a/packages/components/src/components/action/action.tsx
+++ b/packages/components/src/components/action/action.tsx
@@ -154,7 +154,7 @@ export class Action extends LitElement implements FormOwner {
   /** When `true`, a busy indicator is displayed. */
   @property({ reflect: true }) loading = false;
 
-  /** Use this property to override individual strings used by the component. */
+  /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /** Specifies the size of the component. */

--- a/packages/components/src/components/action/action.tsx
+++ b/packages/components/src/components/action/action.tsx
@@ -148,7 +148,7 @@ export class Action extends LitElement implements FormOwner {
   /** When `true`, displays a visual indicator. */
   @property({ reflect: true }) indicator = false;
 
-  /** Specifies the label of the component. If no label is provided, the label inherits what's provided for the `text` prop. */
+  /** Specifies an accessible label for the component. If no label is provided, the label inherits what's provided for the `text` prop. */
   @property() label: string;
 
   /** When `true`, a busy indicator is displayed. */

--- a/packages/components/src/components/alert/alert.tsx
+++ b/packages/components/src/components/alert/alert.tsx
@@ -136,7 +136,7 @@ export class Alert extends LitElement {
   > = "brand";
 
   /**
-   * Specifies an accessible name for the component.
+   * Specifies an accessible label for the component.
    *
    * @required
    */

--- a/packages/components/src/components/alert/alert.tsx
+++ b/packages/components/src/components/alert/alert.tsx
@@ -169,7 +169,7 @@ export class Alert extends LitElement {
   @property({ reflect: true }) scale: Scale = "m";
 
   /**
-   * When true, disables top layer placement when the component is open.
+   * When `true` and the component is `open`, disables top layer placement.
    *
    * Only set this if you need complex z-index control or if top layer placement causes conflicts with third-party components.
    *

--- a/packages/components/src/components/alert/alert.tsx
+++ b/packages/components/src/components/alert/alert.tsx
@@ -142,7 +142,7 @@ export class Alert extends LitElement {
    */
   @property() label: string;
 
-  /** Use this property to override individual strings used by the component. */
+  /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /** Specifies the Unicode numeral system used by the component for localization. */

--- a/packages/components/src/components/autocomplete-item-group/autocomplete-item-group.tsx
+++ b/packages/components/src/components/autocomplete-item-group/autocomplete-item-group.tsx
@@ -34,7 +34,7 @@ export class AutocompleteItemGroup extends LitElement {
    */
   @property() heading: string;
 
-  /** Accessible name for the component. */
+  /** Specifies an accessible label for the component. */
   @property() label: any;
 
   /**

--- a/packages/components/src/components/autocomplete-item-group/autocomplete-item-group.tsx
+++ b/packages/components/src/components/autocomplete-item-group/autocomplete-item-group.tsx
@@ -28,7 +28,7 @@ export class AutocompleteItemGroup extends LitElement {
   @property() disableSpacing = false;
 
   /**
-   * Specifies heading text for the component.
+   * Specifies the component's heading text.
    *
    * @required
    */

--- a/packages/components/src/components/autocomplete-item/autocomplete-item.tsx
+++ b/packages/components/src/components/autocomplete-item/autocomplete-item.tsx
@@ -41,7 +41,7 @@ export class AutocompleteItem extends LitElement {
    */
   @property() active = false;
 
-  /** A description for the component. Displays below the label text. */
+  /** Specifies a description for the component. Displays below the label text. */
   @property() description: string;
 
   /** When `true`, interaction is prevented and the component is displayed with lower opacity. */

--- a/packages/components/src/components/autocomplete-item/autocomplete-item.tsx
+++ b/packages/components/src/components/autocomplete-item/autocomplete-item.tsx
@@ -55,7 +55,7 @@ export class AutocompleteItem extends LitElement {
   @property() guid = IDS.host(guid());
 
   /**
-   * Specifies heading text for the component.
+   * Specifies the component's heading text.
    *
    * @required
    */

--- a/packages/components/src/components/autocomplete-item/autocomplete-item.tsx
+++ b/packages/components/src/components/autocomplete-item/autocomplete-item.tsx
@@ -77,7 +77,7 @@ export class AutocompleteItem extends LitElement {
    */
   @property({ reflect: true }) inputValueMatchPattern: RegExp;
 
-  /** Accessible name for the component. */
+  /** Specifies an accessible label for the component. */
   @property() label: string;
 
   /**

--- a/packages/components/src/components/autocomplete/autocomplete.tsx
+++ b/packages/components/src/components/autocomplete/autocomplete.tsx
@@ -301,7 +301,7 @@ export class Autocomplete
   @property() suffixText: string;
 
   /**
-   * When true, disables top layer placement when the component is open.
+   * When `true` and the component is `open`, disables top layer placement.
    *
    * Only set this if you need complex z-index control or if top layer placement causes conflicts with third-party components.
    *

--- a/packages/components/src/components/autocomplete/autocomplete.tsx
+++ b/packages/components/src/components/autocomplete/autocomplete.tsx
@@ -231,13 +231,7 @@ export class Autocomplete
    */
   @property({ reflect: true }) minLength: number;
 
-  /**
-   * Specifies the name of the component.
-   *
-   * Required to pass the component's `value` on form submission.
-   *
-   * @mdn [name](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#name)
-   */
+  /** Specifies the name of the component. Required to pass the component's `value` on form submission. */
   @property({ reflect: true }) name: string;
 
   /** When `true`, displays and positions the component. */

--- a/packages/components/src/components/autocomplete/autocomplete.tsx
+++ b/packages/components/src/components/autocomplete/autocomplete.tsx
@@ -188,9 +188,9 @@ export class Autocomplete
   @property() flipPlacements: FlipPlacement[];
 
   /**
-   * The `id` of the form that will be associated with the component.
+   * Specifies the `id` of the component's associated form.
    *
-   * When not set, the component will be associated with its ancestor form element, if any.
+   * When not set, the component is associated with its ancestor form element, if one exists.
    */
   @property({ reflect: true }) form: string;
 

--- a/packages/components/src/components/autocomplete/autocomplete.tsx
+++ b/packages/components/src/components/autocomplete/autocomplete.tsx
@@ -231,7 +231,13 @@ export class Autocomplete
    */
   @property({ reflect: true }) minLength: number;
 
-  /** Specifies the name of the component. Required to pass the component's `value` on form submission. */
+  /**
+   * Specifies the name of the component.
+   *
+   * Required to pass the component's `value` on form submission.
+   *
+   * @mdn [name](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#name)
+   */
   @property({ reflect: true }) name: string;
 
   /** When `true`, displays and positions the component. */

--- a/packages/components/src/components/autocomplete/autocomplete.tsx
+++ b/packages/components/src/components/autocomplete/autocomplete.tsx
@@ -206,7 +206,7 @@ export class Autocomplete
   /** Specifies an accessible label for the component. */
   @property() label: string;
 
-  /** When provided, displays label text on the component. */
+  /** Specifies the component's label text. */
   @property() labelText: string;
 
   /** When `true`, a busy indicator is displayed. */

--- a/packages/components/src/components/autocomplete/autocomplete.tsx
+++ b/packages/components/src/components/autocomplete/autocomplete.tsx
@@ -238,11 +238,11 @@ export class Autocomplete
   @property({ reflect: true }) open = false;
 
   /**
-   * Determines the type of positioning to use for the overlaid content.
+   * Specifies the type of positioning to use for overlaid content, where:
    *
-   * Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout.
+   * `"absolute"` works for most cases - positioning the component inside of overflowing parent containers, which affects the container's layout, and
    *
-   * `"fixed"` should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
+   * `"fixed"` is used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
    */
   @property({ reflect: true }) overlayPositioning: OverlayPositioning = "absolute";
 

--- a/packages/components/src/components/autocomplete/autocomplete.tsx
+++ b/packages/components/src/components/autocomplete/autocomplete.tsx
@@ -220,7 +220,7 @@ export class Autocomplete
    */
   @property({ reflect: true }) maxLength: number;
 
-  /** Use this property to override individual strings used by the component. */
+  /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /**

--- a/packages/components/src/components/autocomplete/autocomplete.tsx
+++ b/packages/components/src/components/autocomplete/autocomplete.tsx
@@ -184,7 +184,7 @@ export class Autocomplete
   /** When `true`, interaction is prevented and the component is displayed with lower opacity. */
   @property({ reflect: true }) disabled = false;
 
-  /** Specifies the component's fallback `placement` when it's initial or specified `placement` has insufficient space available. */
+  /** Specifies the component's fallback `placement` for slotted content when it's initial or specified `placement` has insufficient space available. */
   @property() flipPlacements: FlipPlacement[];
 
   /**

--- a/packages/components/src/components/autocomplete/autocomplete.tsx
+++ b/packages/components/src/components/autocomplete/autocomplete.tsx
@@ -203,7 +203,7 @@ export class Autocomplete
   /** The component's input value. */
   @property() inputValue: string;
 
-  /** Accessible name for the component. */
+  /** Specifies an accessible label for the component. */
   @property() label: string;
 
   /** When provided, displays label text on the component. */

--- a/packages/components/src/components/autocomplete/autocomplete.tsx
+++ b/packages/components/src/components/autocomplete/autocomplete.tsx
@@ -312,7 +312,7 @@ export class Autocomplete
   @property() validationMessage: string;
 
   /**
-   * The current validation state of the component.
+   * The component's current validation state.
    *
    * @readonly
    * @mdn [ValidityState](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState)

--- a/packages/components/src/components/avatar/avatar.tsx
+++ b/packages/components/src/components/avatar/avatar.tsx
@@ -31,7 +31,7 @@ export class Avatar extends LitElement {
   /** Specifies the full name of the user. When `label` and `thumbnail` are not defined, specifies the accessible name for the component. */
   @property({ reflect: true }) fullName: string;
 
-  /** Specifies alternative text when `thumbnail` is defined, otherwise specifies an accessible label. */
+  /** Specifies alternative text when `thumbnail` is defined, otherwise specifies an accessible label for the component. */
   @property() label: string;
 
   /** Specifies the size of the component. */

--- a/packages/components/src/components/block-group/block-group.tsx
+++ b/packages/components/src/components/block-group/block-group.tsx
@@ -101,7 +101,7 @@ export class BlockGroup extends LitElement implements SortableComponent {
   @property({ reflect: true }) group?: string;
 
   /**
-   * Specifies an accessible name for the component.
+   * Specifies an accessible label for the component.
    *
    * When `dragEnabled` is `true` and multiple group sorting is enabled with `group`, specifies the component's name for dragging between groups.
    *

--- a/packages/components/src/components/block-section/block-section.tsx
+++ b/packages/components/src/components/block-section/block-section.tsx
@@ -70,7 +70,7 @@ export class BlockSection extends LitElement {
   /** Specifies an icon to display at the start of the component. */
   @property({ reflect: true, type: String }) iconStart: IconName;
 
-  /** Use this property to override individual strings used by the component. */
+  /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /**

--- a/packages/components/src/components/block/block.tsx
+++ b/packages/components/src/components/block/block.tsx
@@ -106,7 +106,7 @@ export class Block extends LitElement {
   @property({ reflect: true }) expanded = false;
 
   /**
-   * The component header text.
+   * Specifies the component's heading text.
    *
    */
   @property() heading: string;

--- a/packages/components/src/components/block/block.tsx
+++ b/packages/components/src/components/block/block.tsx
@@ -111,7 +111,7 @@ export class Block extends LitElement {
    */
   @property() heading: string;
 
-  /** Specifies the heading level of the component's `heading` for proper document structure, without affecting visual styling. */
+  /** Specifies the heading level number of the component's `heading` for proper document structure, without affecting visual styling. */
   @property({ type: Number, reflect: true }) headingLevel: HeadingLevel;
 
   /** Specifies an icon to display at the end of the component. */

--- a/packages/components/src/components/block/block.tsx
+++ b/packages/components/src/components/block/block.tsx
@@ -137,7 +137,7 @@ export class Block extends LitElement {
   /** Determines where the action menu will be positioned. */
   @property({ reflect: true }) menuPlacement: LogicalPlacement = defaultEndMenuPlacement;
 
-  /** Use this property to override individual strings used by the component. */
+  /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /**

--- a/packages/components/src/components/block/block.tsx
+++ b/packages/components/src/components/block/block.tsx
@@ -181,11 +181,11 @@ export class Block extends LitElement {
   }
 
   /**
-   * Determines the type of positioning to use for the overlaid content.
+   * Specifies the type of positioning to use for overlaid content, where:
    *
-   * Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout.
+   * `"absolute"` works for most cases - positioning the component inside of overflowing parent containers, which affects the container's layout, and
    *
-   * `"fixed"` should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
+   * `"fixed"` is used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
    */
   @property({ reflect: true }) overlayPositioning: OverlayPositioning = "absolute";
 

--- a/packages/components/src/components/block/block.tsx
+++ b/packages/components/src/components/block/block.tsx
@@ -131,7 +131,7 @@ export class Block extends LitElement {
    */
   @property() label: string;
 
-  /** Specifies the component's fallback menu `placement` when it's initial or specified `placement` has insufficient space available. */
+  /** Specifies the component's fallback `menuPlacement` when it's initial or specified `menuPlacement` has insufficient space available. */
   @property() menuFlipPlacements: FlipPlacement[];
 
   /** Determines where the action menu will be positioned. */

--- a/packages/components/src/components/block/block.tsx
+++ b/packages/components/src/components/block/block.tsx
@@ -127,7 +127,7 @@ export class Block extends LitElement {
   @property({ reflect: true }) loading = false;
 
   /**
-   * Specifies an accessible name for the component.
+   * Specifies an accessible label for the component.
    */
   @property() label: string;
 

--- a/packages/components/src/components/block/block.tsx
+++ b/packages/components/src/components/block/block.tsx
@@ -86,7 +86,7 @@ export class Block extends LitElement {
   /** When `true`, the component is collapsible. */
   @property({ reflect: true }) collapsible = false;
 
-  /** A description for the component, which displays below the heading. */
+  /** Specifies a description for the component. Displays below the heading. */
   @property() description: string;
 
   /** When `true`, interaction is prevented and the component is displayed with lower opacity. */

--- a/packages/components/src/components/button/button.tsx
+++ b/packages/components/src/components/button/button.tsx
@@ -113,9 +113,9 @@ export class Button extends LitElement implements LabelableComponent, FormOwner 
   @property({ reflect: true, converter: stringOrBoolean }) download: string | boolean = false;
 
   /**
-   * The `id` of the form that will be associated with the component.
+   * Specifies the `id` of the component's associated form.
    *
-   * When not set, the component will be associated with its ancestor form element, if any.
+   * When not set, the component is associated with its ancestor form element, if one exists.
    */
   @property({ reflect: true }) form: string;
 

--- a/packages/components/src/components/button/button.tsx
+++ b/packages/components/src/components/button/button.tsx
@@ -144,7 +144,7 @@ export class Button extends LitElement implements LabelableComponent, FormOwner 
   /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
-  /** Specifies the name of the component on form submission. */
+  /** Specifies the name of the component. Required to pass the component's `value` on form submission. */
   @property({ reflect: true }) name?: string;
 
   /**

--- a/packages/components/src/components/button/button.tsx
+++ b/packages/components/src/components/button/button.tsx
@@ -135,7 +135,7 @@ export class Button extends LitElement implements LabelableComponent, FormOwner 
   @property({ reflect: true }) kind: Extract<"brand" | "danger" | "inverse" | "neutral", Kind> =
     "brand";
 
-  /** Accessible name for the component. */
+  /** Specifies an accessible label for the component. */
   @property() label: string;
 
   /** When `true`, a busy indicator is displayed. */

--- a/packages/components/src/components/button/button.tsx
+++ b/packages/components/src/components/button/button.tsx
@@ -141,7 +141,7 @@ export class Button extends LitElement implements LabelableComponent, FormOwner 
   /** When `true`, a busy indicator is displayed. */
   @property({ reflect: true }) loading = false;
 
-  /** Use this property to override individual strings used by the component. */
+  /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /** Specifies the name of the component on form submission. */

--- a/packages/components/src/components/card-group/card-group.tsx
+++ b/packages/components/src/components/card-group/card-group.tsx
@@ -42,7 +42,7 @@ export class CardGroup extends LitElement {
   @property({ reflect: true }) disabled = false;
 
   /**
-   * Accessible name for the component.
+   * Specifies an accessible label for the component.
    *
    * @required
    */

--- a/packages/components/src/components/card/card.tsx
+++ b/packages/components/src/components/card/card.tsx
@@ -87,7 +87,7 @@ export class Card extends LitElement {
   /** When `true`, a busy indicator is displayed. */
   @property({ reflect: true }) loading = false;
 
-  /** Use this property to override individual strings used by the component. */
+  /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /**

--- a/packages/components/src/components/card/card.tsx
+++ b/packages/components/src/components/card/card.tsx
@@ -81,7 +81,7 @@ export class Card extends LitElement {
   /** When `true`, interaction is prevented and the component is displayed with lower opacity. */
   @property({ reflect: true }) disabled = false;
 
-  /** Accessible name for the component. */
+  /** Specifies an accessible label for the component. */
   @property() label: string;
 
   /** When `true`, a busy indicator is displayed. */

--- a/packages/components/src/components/carousel-item/carousel-item.tsx
+++ b/packages/components/src/components/carousel-item/carousel-item.tsx
@@ -27,7 +27,7 @@ export class CarouselItem extends LitElement {
   // #region Public Properties
 
   /**
-   * Accessible name for the component.
+   * Specifies an accessible label for the component.
    *
    * @required
    */

--- a/packages/components/src/components/carousel/carousel.tsx
+++ b/packages/components/src/components/carousel/carousel.tsx
@@ -138,7 +138,7 @@ export class Carousel extends LitElement {
   @property({ reflect: true }) disabled = false;
 
   /**
-   * Accessible name for the component.
+   * Specifies an accessible label for the component.
    *
    * @required
    */

--- a/packages/components/src/components/carousel/carousel.tsx
+++ b/packages/components/src/components/carousel/carousel.tsx
@@ -144,7 +144,7 @@ export class Carousel extends LitElement {
    */
   @property() label: string;
 
-  /** Use this property to override individual strings used by the component. */
+  /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /**

--- a/packages/components/src/components/checkbox/checkbox.tsx
+++ b/packages/components/src/components/checkbox/checkbox.tsx
@@ -77,9 +77,9 @@ export class Checkbox extends LitElement implements LabelableComponent, Checkabl
   @property({ reflect: true }) disabled = false;
 
   /**
-   * The `id` of the form that will be associated with the component.
+   * Specifies the `id` of the component's associated form.
    *
-   * When not set, the component will be associated with its ancestor form element, if any.
+   * When not set, the component is associated with its ancestor form element, if one exists.
    */
   @property({ reflect: true }) form: string;
 

--- a/packages/components/src/components/checkbox/checkbox.tsx
+++ b/packages/components/src/components/checkbox/checkbox.tsx
@@ -99,7 +99,7 @@ export class Checkbox extends LitElement implements LabelableComponent, Checkabl
    */
   @property({ reflect: true }) indeterminate = false;
 
-  /** Accessible name for the component. */
+  /** Specifies an accessible label for the component. */
   @property() label: string;
 
   /** When provided, displays label text on the component. */

--- a/packages/components/src/components/checkbox/checkbox.tsx
+++ b/packages/components/src/components/checkbox/checkbox.tsx
@@ -124,7 +124,7 @@ export class Checkbox extends LitElement implements LabelableComponent, Checkabl
   @property({ reflect: true }) status: Status = "idle";
 
   /**
-   * The current validation state of the component.
+   * The component's current validation state.
    *
    * @readonly
    * @mdn [ValidityState](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState)

--- a/packages/components/src/components/checkbox/checkbox.tsx
+++ b/packages/components/src/components/checkbox/checkbox.tsx
@@ -108,11 +108,7 @@ export class Checkbox extends LitElement implements LabelableComponent, Checkabl
   /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
-  /**
-   * Specifies the name of the component.
-   *
-   * Required to pass the component's `value` on form submission.
-   */
+  /** Specifies the name of the component. Required to pass the component's `value` on form submission.*/
   @property({ reflect: true }) name: string;
 
   /**

--- a/packages/components/src/components/checkbox/checkbox.tsx
+++ b/packages/components/src/components/checkbox/checkbox.tsx
@@ -102,7 +102,7 @@ export class Checkbox extends LitElement implements LabelableComponent, Checkabl
   /** Specifies an accessible label for the component. */
   @property() label: string;
 
-  /** When provided, displays label text on the component. */
+  /** Specifies the component's label text. */
   @property() labelText: string;
 
   /** Overrides individual strings used by the component. */

--- a/packages/components/src/components/checkbox/checkbox.tsx
+++ b/packages/components/src/components/checkbox/checkbox.tsx
@@ -105,7 +105,7 @@ export class Checkbox extends LitElement implements LabelableComponent, Checkabl
   /** When provided, displays label text on the component. */
   @property() labelText: string;
 
-  /** Use this property to override individual strings used by the component. */
+  /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /**

--- a/packages/components/src/components/chip-group/chip-group.tsx
+++ b/packages/components/src/components/chip-group/chip-group.tsx
@@ -44,7 +44,7 @@ export class ChipGroup extends LitElement {
   @property({ reflect: true }) disabled = false;
 
   /**
-   * Accessible name for the component.
+   * Specifies an accessible label for the component.
    *
    * @required
    */

--- a/packages/components/src/components/chip/chip.tsx
+++ b/packages/components/src/components/chip/chip.tsx
@@ -98,7 +98,7 @@ export class Chip extends LitElement {
   @property({ reflect: true }) kind: Extract<"brand" | "inverse" | "neutral", Kind> = "neutral";
 
   /**
-   * Accessible name for the component.
+   * Specifies an accessible label for the component.
    *
    * @required
    */

--- a/packages/components/src/components/chip/chip.tsx
+++ b/packages/components/src/components/chip/chip.tsx
@@ -68,7 +68,7 @@ export class Chip extends LitElement {
     Appearance
   > = "solid";
 
-  /** When `true`, a close button is added to the component. */
+  /** When `true`, displays a close button in the component. */
   @property({ reflect: true }) closable = false;
 
   /** When `true`, hides the component. */

--- a/packages/components/src/components/chip/chip.tsx
+++ b/packages/components/src/components/chip/chip.tsx
@@ -104,7 +104,7 @@ export class Chip extends LitElement {
    */
   @property() label: string;
 
-  /** Use this property to override individual strings used by the component. */
+  /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /** @private */

--- a/packages/components/src/components/color-picker/color-picker.tsx
+++ b/packages/components/src/components/color-picker/color-picker.tsx
@@ -328,7 +328,7 @@ export class ColorPicker extends LitElement {
   /** When `true`, hides the hex input. */
   @property() hexDisabled = false;
 
-  /** Use this property to override individual strings used by the component. */
+  /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /** Specifies the Unicode numeral system used by the component for localization. */

--- a/packages/components/src/components/combobox-item-group/combobox-item-group.tsx
+++ b/packages/components/src/components/combobox-item-group/combobox-item-group.tsx
@@ -40,7 +40,7 @@ export class ComboboxItemGroup extends LitElement {
   @property() ancestors: ComboboxChildElement[];
 
   /**
-   * Specifies the title of the component.
+   * Specifies an accessible label for the component.
    *
    * @required
    */

--- a/packages/components/src/components/combobox-item/combobox-item.tsx
+++ b/packages/components/src/components/combobox-item/combobox-item.tsx
@@ -87,7 +87,7 @@ export class ComboboxItem extends LitElement {
   /** When `true`, the icon will be flipped when the element direction is right-to-left (`"rtl"`). */
   @property({ reflect: true }) iconFlipRtl = false;
 
-  /** The component's label. */
+  /** Specifies an accessible label for the component. */
   @property() label: any;
 
   /** Provides additional metadata to the component used in filtering. */

--- a/packages/components/src/components/combobox-item/combobox-item.tsx
+++ b/packages/components/src/components/combobox-item/combobox-item.tsx
@@ -55,7 +55,7 @@ export class ComboboxItem extends LitElement {
   /** Specifies the parent and grandparent items, which are set on `calcite-combobox`. */
   @property() ancestors: ComboboxChildElement[];
 
-  /** A description for the component, which displays below the heading. */
+  /** Specifies a description for the component. Displays below the heading. */
   @property() description: string;
 
   /** When `true`, interaction is prevented and the component is displayed with lower opacity. */

--- a/packages/components/src/components/combobox-item/combobox-item.tsx
+++ b/packages/components/src/components/combobox-item/combobox-item.tsx
@@ -75,7 +75,7 @@ export class ComboboxItem extends LitElement {
   @property({ reflect: true }) guid = guid();
 
   /**
-   * The component's text.
+   * Specifies the component's heading text.
    *
    * @required
    */

--- a/packages/components/src/components/combobox/combobox.tsx
+++ b/packages/components/src/components/combobox/combobox.tsx
@@ -484,7 +484,7 @@ export class Combobox
   @property() validationMessage: string;
 
   /**
-   * The current validation state of the component.
+   * The component's current validation state.
    *
    * @readonly
    * @mdn [ValidityState](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState)

--- a/packages/components/src/components/combobox/combobox.tsx
+++ b/packages/components/src/components/combobox/combobox.tsx
@@ -356,9 +356,9 @@ export class Combobox
   @property() flipPlacements: FlipPlacement[];
 
   /**
-   * The `id` of the form that will be associated with the component.
+   * Specifies the `id` of the component's associated form.
    *
-   * When not set, the component will be associated with its ancestor form element, if any.
+   * When not set, the component is associated with its ancestor form element, if one exists.
    */
   @property({ reflect: true }) form: string;
 

--- a/packages/components/src/components/combobox/combobox.tsx
+++ b/packages/components/src/components/combobox/combobox.tsx
@@ -352,7 +352,7 @@ export class Combobox
     return this.items.filter((item) => !isHidden(item));
   }
 
-  /** Specifies the component's fallback slotted content placement when it's initial placement has insufficient space available. */
+  /** Specifies the component's fallback `placement` for slotted content when it's initial or specified `placement` has insufficient space available. */
   @property() flipPlacements: FlipPlacement[];
 
   /**

--- a/packages/components/src/components/combobox/combobox.tsx
+++ b/packages/components/src/components/combobox/combobox.tsx
@@ -363,7 +363,7 @@ export class Combobox
   @property({ reflect: true }) form: string;
 
   /**
-   * Accessible name for the component.
+   * Specifies an accessible label for the component.
    *
    * @required
    */

--- a/packages/components/src/components/combobox/combobox.tsx
+++ b/packages/components/src/components/combobox/combobox.tsx
@@ -369,7 +369,7 @@ export class Combobox
    */
   @property() label: string;
 
-  /** When provided, displays label text on the component. */
+  /** Specifies the component's label text. */
   @property() labelText: string;
 
   /** Specifies the maximum number of `calcite-combobox-item`s (including nested children) to display before displaying a scrollbar. */

--- a/packages/components/src/components/combobox/combobox.tsx
+++ b/packages/components/src/components/combobox/combobox.tsx
@@ -375,7 +375,7 @@ export class Combobox
   /** Specifies the maximum number of `calcite-combobox-item`s (including nested children) to display before displaying a scrollbar. */
   @property({ reflect: true }) maxItems = 0;
 
-  /** Use this property to override individual strings used by the component. */
+  /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /**

--- a/packages/components/src/components/combobox/combobox.tsx
+++ b/packages/components/src/components/combobox/combobox.tsx
@@ -385,11 +385,11 @@ export class Combobox
   @property({ reflect: true }) open = false;
 
   /**
-   * Determines the type of positioning to use for the overlaid content.
+   * Specifies the type of positioning to use for overlaid content, where:
    *
-   * Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout.
+   * `"absolute"` works for most cases - positioning the component inside of overflowing parent containers, which affects the container's layout, and
    *
-   * `"fixed"` should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
+   * `"fixed"` is used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
    */
   @property({ reflect: true }) overlayPositioning: OverlayPositioning = "absolute";
 

--- a/packages/components/src/components/combobox/combobox.tsx
+++ b/packages/components/src/components/combobox/combobox.tsx
@@ -378,11 +378,7 @@ export class Combobox
   /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
-  /**
-   * Specifies the name of the component.
-   *
-   * Required to pass the component's `value` on form submission.
-   */
+  /** Specifies the name of the component. Required to pass the component's `value` on form submission. */
   @property({ reflect: true }) name: string;
 
   /** When `true`, displays and positions the component. */

--- a/packages/components/src/components/combobox/combobox.tsx
+++ b/packages/components/src/components/combobox/combobox.tsx
@@ -467,7 +467,7 @@ export class Combobox
   @property({ reflect: true }) status: Status = "idle";
 
   /**
-   * When true, disables top layer placement when the component is open.
+   * When `true` and the component is `open`, disables top layer placement.
    *
    * Only set this if you need complex z-index control or if top layer placement causes conflicts with third-party components.
    *

--- a/packages/components/src/components/date-picker-month-header/date-picker-month-header.tsx
+++ b/packages/components/src/components/date-picker-month-header/date-picker-month-header.tsx
@@ -74,7 +74,7 @@ export class DatePickerMonthHeader extends LitElement {
   /** The focused date is indicated and will become the selected date if the user proceeds. */
   @property() activeDate: Date;
 
-  /** Specifies the number at which section headings should start. */
+  /** Specifies the heading level number of the component's `heading` for proper document structure, without affecting visual styling. */
   @property({ type: Number }) headingLevel: HeadingLevel;
 
   /** CLDR locale data for translated calendar info. */

--- a/packages/components/src/components/date-picker-month/date-picker-month.tsx
+++ b/packages/components/src/components/date-picker-month/date-picker-month.tsx
@@ -82,7 +82,7 @@ export class DatePickerMonth extends LitElement {
   /** End date currently active. */
   @property() endDate?: Date;
 
-  /** Specifies the number at which section headings should start. */
+  /** Specifies the heading level number of the component's `heading` for proper document structure, without affecting visual styling. */
   @property({ type: Number, reflect: true }) headingLevel: HeadingLevel;
 
   /** The range of dates currently being hovered. */

--- a/packages/components/src/components/date-picker/date-picker.tsx
+++ b/packages/components/src/components/date-picker/date-picker.tsx
@@ -95,7 +95,7 @@ export class DatePicker extends LitElement {
   /** Specifies the number of calendars displayed when `range` is `true`. */
   @property({ type: Number, reflect: true }) calendars: 1 | 2 = 2;
 
-  /** Specifies the heading level of the component's `heading` for proper document structure, without affecting visual styling. */
+  /** Specifies the heading level number of the component's `heading` for proper document structure, without affecting visual styling. */
   @property({ type: Number, reflect: true }) headingLevel: HeadingLevel;
 
   /** Defines the layout of the component. */

--- a/packages/components/src/components/date-picker/date-picker.tsx
+++ b/packages/components/src/components/date-picker/date-picker.tsx
@@ -110,7 +110,7 @@ export class DatePicker extends LitElement {
   /** Specifies the latest allowed date as a full date object (`new Date("yyyy-mm-dd")`). */
   @property() maxAsDate: Date;
 
-  /** Use this property to override individual strings used by the component. */
+  /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /**

--- a/packages/components/src/components/dialog/dialog.tsx
+++ b/packages/components/src/components/dialog/dialog.tsx
@@ -172,7 +172,7 @@ export class Dialog extends LitElement {
    */
   @property() focusTrapOptions: Partial<FocusTrapOptions>;
 
-  /** The component header text. */
+  /** Specifies the component's heading text. */
   @property() heading: string;
 
   /** Specifies the heading level number of the component's `heading` for proper document structure, without affecting visual styling. */

--- a/packages/components/src/components/dialog/dialog.tsx
+++ b/packages/components/src/components/dialog/dialog.tsx
@@ -138,7 +138,7 @@ export class Dialog extends LitElement {
   /** When `true`, disables the component's close button. */
   @property({ reflect: true }) closeDisabled = false;
 
-  /** A description for the component. */
+  /** Specifies a description for the component. */
   @property() description: string;
 
   /** When `true`, the component is draggable. */

--- a/packages/components/src/components/dialog/dialog.tsx
+++ b/packages/components/src/components/dialog/dialog.tsx
@@ -221,11 +221,11 @@ export class Dialog extends LitElement {
   @property({ reflect: true }) outsideCloseDisabled = false;
 
   /**
-   * Determines the type of positioning to use for the overlaid content.
+   * Specifies the type of positioning to use for overlaid content, where:
    *
-   * Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout.
+   * `"absolute"` works for most cases - positioning the component inside of overflowing parent containers, which affects the container's layout, and
    *
-   * `"fixed"` should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
+   * `"fixed"` is used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
    */
   @property({ reflect: true }) overlayPositioning: OverlayPositioning = "absolute";
 

--- a/packages/components/src/components/dialog/dialog.tsx
+++ b/packages/components/src/components/dialog/dialog.tsx
@@ -175,7 +175,7 @@ export class Dialog extends LitElement {
   /** The component header text. */
   @property() heading: string;
 
-  /** Specifies the heading level of the component's `heading` for proper document structure, without affecting visual styling. */
+  /** Specifies the heading level number of the component's `heading` for proper document structure, without affecting visual styling. */
   @property({ type: Number, reflect: true }) headingLevel: HeadingLevel;
 
   /** Specifies the kind of the component, which will style the top border. */

--- a/packages/components/src/components/dialog/dialog.tsx
+++ b/packages/components/src/components/dialog/dialog.tsx
@@ -196,7 +196,7 @@ export class Dialog extends LitElement {
   /** When `true`, the action menu items in the `header-menu-actions` slot are open. */
   @property({ reflect: true }) menuOpen = false;
 
-  /** Use this property to override individual strings used by the component. */
+  /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /** When `true`, displays a scrim blocking interaction underneath the component. */

--- a/packages/components/src/components/dialog/dialog.tsx
+++ b/packages/components/src/components/dialog/dialog.tsx
@@ -239,7 +239,7 @@ export class Dialog extends LitElement {
   @property({ reflect: true }) scale: Scale = "m";
 
   /**
-   * When true, disables top layer placement when the component is open.
+   * When `true` and the component is `open`, disables top layer placement.
    *
    * Only set this if you need complex z-index control or if top layer placement causes conflicts with third-party components.
    *

--- a/packages/components/src/components/dropdown-item/dropdown-item.tsx
+++ b/packages/components/src/components/dropdown-item/dropdown-item.tsx
@@ -75,7 +75,7 @@ export class DropdownItem extends LitElement {
   /** Specifies an icon to display at the start of the component. */
   @property({ reflect: true, type: String }) iconStart: IconName;
 
-  /** Accessible name for the component. */
+  /** Specifies an accessible label for the component. */
   @property() label: string;
 
   /** Specifies the relationship to the linked document defined in `href`. */

--- a/packages/components/src/components/dropdown/dropdown.tsx
+++ b/packages/components/src/components/dropdown/dropdown.tsx
@@ -153,7 +153,7 @@ export class Dropdown extends LitElement implements FloatingUIComponent {
   @property() selectedItems: DropdownItem["el"][] = [];
 
   /**
-   * When true, disables top layer placement when the component is open.
+   * When `true` and the component is `open`, disables top layer placement.
    *
    * Only set this if you need complex z-index control or if top layer placement causes conflicts with third-party components.
    *

--- a/packages/components/src/components/dropdown/dropdown.tsx
+++ b/packages/components/src/components/dropdown/dropdown.tsx
@@ -104,7 +104,7 @@ export class Dropdown extends LitElement implements FloatingUIComponent {
   /** When `true`, interaction is prevented and the component is displayed with lower opacity. */
   @property({ reflect: true }) disabled = false;
 
-  /** Specifies the component's fallback `calcite-dropdown-item` `placement` when it's initial or specified `placement` has insufficient space available. */
+  /** Specifies the component's fallback `placement` for slotted `calcite-dropdown-items` when their initial or specified `placement` has insufficient space available. */
   @property() flipPlacements: FlipPlacement[];
 
   /**

--- a/packages/components/src/components/dropdown/dropdown.tsx
+++ b/packages/components/src/components/dropdown/dropdown.tsx
@@ -127,11 +127,11 @@ export class Dropdown extends LitElement implements FloatingUIComponent {
   @property({ reflect: true }) open = false;
 
   /**
-   * Determines the type of positioning to use for the overlaid content.
+   * Specifies the type of positioning to use for overlaid content, where:
    *
-   * Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout.
+   * `"absolute"` works for most cases - positioning the component inside of overflowing parent containers, which affects the container's layout, and
    *
-   * `"fixed"` should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
+   * `"fixed"` is used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
    */
   @property({ reflect: true }) overlayPositioning: OverlayPositioning = "absolute";
 

--- a/packages/components/src/components/fab/fab.tsx
+++ b/packages/components/src/components/fab/fab.tsx
@@ -54,7 +54,7 @@ export class Fab extends LitElement {
   @property({ reflect: true }) kind: Extract<"brand" | "danger" | "inverse" | "neutral", Kind> =
     "brand";
 
-  /** Accessible name for the component. */
+  /** Specifies an accessible label for the component. */
   @property() label: string;
 
   /** When `true`, a busy indicator is displayed. */

--- a/packages/components/src/components/filter/filter.tsx
+++ b/packages/components/src/components/filter/filter.tsx
@@ -82,7 +82,7 @@ export class Filter extends LitElement {
   @property() items: object[] = [];
 
   /**
-   * Specifies an accessible name for the component.
+   * Specifies an accessible label for the component.
    */
   @property() label: string;
 

--- a/packages/components/src/components/filter/filter.tsx
+++ b/packages/components/src/components/filter/filter.tsx
@@ -86,7 +86,7 @@ export class Filter extends LitElement {
    */
   @property() label: string;
 
-  /** Use this property to override individual strings used by the component. */
+  /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /** Specifies placeholder text for the input element. */

--- a/packages/components/src/components/flow-item/flow-item.tsx
+++ b/packages/components/src/components/flow-item/flow-item.tsx
@@ -119,11 +119,11 @@ export class FlowItem extends LitElement {
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /**
-   * Determines the type of positioning to use for the overlaid content.
+   * Specifies the type of positioning to use for overlaid content, where:
    *
-   * Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout.
+   * `"absolute"` works for most cases - positioning the component inside of overflowing parent containers, which affects the container's layout, and
    *
-   * `"fixed"` should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
+   * `"fixed"` is used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
    */
   @property({ reflect: true }) overlayPositioning: OverlayPositioning = "absolute";
 

--- a/packages/components/src/components/flow-item/flow-item.tsx
+++ b/packages/components/src/components/flow-item/flow-item.tsx
@@ -97,7 +97,7 @@ export class FlowItem extends LitElement {
   /** When `true`, interaction is prevented and the component is displayed with lower opacity. */
   @property({ reflect: true }) disabled = false;
 
-  /** The component header text. */
+  /** Specifies the component's heading text. */
   @property() heading: string;
 
   /** Specifies the heading level number of the component's `heading` for proper document structure, without affecting visual styling. */

--- a/packages/components/src/components/flow-item/flow-item.tsx
+++ b/packages/components/src/components/flow-item/flow-item.tsx
@@ -75,7 +75,7 @@ export class FlowItem extends LitElement {
   /** When `true`, displays a close button in the trailing side of the component's header. */
   @property({ reflect: true }) closable = false;
 
-  /** When `true`, the component will be hidden. */
+  /** When `true`, hides the component. */
   @property({ reflect: true }) closed = false;
 
   /**

--- a/packages/components/src/components/flow-item/flow-item.tsx
+++ b/packages/components/src/components/flow-item/flow-item.tsx
@@ -115,7 +115,7 @@ export class FlowItem extends LitElement {
   /** When `true`, the action menu items in the `header-menu-actions` slot are open. */
   @property({ reflect: true }) menuOpen = false;
 
-  /** Use this property to override individual strings used by the component. */
+  /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /**

--- a/packages/components/src/components/flow-item/flow-item.tsx
+++ b/packages/components/src/components/flow-item/flow-item.tsx
@@ -100,7 +100,7 @@ export class FlowItem extends LitElement {
   /** The component header text. */
   @property() heading: string;
 
-  /** Specifies the heading level of the component's `heading` for proper document structure, without affecting visual styling. */
+  /** Specifies the heading level number of the component's `heading` for proper document structure, without affecting visual styling. */
   @property({ type: Number, reflect: true }) headingLevel: HeadingLevel;
 
   /** Specifies an icon to display. */

--- a/packages/components/src/components/flow-item/flow-item.tsx
+++ b/packages/components/src/components/flow-item/flow-item.tsx
@@ -91,7 +91,7 @@ export class FlowItem extends LitElement {
   /** When `true`, the component is collapsible. */
   @property({ reflect: true }) collapsible = false;
 
-  /** A description for the component. */
+  /** Specifies a description for the component. */
   @property() description: string;
 
   /** When `true`, interaction is prevented and the component is displayed with lower opacity. */

--- a/packages/components/src/components/handle/handle.tsx
+++ b/packages/components/src/components/handle/handle.tsx
@@ -65,7 +65,7 @@ export class Handle extends LitElement {
    */
   @property() label: string;
 
-  /** Use this property to override individual strings used by the component. */
+  /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /** When `true`, the component is selected. */

--- a/packages/components/src/components/inline-editable/inline-editable.tsx
+++ b/packages/components/src/components/inline-editable/inline-editable.tsx
@@ -90,7 +90,7 @@ export class InlineEditable extends LitElement implements LabelableComponent {
   /** When `true`, a busy indicator is displayed. */
   @property({ reflect: true }) loading = false;
 
-  /** Use this property to override individual strings used by the component. */
+  /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /** Specifies the size of the component. */

--- a/packages/components/src/components/input-date-picker/input-date-picker.tsx
+++ b/packages/components/src/components/input-date-picker/input-date-picker.tsx
@@ -261,11 +261,11 @@ export class InputDatePicker
   @property({ reflect: true }) open = false;
 
   /**
-   * Determines the type of positioning to use for the overlaid content.
+   * Specifies the type of positioning to use for overlaid content, where:
    *
-   * Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout.
+   * `"absolute"` works for most cases - positioning the component inside of overflowing parent containers, which affects the container's layout, and
    *
-   * `"fixed"` should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
+   * `"fixed"` is used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
    */
   @property({ reflect: true }) overlayPositioning: OverlayPositioning = "absolute";
 

--- a/packages/components/src/components/input-date-picker/input-date-picker.tsx
+++ b/packages/components/src/components/input-date-picker/input-date-picker.tsx
@@ -202,7 +202,7 @@ export class InputDatePicker
   /** When `true`, interaction is prevented and the component is displayed with lower opacity. */
   @property({ reflect: true }) disabled = false;
 
-  /** Specifies the component's fallback `calcite-date-picker` `placement` when it's initial or specified `placement` has insufficient space available. */
+  /** Specifies the component's fallback `placement` for slotted content when it's initial or specified `placement` has insufficient space available. */
   @property() flipPlacements: FlipPlacement[];
 
   /** When `true`, prevents focus trapping. */

--- a/packages/components/src/components/input-date-picker/input-date-picker.tsx
+++ b/packages/components/src/components/input-date-picker/input-date-picker.tsx
@@ -218,7 +218,7 @@ export class InputDatePicker
   /** Specifies the heading level of the component's `heading` for proper document structure, without affecting visual styling. */
   @property({ type: Number, reflect: true }) headingLevel: HeadingLevel;
 
-  /** Accessible name for the component. */
+  /** Specifies an accessible label for the component. */
   @property() label: string;
 
   /** When provided, displays label text on the component. */

--- a/packages/components/src/components/input-date-picker/input-date-picker.tsx
+++ b/packages/components/src/components/input-date-picker/input-date-picker.tsx
@@ -209,9 +209,9 @@ export class InputDatePicker
   @property({ reflect: true }) focusTrapDisabled = false;
 
   /**
-   * The `id` of the form that will be associated with the component.
+   * Specifies the `id` of the component's associated form.
    *
-   * When not set, the component will be associated with its ancestor form element, if any.
+   * When not set, the component is associated with its ancestor form element, if one exists.
    */
   @property({ reflect: true }) form: string;
 

--- a/packages/components/src/components/input-date-picker/input-date-picker.tsx
+++ b/packages/components/src/components/input-date-picker/input-date-picker.tsx
@@ -236,7 +236,7 @@ export class InputDatePicker
   /** Specifies the latest allowed date as a full date object. */
   @property() maxAsDate: Date;
 
-  /** Use this property to override individual strings used by the component. */
+  /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides & DatePicker["messageOverrides"];
 
   /**

--- a/packages/components/src/components/input-date-picker/input-date-picker.tsx
+++ b/packages/components/src/components/input-date-picker/input-date-picker.tsx
@@ -221,7 +221,7 @@ export class InputDatePicker
   /** Specifies an accessible label for the component. */
   @property() label: string;
 
-  /** When provided, displays label text on the component. */
+  /** Specifies the component's label text. */
   @property() labelText: string;
 
   /** Defines the layout of the component. */

--- a/packages/components/src/components/input-date-picker/input-date-picker.tsx
+++ b/packages/components/src/components/input-date-picker/input-date-picker.tsx
@@ -305,7 +305,7 @@ export class InputDatePicker
   @property({ reflect: true }) status: Status = "idle";
 
   /**
-   * When true, disables top layer placement when the component is open.
+   * When `true` and the component is `open`, disables top layer placement.
    *
    * Only set this if you need complex z-index control or if top layer placement causes conflicts with third-party components.
    *

--- a/packages/components/src/components/input-date-picker/input-date-picker.tsx
+++ b/packages/components/src/components/input-date-picker/input-date-picker.tsx
@@ -322,7 +322,7 @@ export class InputDatePicker
   @property() validationMessage: string;
 
   /**
-   * The current validation state of the component.
+   * The component's current validation state.
    *
    * @readonly
    * @mdn [ValidityState](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState)

--- a/packages/components/src/components/input-date-picker/input-date-picker.tsx
+++ b/packages/components/src/components/input-date-picker/input-date-picker.tsx
@@ -251,11 +251,7 @@ export class InputDatePicker
   /** Specifies the monthStyle used by the component. */
   @property() monthStyle: "abbreviated" | "wide" = "wide";
 
-  /**
-   * Specifies the name of the component.
-   *
-   * Required to pass the component's `value` on form submission.
-   */
+  /** Specifies the name of the component. Required to pass the component's `value` on form submission.*/
   @property({ reflect: true }) name: string;
 
   /** Specifies the Unicode numeral system used by the component for localization. This property cannot be dynamically changed. */

--- a/packages/components/src/components/input-date-picker/input-date-picker.tsx
+++ b/packages/components/src/components/input-date-picker/input-date-picker.tsx
@@ -215,7 +215,7 @@ export class InputDatePicker
    */
   @property({ reflect: true }) form: string;
 
-  /** Specifies the heading level of the component's `heading` for proper document structure, without affecting visual styling. */
+  /** Specifies the heading level number of the component's `heading` for proper document structure, without affecting visual styling. */
   @property({ type: Number, reflect: true }) headingLevel: HeadingLevel;
 
   /** Specifies an accessible label for the component. */

--- a/packages/components/src/components/input-number/input-number.tsx
+++ b/packages/components/src/components/input-number/input-number.tsx
@@ -310,7 +310,7 @@ export class InputNumber
   @property() validationMessage: string;
 
   /**
-   * The current validation state of the component.
+   * The component's current validation state.
    *
    * @readonly
    * @mdn [ValidityState](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState)

--- a/packages/components/src/components/input-number/input-number.tsx
+++ b/packages/components/src/components/input-number/input-number.tsx
@@ -200,7 +200,7 @@ export class InputNumber
   /** When `true`, restricts the component to integer numbers only and disables exponential notation. */
   @property() integer = false;
 
-  /** Accessible name for the component's button or hyperlink. */
+  /** Specifies an accessible label for the component's button or hyperlink. */
   @property() label: string;
 
   /** When provided, displays label text on the component. */

--- a/packages/components/src/components/input-number/input-number.tsx
+++ b/packages/components/src/components/input-number/input-number.tsx
@@ -178,9 +178,9 @@ export class InputNumber
   @property({ reflect: true }) editingEnabled = false;
 
   /**
-   * The `id` of the form that will be associated with the component.
+   * Specifies the `id` of the component's associated form.
    *
-   * When not set, the component will be associated with its ancestor form element, if any.
+   * When not set, the component is associated with its ancestor form element, if one exists.
    */
   @property({ reflect: true }) form: string;
 

--- a/packages/components/src/components/input-number/input-number.tsx
+++ b/packages/components/src/components/input-number/input-number.tsx
@@ -203,7 +203,7 @@ export class InputNumber
   /** Specifies an accessible label for the component's button or hyperlink. */
   @property() label: string;
 
-  /** When provided, displays label text on the component. */
+  /** Specifies the component's label text. */
   @property() labelText: string;
 
   /** When `true`, the component is in the loading state and `calcite-progress` is displayed. */

--- a/packages/components/src/components/input-number/input-number.tsx
+++ b/packages/components/src/components/input-number/input-number.tsx
@@ -253,13 +253,7 @@ export class InputNumber
    */
   @property({ reflect: true }) minLength: number;
 
-  /**
-   * Specifies the name of the component.
-   *
-   * Required to pass the component's `value` on form submission.
-   *
-   * @mdn [name](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#name)
-   */
+  /** Specifies the name of the component. Required to pass the component's `value` on form submission.*/
   @property({ reflect: true }) name: string;
 
   /** Specifies the placement of the buttons. */

--- a/packages/components/src/components/input-number/input-number.tsx
+++ b/packages/components/src/components/input-number/input-number.tsx
@@ -233,7 +233,7 @@ export class InputNumber
    */
   @property({ reflect: true }) maxLength: number;
 
-  /** Use this property to override individual strings used by the component. */
+  /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /**

--- a/packages/components/src/components/input-number/input-number.tsx
+++ b/packages/components/src/components/input-number/input-number.tsx
@@ -253,7 +253,13 @@ export class InputNumber
    */
   @property({ reflect: true }) minLength: number;
 
-  /** Specifies the name of the component. Required to pass the component's `value` on form submission.*/
+  /**
+   * Specifies the name of the component.
+   *
+   * Required to pass the component's `value` on form submission.
+   *
+   * @mdn [name](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#name)
+   */
   @property({ reflect: true }) name: string;
 
   /** Specifies the placement of the buttons. */

--- a/packages/components/src/components/input-text/input-text.tsx
+++ b/packages/components/src/components/input-text/input-text.tsx
@@ -172,7 +172,7 @@ export class InputText
   /** When `true`, the icon will be flipped when the element direction is right-to-left (`"rtl"`). */
   @property({ reflect: true }) iconFlipRtl = false;
 
-  /** Accessible name for the component's button or hyperlink. */
+  /** Specifies an accessible label for the component's button or hyperlink. */
   @property() label: string;
 
   @property() labelText: string;

--- a/packages/components/src/components/input-text/input-text.tsx
+++ b/packages/components/src/components/input-text/input-text.tsx
@@ -175,6 +175,7 @@ export class InputText
   /** Specifies an accessible label for the component's button or hyperlink. */
   @property() label: string;
 
+  /** Specifies the component's label text. */
   @property() labelText: string;
 
   /** When `true`, the component is in the loading state and `calcite-progress` is displayed. */

--- a/packages/components/src/components/input-text/input-text.tsx
+++ b/packages/components/src/components/input-text/input-text.tsx
@@ -188,7 +188,7 @@ export class InputText
    */
   @property({ reflect: true }) maxLength: number;
 
-  /** Use this property to override individual strings used by the component. */
+  /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /**

--- a/packages/components/src/components/input-text/input-text.tsx
+++ b/packages/components/src/components/input-text/input-text.tsx
@@ -156,9 +156,9 @@ export class InputText
   @property({ reflect: true }) editingEnabled = false;
 
   /**
-   * The `id` of the form that will be associated with the component.
+   * Specifies the `id` of the component's associated form.
    *
-   * When not set, the component will be associated with its ancestor form element, if any.
+   * When not set, the component is associated with its ancestor form element, if one exists.
    */
   @property({ reflect: true }) form: string;
 

--- a/packages/components/src/components/input-text/input-text.tsx
+++ b/packages/components/src/components/input-text/input-text.tsx
@@ -199,7 +199,13 @@ export class InputText
    */
   @property({ reflect: true }) minLength: number;
 
-  /** Specifies the name of the component. Required to pass the component's `value` on form submission.*/
+  /**
+   * Specifies the name of the component.
+   *
+   * Required to pass the component's `value` on form submission.
+   *
+   * @mdn [name](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#name)
+   */
   @property({ reflect: true }) name: string;
 
   /**

--- a/packages/components/src/components/input-text/input-text.tsx
+++ b/packages/components/src/components/input-text/input-text.tsx
@@ -252,7 +252,7 @@ export class InputText
   @property() validationMessage: string;
 
   /**
-   * The current validation state of the component.
+   * The component's current validation state.
    *
    * @readonly
    * @mdn [ValidityState](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState)

--- a/packages/components/src/components/input-text/input-text.tsx
+++ b/packages/components/src/components/input-text/input-text.tsx
@@ -199,13 +199,7 @@ export class InputText
    */
   @property({ reflect: true }) minLength: number;
 
-  /**
-   * Specifies the name of the component.
-   *
-   * Required to pass the component's `value` on form submission.
-   *
-   * @mdn [name](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#name)
-   */
+  /** Specifies the name of the component. Required to pass the component's `value` on form submission.*/
   @property({ reflect: true }) name: string;
 
   /**

--- a/packages/components/src/components/input-time-picker/input-time-picker.tsx
+++ b/packages/components/src/components/input-time-picker/input-time-picker.tsx
@@ -133,7 +133,7 @@ export class InputTimePicker
   /** Specifies an accessible label for the component. */
   @property() label: string;
 
-  /** When provided, displays label text on the component. */
+  /** Specifies the component's label text. */
   @property() labelText: string;
 
   /**

--- a/packages/components/src/components/input-time-picker/input-time-picker.tsx
+++ b/packages/components/src/components/input-time-picker/input-time-picker.tsx
@@ -207,7 +207,7 @@ export class InputTimePicker
   @property() validationMessage: string;
 
   /**
-   * The current validation state of the component.
+   * The component's current validation state.
    *
    * @readonly
    * @mdn [ValidityState](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState)

--- a/packages/components/src/components/input-time-picker/input-time-picker.tsx
+++ b/packages/components/src/components/input-time-picker/input-time-picker.tsx
@@ -155,7 +155,7 @@ export class InputTimePicker
    */
   @property({ reflect: true }) min: string;
 
-  /** Specifies the name of the component on form submission. */
+  /** Specifies the name of the component. Required to pass the component's `value` on form submission. */
   @property() name: string;
 
   /** Specifies the Unicode numeral system used by the component for localization. */

--- a/packages/components/src/components/input-time-picker/input-time-picker.tsx
+++ b/packages/components/src/components/input-time-picker/input-time-picker.tsx
@@ -130,7 +130,7 @@ export class InputTimePicker
    */
   @property({ reflect: true }) hourFormat: HourFormat = "user";
 
-  /** Accessible name for the component. */
+  /** Specifies an accessible label for the component. */
   @property() label: string;
 
   /** When provided, displays label text on the component. */

--- a/packages/components/src/components/input-time-picker/input-time-picker.tsx
+++ b/packages/components/src/components/input-time-picker/input-time-picker.tsx
@@ -113,9 +113,9 @@ export class InputTimePicker
   @property({ reflect: true }) focusTrapDisabled = false;
 
   /**
-   * The `id` of the form that will be associated with the component.
+   * Specifies the `id` of the component's associated form.
    *
-   * When not set, the component will be associated with its ancestor form element, if any.
+   * When not set, the component is associated with its ancestor form element, if one exists.
    */
   @property({ reflect: true }) form: string;
 

--- a/packages/components/src/components/input-time-picker/input-time-picker.tsx
+++ b/packages/components/src/components/input-time-picker/input-time-picker.tsx
@@ -144,7 +144,7 @@ export class InputTimePicker
    */
   @property({ reflect: true }) max: string;
 
-  /** Use this property to override individual strings used by the component. */
+  /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides & TimePicker["messageOverrides"];
 
   /**

--- a/packages/components/src/components/input-time-picker/input-time-picker.tsx
+++ b/packages/components/src/components/input-time-picker/input-time-picker.tsx
@@ -165,11 +165,11 @@ export class InputTimePicker
   @property({ reflect: true }) open = false;
 
   /**
-   * Determines the type of positioning to use for the overlaid content.
+   * Specifies the type of positioning to use for overlaid content, where:
    *
-   * Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout.
+   * `"absolute"` works for most cases - positioning the component inside of overflowing parent containers, which affects the container's layout, and
    *
-   * `"fixed"` should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
+   * `"fixed"` is used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
    */
   @property() overlayPositioning: OverlayPositioning = "absolute";
 

--- a/packages/components/src/components/input-time-zone/input-time-zone.tsx
+++ b/packages/components/src/components/input-time-zone/input-time-zone.tsx
@@ -109,7 +109,7 @@ export class InputTimeZone extends LitElement implements FormComponent, Labelabl
    */
   @property({ reflect: true }) form: string;
 
-  /** When provided, displays label text on the component. */
+  /** Specifies the component's label text. */
   @property() labelText: string;
 
   /** Specifies the component's maximum number of options to display before displaying a scrollbar. */

--- a/packages/components/src/components/input-time-zone/input-time-zone.tsx
+++ b/packages/components/src/components/input-time-zone/input-time-zone.tsx
@@ -129,11 +129,7 @@ export class InputTimeZone extends LitElement implements FormComponent, Labelabl
    */
   @property({ reflect: true }) mode: TimeZoneMode = "offset";
 
-  /**
-   * Specifies the name of the component.
-   *
-   * Required to pass the component's `value` on form submission.
-   */
+  /** Specifies the name of the component. Required to pass the component's `value` on form submission. */
   @property({ reflect: true }) name: string;
 
   /**

--- a/packages/components/src/components/input-time-zone/input-time-zone.tsx
+++ b/packages/components/src/components/input-time-zone/input-time-zone.tsx
@@ -103,9 +103,9 @@ export class InputTimeZone extends LitElement implements FormComponent, Labelabl
   @property({ reflect: true }) disabled = false;
 
   /**
-   * The `id` of the form that will be associated with the component.
+   * Specifies the `id` of the component's associated form.
    *
-   * When not set, the component will be associated with its ancestor form element, if any.
+   * When not set, the component is associated with its ancestor form element, if one exists.
    */
   @property({ reflect: true }) form: string;
 

--- a/packages/components/src/components/input-time-zone/input-time-zone.tsx
+++ b/packages/components/src/components/input-time-zone/input-time-zone.tsx
@@ -192,7 +192,7 @@ export class InputTimeZone extends LitElement implements FormComponent, Labelabl
   @property() validationMessage: string;
 
   /**
-   * The current validation state of the component.
+   * The component's current validation state.
    *
    * @readonly
    * @mdn [ValidityState](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState)

--- a/packages/components/src/components/input-time-zone/input-time-zone.tsx
+++ b/packages/components/src/components/input-time-zone/input-time-zone.tsx
@@ -149,11 +149,11 @@ export class InputTimeZone extends LitElement implements FormComponent, Labelabl
   @property({ reflect: true }) open = false;
 
   /**
-   * Determines the type of positioning to use for the overlaid content.
+   * Specifies the type of positioning to use for overlaid content, where:
    *
-   * Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout.
+   * `"absolute"` works for most cases - positioning the component inside of overflowing parent containers, which affects the container's layout, and
    *
-   * `"fixed"` should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
+   * `"fixed"` is used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
    */
   @property({ reflect: true }) overlayPositioning: OverlayPositioning = "absolute";
 

--- a/packages/components/src/components/input-time-zone/input-time-zone.tsx
+++ b/packages/components/src/components/input-time-zone/input-time-zone.tsx
@@ -115,7 +115,7 @@ export class InputTimeZone extends LitElement implements FormComponent, Labelabl
   /** Specifies the component's maximum number of options to display before displaying a scrollbar. */
   @property({ reflect: true }) maxItems = 0;
 
-  /** Use this property to override individual strings used by the component. */
+  /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /**

--- a/packages/components/src/components/input/input.tsx
+++ b/packages/components/src/components/input/input.tsx
@@ -352,7 +352,7 @@ export class Input
   @property() validationMessage: string;
 
   /**
-   * The current validation state of the component.
+   * The component's current validation state.
    *
    * @readonly
    * @mdn [ValidityState](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState)

--- a/packages/components/src/components/input/input.tsx
+++ b/packages/components/src/components/input/input.tsx
@@ -189,9 +189,9 @@ export class Input
   @property() files: FileList | undefined;
 
   /**
-   * The `id` of the form that will be associated with the component.
+   * Specifies the `id` of the component's associated form.
    *
-   * When not set, the component will be associated with its ancestor form element, if any.
+   * When not set, the component is associated with its ancestor form element, if one exists.
    */
   @property({ reflect: true }) form: string;
 

--- a/packages/components/src/components/input/input.tsx
+++ b/packages/components/src/components/input/input.tsx
@@ -207,7 +207,7 @@ export class Input
   /** Specifies an accessible label for the component. */
   @property() label: string;
 
-  /** When provided, displays label text on the component. */
+  /** Specifies the component's label text. */
   @property() labelText: string;
 
   /** When `true`, a busy indicator is displayed. */

--- a/packages/components/src/components/input/input.tsx
+++ b/packages/components/src/components/input/input.tsx
@@ -204,7 +204,7 @@ export class Input
   /** When `true`, the icon will be flipped when the element direction is right-to-left (`"rtl"`). */
   @property({ reflect: true }) iconFlipRtl = false;
 
-  /** Accessible name for the component. */
+  /** Specifies an accessible label for the component. */
   @property() label: string;
 
   /** When provided, displays label text on the component. */

--- a/packages/components/src/components/input/input.tsx
+++ b/packages/components/src/components/input/input.tsx
@@ -264,7 +264,13 @@ export class Input
    */
   @property() multiple = false;
 
-  /** Specifies the name of the component. Required to pass the component's `value` on form submission. */
+  /**
+   * Specifies the name of the component.
+   *
+   * Required to pass the component's `value` on form submission.
+   *
+   * @mdn [name](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#name)
+   */
   @property({ reflect: true }) name: string;
 
   /** Specifies the placement of the buttons for `type="number"`. */

--- a/packages/components/src/components/input/input.tsx
+++ b/packages/components/src/components/input/input.tsx
@@ -264,13 +264,7 @@ export class Input
    */
   @property() multiple = false;
 
-  /**
-   * Specifies the name of the component.
-   *
-   * Required to pass the component's `value` on form submission.
-   *
-   * @mdn [name](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#name)
-   */
+  /** Specifies the name of the component. Required to pass the component's `value` on form submission. */
   @property({ reflect: true }) name: string;
 
   /** Specifies the placement of the buttons for `type="number"`. */

--- a/packages/components/src/components/input/input.tsx
+++ b/packages/components/src/components/input/input.tsx
@@ -236,7 +236,7 @@ export class Input
    */
   @property({ reflect: true }) maxLength: number;
 
-  /** Use this property to override individual strings used by the component. */
+  /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /**

--- a/packages/components/src/components/list-item-group/list-item-group.tsx
+++ b/packages/components/src/components/list-item-group/list-item-group.tsx
@@ -37,7 +37,7 @@ export class ListItemGroup extends LitElement {
    */
   @property({ reflect: true }) filterHidden = false;
 
-  /** Specifies heading text for the component's nested `calcite-list-item` rows. */
+  /** Specifies the heading text for the nested `calcite-list-item` rows. */
   @property({ reflect: true }) heading: string;
 
   /**

--- a/packages/components/src/components/list-item/list-item.tsx
+++ b/packages/components/src/components/list-item/list-item.tsx
@@ -158,7 +158,7 @@ export class ListItem extends LitElement implements SortableComponentItem {
    */
   @property() interactionMode: InteractionMode = null;
 
-  /** Specifies the label of the component, displays above the `description`. */
+  /** Specifies an accessible label for the component, displays above the `description`. */
   @property() label: string;
 
   /** Overrides individual strings used by the component. */

--- a/packages/components/src/components/list-item/list-item.tsx
+++ b/packages/components/src/components/list-item/list-item.tsx
@@ -119,7 +119,7 @@ export class ListItem extends LitElement implements SortableComponentItem {
    */
   @property() sortDisabled = false;
 
-  /** When `true`, a close button is added to the component. */
+  /** When `true`, displays a close button in the component. */
   @property({ reflect: true }) closable = false;
 
   /** When `true`, hides the component. */

--- a/packages/components/src/components/list-item/list-item.tsx
+++ b/packages/components/src/components/list-item/list-item.tsx
@@ -125,7 +125,7 @@ export class ListItem extends LitElement implements SortableComponentItem {
   /** When `true`, hides the component. */
   @property({ reflect: true }) closed = false;
 
-  /** Specifies a description for the component, displays below the `label`. */
+  /** Specifies a description for the component. Displays below the `label`. */
   @property() description: string;
 
   /** When `true`, interaction is prevented and the component is displayed with lower opacity. */

--- a/packages/components/src/components/list/list.tsx
+++ b/packages/components/src/components/list/list.tsx
@@ -232,7 +232,7 @@ export class List extends LitElement implements SortableComponent {
   @property({ reflect: true }) interactionMode: InteractionMode = "interactive";
 
   /**
-   * Specifies an accessible name for the component.
+   * Specifies an accessible label for the component.
    *
    * When `dragEnabled` is `true` and multiple list sorting is enabled with `group`, specifies the component's name for dragging between lists.
    *

--- a/packages/components/src/components/loader/loader.tsx
+++ b/packages/components/src/components/loader/loader.tsx
@@ -41,7 +41,7 @@ export class Loader extends LitElement {
   @property({ reflect: true }) inline = false;
 
   /**
-   * Accessible name for the component.
+   * Specifies an accessible label for the component.
    *
    * @required
    */

--- a/packages/components/src/components/menu-item/menu-item.tsx
+++ b/packages/components/src/components/menu-item/menu-item.tsx
@@ -87,7 +87,7 @@ export class MenuItem extends LitElement {
   @property() isTopLevelItem = false;
 
   /**
-   * Accessible name for the component.
+   * Specifies an accessible label for the component.
    *
    * @required
    */

--- a/packages/components/src/components/menu/menu.tsx
+++ b/packages/components/src/components/menu/menu.tsx
@@ -46,7 +46,7 @@ export class Menu extends LitElement {
   //#region Public Properties
 
   /**
-   * Accessible name for the component.
+   * Specifies an accessible label for the component.
    *
    * @required
    */

--- a/packages/components/src/components/meter/meter.tsx
+++ b/packages/components/src/components/meter/meter.tsx
@@ -103,9 +103,9 @@ export class Meter extends LitElement implements FormComponent {
   @property({ reflect: true }) fillType: MeterFillType = "range";
 
   /**
-   * The `id` of the form that will be associated with the component.
+   * Specifies the `id` of the component's associated form.
    *
-   * When not set, the component will be associated with its ancestor form element, if any.
+   * When not set, the component is associated with its ancestor form element, if one exists.
    */
   @property({ reflect: true }) form: string;
 

--- a/packages/components/src/components/meter/meter.tsx
+++ b/packages/components/src/components/meter/meter.tsx
@@ -131,11 +131,7 @@ export class Meter extends LitElement implements FormComponent {
   /** Specifies the component's lowest allowed value. */
   @property({ reflect: true }) min = 0;
 
-  /**
-   * Specifies the name of the component.
-   *
-   * Required to pass the component's `value` on form submission.
-   */
+  /** Specifies the name of the component. Required to pass the component's `value` on form submission. */
   @property({ reflect: true }) name: string;
 
   /** Specifies the Unicode numeral system used by the component for localization. */

--- a/packages/components/src/components/meter/meter.tsx
+++ b/packages/components/src/components/meter/meter.tsx
@@ -116,7 +116,7 @@ export class Meter extends LitElement implements FormComponent {
   @property({ reflect: true }) high: number;
 
   /**
-   * Accessible name for the component.
+   * Specifies an accessible label for the component.
    *
    * @required
    */

--- a/packages/components/src/components/navigation-logo/navigation-logo.tsx
+++ b/packages/components/src/components/navigation-logo/navigation-logo.tsx
@@ -50,7 +50,7 @@ export class NavigationLogo extends LitElement {
   /** When `true`, the icon will be flipped when the element direction is right-to-left (`"rtl"`). */
   @property({ reflect: true }) iconFlipRtl = false;
 
-  /** Describes the appearance or function of the `thumbnail`. If no label is provided, context will not be provided to assistive technologies. */
+  /** Specifies an accessible label for the component. */
   @property() label: string;
 
   /**

--- a/packages/components/src/components/navigation-logo/navigation-logo.tsx
+++ b/packages/components/src/components/navigation-logo/navigation-logo.tsx
@@ -38,7 +38,7 @@ export class NavigationLogo extends LitElement {
   /** Specifies heading text for the component, such as a product or organization name. */
   @property() heading: string;
 
-  /** Specifies the heading level of the component's heading for proper document structure, without affecting visual styling. */
+  /** Specifies the heading level number of the component's `heading` for proper document structure, without affecting visual styling. */
   @property({ type: Number, reflect: true }) headingLevel: HeadingLevel;
 
   /** Specifies the URL destination of the component, which can be set as an absolute or relative path. */

--- a/packages/components/src/components/navigation-logo/navigation-logo.tsx
+++ b/packages/components/src/components/navigation-logo/navigation-logo.tsx
@@ -32,7 +32,7 @@ export class NavigationLogo extends LitElement {
   /** When `true`, the component is highlighted. */
   @property({ reflect: true }) active: boolean;
 
-  /** Specifies a description for the component, which displays below the `heading`. */
+  /** Specifies a description for the component. Displays below the `heading`. */
   @property() description: string;
 
   /** Specifies the component's heading text. */

--- a/packages/components/src/components/navigation-logo/navigation-logo.tsx
+++ b/packages/components/src/components/navigation-logo/navigation-logo.tsx
@@ -35,7 +35,7 @@ export class NavigationLogo extends LitElement {
   /** Specifies a description for the component, which displays below the `heading`. */
   @property() description: string;
 
-  /** Specifies heading text for the component, such as a product or organization name. */
+  /** Specifies the component's heading text. */
   @property() heading: string;
 
   /** Specifies the heading level number of the component's `heading` for proper document structure, without affecting visual styling. */

--- a/packages/components/src/components/navigation-user/navigation-user.tsx
+++ b/packages/components/src/components/navigation-user/navigation-user.tsx
@@ -33,7 +33,7 @@ export class NavigationUser extends LitElement {
   /** Specifies the full name of the user. */
   @property() fullName: string;
 
-  /** Describes the appearance of the avatar. If no label is provided, context will not be provided to assistive technologies. */
+  /** Specifies an accessible label for the component. */
   @property() label: string;
 
   /** When `true`, hides the `fullName` and `username` contents. */

--- a/packages/components/src/components/navigation/navigation.tsx
+++ b/packages/components/src/components/navigation/navigation.tsx
@@ -72,7 +72,7 @@ export class Navigation extends LitElement {
 
   // #region Public Properties
 
-  /** When `navigationAction` is `true`, specifies the label of the `calcite-action`. */
+  /** When `navigationAction` is `true`, specifies an accessible label for the `calcite-action`. */
   @property() label: string;
 
   /** When `true`, displays a `calcite-action` and emits a `calciteNavActionSelect` event on selection change. */

--- a/packages/components/src/components/notice/notice.tsx
+++ b/packages/components/src/components/notice/notice.tsx
@@ -85,7 +85,7 @@ export class Notice extends LitElement {
   @property({ reflect: true }) appearance: Extract<"transparent" | "outline-fill", Appearance> =
     "outline-fill";
 
-  /** When `true`, a close button is added to the component. */
+  /** When `true`, displays a close button in the component. */
   @property({ reflect: true }) closable = false;
 
   /** When `true`, shows a default recommended icon. Alternatively, pass a Calcite UI Icon name to display a specific icon. */

--- a/packages/components/src/components/option-group/option-group.tsx
+++ b/packages/components/src/components/option-group/option-group.tsx
@@ -18,7 +18,7 @@ export class OptionGroup extends LitElement {
   disabled = false;
 
   /**
-   * Accessible name for the component.
+   * Specifies an accessible label for the component.
    *
    * @required
    */

--- a/packages/components/src/components/option/option.tsx
+++ b/packages/components/src/components/option/option.tsx
@@ -37,7 +37,7 @@ export class Option extends LitElement {
   })
   disabled = false;
 
-  /** Accessible name for the component. */
+  /** Specifies an accessible label for the component. */
   @property() label: string;
 
   /** When `true`, the component is selected. */

--- a/packages/components/src/components/panel/panel.tsx
+++ b/packages/components/src/components/panel/panel.tsx
@@ -142,7 +142,7 @@ export class Panel extends LitElement {
   /** Specifies the component's header text. */
   @property() heading: string;
 
-  /** Specifies the heading level of the component's `heading` for proper document structure, without affecting visual styling. */
+  /** Specifies the heading level number of the component's `heading` for proper document structure, without affecting visual styling. */
   @property({ type: Number, reflect: true }) headingLevel: HeadingLevel;
 
   /** Specifies an icon to display. */

--- a/packages/components/src/components/panel/panel.tsx
+++ b/packages/components/src/components/panel/panel.tsx
@@ -167,11 +167,11 @@ export class Panel extends LitElement {
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /**
-   * Determines the type of positioning to use for the overlaid content.
+   * Specifies the type of positioning to use for overlaid content, where:
    *
-   * Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout.
+   * `"absolute"` works for most cases - positioning the component inside of overflowing parent containers, which affects the container's layout, and
    *
-   * `"fixed"` should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
+   * `"fixed"` is used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
    */
   @property({ reflect: true }) overlayPositioning: OverlayPositioning = "absolute";
 

--- a/packages/components/src/components/panel/panel.tsx
+++ b/packages/components/src/components/panel/panel.tsx
@@ -109,7 +109,7 @@ export class Panel extends LitElement {
   /** Passes a function to run before the component closes. */
   @property() beforeClose: () => Promise<void>;
 
-  /** When `true`, displays a close button in the trailing side of the header. */
+  /** When `true`, displays a close button in the component. */
   @property({ reflect: true }) closable = false;
 
   /** When `true`, the component will be hidden. */

--- a/packages/components/src/components/panel/panel.tsx
+++ b/packages/components/src/components/panel/panel.tsx
@@ -133,7 +133,7 @@ export class Panel extends LitElement {
   /** When `true`, the component is collapsible. */
   @property({ reflect: true }) collapsible = false;
 
-  /** Specifies the component's description text. */
+  /** Specifies a description for the component. */
   @property() description: string;
 
   /** When `true`, interaction is prevented and the component is displayed with lower opacity. */

--- a/packages/components/src/components/panel/panel.tsx
+++ b/packages/components/src/components/panel/panel.tsx
@@ -139,7 +139,7 @@ export class Panel extends LitElement {
   /** When `true`, interaction is prevented and the component is displayed with lower opacity. */
   @property({ reflect: true }) disabled = false;
 
-  /** Specifies the component's header text. */
+  /** Specifies the component's heading text. */
   @property() heading: string;
 
   /** Specifies the heading level number of the component's `heading` for proper document structure, without affecting visual styling. */

--- a/packages/components/src/components/panel/panel.tsx
+++ b/packages/components/src/components/panel/panel.tsx
@@ -154,7 +154,7 @@ export class Panel extends LitElement {
   /** When `true`, a busy indicator is displayed. */
   @property({ reflect: true }) loading = false;
 
-  /** Specifies the component's fallback menu `placement` when it's initial or specified `placement` has insufficient space available. */
+  /** Specifies the component's fallback `menuPlacement` when it's initial or specified `menuPlacement` has insufficient space available. */
   @property() menuFlipPlacements: FlipPlacement[];
 
   /** When `true`, the action menu items in the `header-menu-actions` slot are open. */

--- a/packages/components/src/components/popover/popover.tsx
+++ b/packages/components/src/components/popover/popover.tsx
@@ -128,7 +128,7 @@ export class Popover extends LitElement implements FloatingUIComponent {
   /** When `true`, prevents flipping the component's placement when overlapping its `referenceElement`. */
   @property({ reflect: true }) flipDisabled = false;
 
-  /** Specifies the component's fallback `placement` when it's initial or specified `placement` has insufficient space available. */
+  /** Specifies the component's fallback `placement` for slotted content when it's initial or specified `placement` has insufficient space available. */
   @property() flipPlacements: FlipPlacement[];
 
   /** When `true`, prevents focus trapping. */

--- a/packages/components/src/components/popover/popover.tsx
+++ b/packages/components/src/components/popover/popover.tsx
@@ -152,7 +152,7 @@ export class Popover extends LitElement implements FloatingUIComponent {
   @property({ type: Number, reflect: true }) headingLevel: HeadingLevel;
 
   /**
-   * Accessible name for the component.
+   * Specifies an accessible label for the component.
    *
    * @required
    */

--- a/packages/components/src/components/popover/popover.tsx
+++ b/packages/components/src/components/popover/popover.tsx
@@ -206,7 +206,7 @@ export class Popover extends LitElement implements FloatingUIComponent {
   @property({ reflect: true }) scale: Scale = "m";
 
   /**
-   * When true, disables top layer placement when the component is open.
+   * When `true` and the component is `open`, disables top layer placement.
    *
    * Only set this if you need complex z-index control or if top layer placement causes conflicts with third-party components.
    *

--- a/packages/components/src/components/popover/popover.tsx
+++ b/packages/components/src/components/popover/popover.tsx
@@ -122,7 +122,7 @@ export class Popover extends LitElement implements FloatingUIComponent {
   /** When `true`, clicking outside of the component automatically closes open `calcite-popover`s. */
   @property({ reflect: true }) autoClose = false;
 
-  /** When `true`, displays a close button within the component. */
+  /** When `true`, displays a close button in the component. */
   @property({ reflect: true }) closable = false;
 
   /** When `true`, prevents flipping the component's placement when overlapping its `referenceElement`. */

--- a/packages/components/src/components/popover/popover.tsx
+++ b/packages/components/src/components/popover/popover.tsx
@@ -145,7 +145,7 @@ export class Popover extends LitElement implements FloatingUIComponent {
    */
   @property() focusTrapOptions: Partial<FocusTrapOptions>;
 
-  /** The component header text. */
+  /** Specifies the component's heading text. */
   @property() heading: string;
 
   /** Specifies the heading level number of the component's `heading` for proper document structure, without affecting visual styling. */

--- a/packages/components/src/components/popover/popover.tsx
+++ b/packages/components/src/components/popover/popover.tsx
@@ -175,11 +175,11 @@ export class Popover extends LitElement implements FloatingUIComponent {
   @property({ reflect: true }) open = false;
 
   /**
-   * Determines the type of positioning to use for the overlaid content.
+   * Specifies the type of positioning to use for overlaid content, where:
    *
-   * Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout.
+   * `"absolute"` works for most cases - positioning the component inside of overflowing parent containers, which affects the container's layout, and
    *
-   * `"fixed"` value should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
+   * `"fixed"` is used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
    */
   @property({ reflect: true }) overlayPositioning: OverlayPositioning = "absolute";
 

--- a/packages/components/src/components/popover/popover.tsx
+++ b/packages/components/src/components/popover/popover.tsx
@@ -148,7 +148,7 @@ export class Popover extends LitElement implements FloatingUIComponent {
   /** The component header text. */
   @property() heading: string;
 
-  /** Specifies the heading level of the component's `heading` for proper document structure, without affecting visual styling. */
+  /** Specifies the heading level number of the component's `heading` for proper document structure, without affecting visual styling. */
   @property({ type: Number, reflect: true }) headingLevel: HeadingLevel;
 
   /**

--- a/packages/components/src/components/progress/progress.tsx
+++ b/packages/components/src/components/progress/progress.tsx
@@ -20,7 +20,7 @@ export class Progress extends LitElement {
 
   // #region Public Properties
 
-  /** Accessible name for the component. */
+  /** Specifies an accessible label for the component. */
   @property() label: string;
 
   /** When `true` and type is `"indeterminate"`, reverses the animation direction. */

--- a/packages/components/src/components/radio-button-group/radio-button-group.tsx
+++ b/packages/components/src/components/radio-button-group/radio-button-group.tsx
@@ -66,7 +66,7 @@ export class RadioButtonGroup extends LitElement {
   /** When `true`, interaction is prevented and the component is displayed with lower opacity. */
   @property({ reflect: true }) disabled = false;
 
-  /** When provided, displays label text on the component. */
+  /** Specifies the component's label text. */
   @property() labelText: string;
 
   /** Specifies the layout of the component. */

--- a/packages/components/src/components/radio-button-group/radio-button-group.tsx
+++ b/packages/components/src/components/radio-button-group/radio-button-group.tsx
@@ -76,7 +76,7 @@ export class RadioButtonGroup extends LitElement {
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /**
-   * Specifies the name of the component on form submission. Must be unique to other component instances.
+   * Specifies the name of the component. Required to pass the component's `value` on form submission.
    *
    * @required
    */

--- a/packages/components/src/components/radio-button/radio-button.tsx
+++ b/packages/components/src/components/radio-button/radio-button.tsx
@@ -68,9 +68,9 @@ export class RadioButton extends LitElement implements LabelableComponent, Check
   @property({ reflect: true }) focused = false;
 
   /**
-   * The `id` of the form that will be associated with the component.
+   * Specifies the `id` of the component's associated form.
    *
-   * When not set, the component will be associated with its ancestor form element, if any.
+   * When not set, the component is associated with its ancestor form element, if one exists.
    */
   @property({ reflect: true }) form: string;
 

--- a/packages/components/src/components/radio-button/radio-button.tsx
+++ b/packages/components/src/components/radio-button/radio-button.tsx
@@ -91,11 +91,7 @@ export class RadioButton extends LitElement implements LabelableComponent, Check
   /** When provided, displays label text on the component. */
   @property() labelText: string;
 
-  /**
-   * Specifies the name of the component. Can be inherited from `calcite-radio-button-group`.
-   *
-   * Required to pass the component's `value` on form submission.
-   */
+  /** Specifies the name of the component. Required to pass the component's `value` on form submission.*/
   @property({ reflect: true }) name: string;
 
   /**

--- a/packages/components/src/components/radio-button/radio-button.tsx
+++ b/packages/components/src/components/radio-button/radio-button.tsx
@@ -88,7 +88,7 @@ export class RadioButton extends LitElement implements LabelableComponent, Check
    */
   @property() label?: string;
 
-  /** When provided, displays label text on the component. */
+  /** Specifies the component's label text. */
   @property() labelText: string;
 
   /** Specifies the name of the component. Required to pass the component's `value` on form submission.*/

--- a/packages/components/src/components/rating/rating.tsx
+++ b/packages/components/src/components/rating/rating.tsx
@@ -101,9 +101,9 @@ export class Rating extends LitElement implements LabelableComponent, FormCompon
   @property({ reflect: true }) disabled = false;
 
   /**
-   * The `id` of the form that will be associated with the component.
+   * Specifies the `id` of the component's associated form.
    *
-   * When not set, the component will be associated with its ancestor form element, if any.
+   * When not set, the component is associated with its ancestor form element, if one exists.
    */
   @property({ reflect: true }) form: string;
 

--- a/packages/components/src/components/rating/rating.tsx
+++ b/packages/components/src/components/rating/rating.tsx
@@ -113,11 +113,7 @@ export class Rating extends LitElement implements LabelableComponent, FormCompon
   /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
-  /**
-   * Specifies the name of the component.
-   *
-   * Required to pass the component's `value` on form submission.
-   */
+  /** Specifies the name of the component. Required to pass the component's `value` on form submission.*/
   @property({ reflect: true }) name: string;
 
   /** When `true`, the component's value can be read, but cannot be modified. */

--- a/packages/components/src/components/rating/rating.tsx
+++ b/packages/components/src/components/rating/rating.tsx
@@ -145,7 +145,7 @@ export class Rating extends LitElement implements LabelableComponent, FormCompon
   @property() validationMessage: string;
 
   /**
-   * The current validation state of the component.
+   * The component's current validation state.
    *
    * @readonly
    * @mdn [ValidityState](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState)

--- a/packages/components/src/components/rating/rating.tsx
+++ b/packages/components/src/components/rating/rating.tsx
@@ -107,7 +107,7 @@ export class Rating extends LitElement implements LabelableComponent, FormCompon
    */
   @property({ reflect: true }) form: string;
 
-  /** When provided, displays label text on the component. */
+  /** Specifies the component's label text. */
   @property() labelText: string;
 
   /** Overrides individual strings used by the component. */

--- a/packages/components/src/components/segmented-control/segmented-control.tsx
+++ b/packages/components/src/components/segmented-control/segmented-control.tsx
@@ -85,9 +85,9 @@ export class SegmentedControl extends LitElement implements LabelableComponent, 
   @property({ reflect: true }) disabled = false;
 
   /**
-   * The `id` of the form that will be associated with the component.
+   * Specifies the `id` of the component's associated form.
    *
-   * When not set, the component will be associated with its ancestor form element, if any.
+   * When not set, the component is associated with its ancestor form element, if one exists.
    */
   @property({ reflect: true }) form: string;
 

--- a/packages/components/src/components/segmented-control/segmented-control.tsx
+++ b/packages/components/src/components/segmented-control/segmented-control.tsx
@@ -100,11 +100,7 @@ export class SegmentedControl extends LitElement implements LabelableComponent, 
   /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
-  /**
-   * Specifies the name of the component.
-   *
-   * Required to pass the component's `value` on form submission.
-   */
+  /** Specifies the name of the component. Required to pass the component's `value` on form submission.*/
   @property({ reflect: true }) name: string;
 
   /**

--- a/packages/components/src/components/segmented-control/segmented-control.tsx
+++ b/packages/components/src/components/segmented-control/segmented-control.tsx
@@ -94,7 +94,7 @@ export class SegmentedControl extends LitElement implements LabelableComponent, 
   /** Defines the layout of the component. */
   @property({ reflect: true }) layout: Extract<"horizontal" | "vertical", Layout> = "horizontal";
 
-  /** When provided, displays label text on the component. */
+  /** Specifies the component's label text. */
   @property() labelText: string;
 
   /** Overrides individual strings used by the component. */

--- a/packages/components/src/components/segmented-control/segmented-control.tsx
+++ b/packages/components/src/components/segmented-control/segmented-control.tsx
@@ -131,7 +131,7 @@ export class SegmentedControl extends LitElement implements LabelableComponent, 
   @property() validationMessage: string;
 
   /**
-   * The current validation state of the component.
+   * The component's current validation state.
    *
    * @readonly
    * @mdn [ValidityState](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState)

--- a/packages/components/src/components/select/select.tsx
+++ b/packages/components/src/components/select/select.tsx
@@ -96,9 +96,9 @@ export class Select extends LitElement implements LabelableComponent, FormCompon
   @property({ reflect: true }) disabled = false;
 
   /**
-   * The `id` of the form that will be associated with the component.
+   * Specifies the `id` of the component's associated form.
    *
-   * When not set, the component will be associated with its ancestor form element, if any.
+   * When not set, the component is associated with its ancestor form element, if one exists.
    */
   @property({ reflect: true }) form: string;
 

--- a/packages/components/src/components/select/select.tsx
+++ b/packages/components/src/components/select/select.tsx
@@ -109,7 +109,7 @@ export class Select extends LitElement implements LabelableComponent, FormCompon
    */
   @property() label: string;
 
-  /** When provided, displays label text on the component. */
+  /** Specifies the component's label text. */
   @property() labelText: string;
 
   /** Specifies the name of the component. Required to pass the component's `value` on form submission.*/

--- a/packages/components/src/components/select/select.tsx
+++ b/packages/components/src/components/select/select.tsx
@@ -112,11 +112,7 @@ export class Select extends LitElement implements LabelableComponent, FormCompon
   /** When provided, displays label text on the component. */
   @property() labelText: string;
 
-  /**
-   * Specifies the name of the component.
-   *
-   * Required to pass the component's `value` on form submission.
-   */
+  /** Specifies the name of the component. Required to pass the component's `value` on form submission.*/
   @property({ reflect: true }) name: string;
 
   /**

--- a/packages/components/src/components/select/select.tsx
+++ b/packages/components/src/components/select/select.tsx
@@ -103,7 +103,7 @@ export class Select extends LitElement implements LabelableComponent, FormCompon
   @property({ reflect: true }) form: string;
 
   /**
-   * Accessible name for the component.
+   * Specifies an accessible label for the component.
    *
    * @required
    */

--- a/packages/components/src/components/select/select.tsx
+++ b/packages/components/src/components/select/select.tsx
@@ -143,7 +143,7 @@ export class Select extends LitElement implements LabelableComponent, FormCompon
   @property() validationMessage: string;
 
   /**
-   * The current validation state of the component.
+   * The component's current validation state.
    *
    * @readonly
    * @mdn [ValidityState](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState)

--- a/packages/components/src/components/sheet/sheet.tsx
+++ b/packages/components/src/components/sheet/sheet.tsx
@@ -178,7 +178,7 @@ export class Sheet extends LitElement {
   @property({ reflect: true }) height: Height;
 
   /**
-   * Specifies the component's label.
+   * Specifies an accessible label for the component.
    *
    * @required
    */

--- a/packages/components/src/components/slider/slider.tsx
+++ b/packages/components/src/components/slider/slider.tsx
@@ -323,7 +323,7 @@ export class Slider extends LitElement implements LabelableComponent, FormCompon
   @property() validationMessage: string;
 
   /**
-   * The current validation state of the component.
+   * The component's current validation state.
    *
    * @readonly
    * @mdn [ValidityState](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState)

--- a/packages/components/src/components/slider/slider.tsx
+++ b/packages/components/src/components/slider/slider.tsx
@@ -268,7 +268,7 @@ export class Slider extends LitElement implements LabelableComponent, FormCompon
   /** When provided, displays label text on the component. */
   @property() labelText: string;
 
-  /** Use this property to override individual strings used by the component. */
+  /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /** For multiple selections, the component's lower value. */

--- a/packages/components/src/components/slider/slider.tsx
+++ b/packages/components/src/components/slider/slider.tsx
@@ -215,9 +215,9 @@ export class Slider extends LitElement implements LabelableComponent, FormCompon
   @property({ reflect: true }) fillPlacement: "start" | "none" | "end" = "start";
 
   /**
-   * The `id` of the form that will be associated with the component.
+   * Specifies the `id` of the component's associated form.
    *
-   * When not set, the component will be associated with its ancestor form element, if any.
+   * When not set, the component is associated with its ancestor form element, if one exists.
    */
   @property({ reflect: true }) form: string;
 

--- a/packages/components/src/components/slider/slider.tsx
+++ b/packages/components/src/components/slider/slider.tsx
@@ -265,7 +265,7 @@ export class Slider extends LitElement implements LabelableComponent, FormCompon
   /** Accessible name for first (or only) handle, such as `"Temperature, lower bound"`. */
   @property() minLabel: string;
 
-  /** When provided, displays label text on the component. */
+  /** Specifies the component's label text. */
   @property() labelText: string;
 
   /** Overrides individual strings used by the component. */

--- a/packages/components/src/components/slider/slider.tsx
+++ b/packages/components/src/components/slider/slider.tsx
@@ -281,11 +281,7 @@ export class Slider extends LitElement implements LabelableComponent, FormCompon
    */
   @property({ reflect: true }) mirrored = false;
 
-  /**
-   * Specifies the name of the component.
-   *
-   * Required to pass the component's `value` on form submission.
-   */
+  /** Specifies the name of the component. Required to pass the component's `value` on form submission.*/
   @property({ reflect: true }) name: string;
 
   /** Specifies the Unicode numeral system used by the component for localization. */

--- a/packages/components/src/components/sort-handle/sort-handle.tsx
+++ b/packages/components/src/components/sort-handle/sort-handle.tsx
@@ -73,7 +73,7 @@ export class SortHandle extends LitElement {
   /** Specifies an accessible label for the component. */
   @property() label: string;
 
-  /** Use this property to override individual strings used by the component. */
+  /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /**

--- a/packages/components/src/components/sort-handle/sort-handle.tsx
+++ b/packages/components/src/components/sort-handle/sort-handle.tsx
@@ -67,7 +67,7 @@ export class SortHandle extends LitElement {
   /** When `true`, interaction is prevented and the component is displayed with lower opacity. */
   @property({ reflect: true }) disabled = false;
 
-  /** Specifies the component's fallback `calcite-dropdown-item` `placement` when it's initial or specified `placement` has insufficient space available. */
+  /** Specifies the component's fallback `placement` for slotted content when it's initial or specified `placement` has insufficient space available. */
   @property() flipPlacements: FlipPlacement[];
 
   /** Specifies an accessible label for the component. */

--- a/packages/components/src/components/sort-handle/sort-handle.tsx
+++ b/packages/components/src/components/sort-handle/sort-handle.tsx
@@ -70,7 +70,7 @@ export class SortHandle extends LitElement {
   /** Specifies the component's fallback `calcite-dropdown-item` `placement` when it's initial or specified `placement` has insufficient space available. */
   @property() flipPlacements: FlipPlacement[];
 
-  /** Specifies the label of the component. */
+  /** Specifies an accessible label for the component. */
   @property() label: string;
 
   /** Use this property to override individual strings used by the component. */

--- a/packages/components/src/components/sort-handle/sort-handle.tsx
+++ b/packages/components/src/components/sort-handle/sort-handle.tsx
@@ -93,11 +93,11 @@ export class SortHandle extends LitElement {
   @property({ reflect: true }) open = false;
 
   /**
-   * Determines the type of positioning to use for the overlaid content.
+   * Specifies the type of positioning to use for overlaid content, where:
    *
-   * Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout.
+   * `"absolute"` works for most cases - positioning the component inside of overflowing parent containers, which affects the container's layout, and
    *
-   * `"fixed"` should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
+   * `"fixed"` is used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
    */
   @property({ reflect: true }) overlayPositioning: OverlayPositioning = "absolute";
 

--- a/packages/components/src/components/split-button/split-button.tsx
+++ b/packages/components/src/components/split-button/split-button.tsx
@@ -97,11 +97,11 @@ export class SplitButton extends LitElement {
   @property({ reflect: true }) loading = false;
 
   /**
-   * Determines the type of positioning to use for the overlaid content.
+   * Specifies the type of positioning to use for overlaid content, where:
    *
-   * Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout.
+   * `"absolute"` works for most cases - positioning the component inside of overflowing parent containers, which affects the container's layout, and
    *
-   * `"fixed"` should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
+   * `"fixed"` is used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
    */
   @property({ reflect: true }) overlayPositioning: OverlayPositioning = "absolute";
 

--- a/packages/components/src/components/split-button/split-button.tsx
+++ b/packages/components/src/components/split-button/split-button.tsx
@@ -83,7 +83,7 @@ export class SplitButton extends LitElement {
   /** Accessible name for the dropdown menu. */
   @property({ reflect: true }) dropdownLabel: string;
 
-  /** Specifies the component's fallback slotted content `placement` when it's initial or specified `placement` has insufficient space available. */
+  /** Specifies the component's fallback `placement` for slotted content when it's initial or specified `placement` has insufficient space available. */
   @property() flipPlacements: FlipPlacement[];
 
   /** Specifies the URL of the linked resource, which can be set as an absolute or relative path. */

--- a/packages/components/src/components/stepper-item/stepper-item.tsx
+++ b/packages/components/src/components/stepper-item/stepper-item.tsx
@@ -81,7 +81,7 @@ export class StepperItem extends LitElement {
   /** When `true`, the step has been completed. */
   @property({ reflect: true }) complete = false;
 
-  /** A description for the component. Displays below the header text. */
+  /** Specifies a description for the component. Displays below the header text. */
   @property() description: string;
 
   /** When `true`, interaction is prevented and the component is displayed with lower opacity. */

--- a/packages/components/src/components/stepper-item/stepper-item.tsx
+++ b/packages/components/src/components/stepper-item/stepper-item.tsx
@@ -90,7 +90,7 @@ export class StepperItem extends LitElement {
   /** When `true`, the component contains an error that requires resolution from the user. */
   @property({ reflect: true }) error = false;
 
-  /** The component header text. */
+  /** Specifies the component's heading text. */
   @property() heading: string;
 
   /**

--- a/packages/components/src/components/stepper-item/stepper-item.tsx
+++ b/packages/components/src/components/stepper-item/stepper-item.tsx
@@ -117,7 +117,7 @@ export class StepperItem extends LitElement {
    */
   @property({ reflect: true }) layout: StepperLayout;
 
-  /** Use this property to override individual strings used by the component. */
+  /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /**

--- a/packages/components/src/components/stepper/stepper.tsx
+++ b/packages/components/src/components/stepper/stepper.tsx
@@ -75,7 +75,7 @@ export class Stepper extends LitElement {
   /** Defines the layout of the component. */
   @property({ reflect: true }) layout: StepperLayout = "horizontal";
 
-  /** Use this property to override individual strings used by the component. */
+  /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /** When `true`, displays the step number in the `calcite-stepper-item` heading. */

--- a/packages/components/src/components/swatch-group/swatch-group.tsx
+++ b/packages/components/src/components/swatch-group/swatch-group.tsx
@@ -40,7 +40,7 @@ export class SwatchGroup extends LitElement {
   @property({ reflect: true }) disabled = false;
 
   /**
-   * Accessible name for the component.
+   * Specifies an accessible label for the component.
    *
    * @required
    */

--- a/packages/components/src/components/swatch/swatch.tsx
+++ b/packages/components/src/components/swatch/swatch.tsx
@@ -75,7 +75,7 @@ export class Swatch extends LitElement {
   @property() interactive = false;
 
   /**
-   * Accessible name for the component.
+   * Specifies an accessible label for the component.
    *
    * @required
    */

--- a/packages/components/src/components/switch/switch.tsx
+++ b/packages/components/src/components/switch/switch.tsx
@@ -63,7 +63,7 @@ export class Switch extends LitElement implements LabelableComponent, CheckableF
    */
   @property({ reflect: true }) form: string;
 
-  /** Accessible name for the component. */
+  /** Specifies an accessible label for the component. */
   @property() label: string;
 
   /** When provided, displays label text at the end of the component */

--- a/packages/components/src/components/switch/switch.tsx
+++ b/packages/components/src/components/switch/switch.tsx
@@ -72,11 +72,7 @@ export class Switch extends LitElement implements LabelableComponent, CheckableF
   /** When provided, displays label text at the start of the component */
   @property() labelTextStart: string;
 
-  /**
-   * Specifies the name of the component.
-   *
-   * Required to pass the component's `value` on form submission.
-   */
+  /** Specifies the name of the component. Required to pass the component's `value` on form submission.*/
   @property({ reflect: true }) name: string;
 
   /** Specifies the size of the component. */

--- a/packages/components/src/components/switch/switch.tsx
+++ b/packages/components/src/components/switch/switch.tsx
@@ -57,9 +57,9 @@ export class Switch extends LitElement implements LabelableComponent, CheckableF
   @property({ reflect: true }) disabled = false;
 
   /**
-   * The `id` of the form that will be associated with the component.
+   * Specifies the `id` of the component's associated form.
    *
-   * When not set, the component will be associated with its ancestor form element, if any.
+   * When not set, the component is associated with its ancestor form element, if one exists.
    */
   @property({ reflect: true }) form: string;
 

--- a/packages/components/src/components/switch/switch.tsx
+++ b/packages/components/src/components/switch/switch.tsx
@@ -66,10 +66,10 @@ export class Switch extends LitElement implements LabelableComponent, CheckableF
   /** Specifies an accessible label for the component. */
   @property() label: string;
 
-  /** When provided, displays label text at the end of the component */
+  /** Specifies the component's end label text. */
   @property() labelTextEnd: string;
 
-  /** When provided, displays label text at the start of the component */
+  /** Specifies the component's start label text.*/
   @property() labelTextStart: string;
 
   /** Specifies the name of the component. Required to pass the component's `value` on form submission.*/

--- a/packages/components/src/components/tab-nav/tab-nav.tsx
+++ b/packages/components/src/components/tab-nav/tab-nav.tsx
@@ -85,7 +85,7 @@ export class TabNav extends LitElement {
   /** @private */
   @property({ reflect: true }) layout: TabLayout = "inline";
 
-  /** Use this property to override individual strings used by the component. */
+  /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /**

--- a/packages/components/src/components/tab-title/tab-title.tsx
+++ b/packages/components/src/components/tab-title/tab-title.tsx
@@ -89,7 +89,7 @@ export class TabTitle extends LitElement {
   /** @private */
   @property({ reflect: true }) bordered = false;
 
-  /** When `true`, a close button is added to the component. */
+  /** When `true`, displays a close button in the component. */
   @property({ reflect: true }) closable = false;
 
   /** When `true`, hides the component. */

--- a/packages/components/src/components/tab-title/tab-title.tsx
+++ b/packages/components/src/components/tab-title/tab-title.tsx
@@ -92,7 +92,7 @@ export class TabTitle extends LitElement {
   /** When `true`, a close button is added to the component. */
   @property({ reflect: true }) closable = false;
 
-  /** When `true`, does not display or position the component. */
+  /** When `true`, hides the component. */
   @property({ reflect: true }) closed = false;
 
   /** When `true`, interaction is prevented and the component is displayed with lower opacity. */

--- a/packages/components/src/components/tab-title/tab-title.tsx
+++ b/packages/components/src/components/tab-title/tab-title.tsx
@@ -110,7 +110,7 @@ export class TabTitle extends LitElement {
   /** @private */
   @property({ reflect: true }) layout: TabLayout;
 
-  /** Use this property to override individual strings used by the component. */
+  /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /**

--- a/packages/components/src/components/table-cell/table-cell.tsx
+++ b/packages/components/src/components/table-cell/table-cell.tsx
@@ -71,7 +71,7 @@ export class TableCell extends LitElement {
   /** @private */
   @property() lastCell: boolean;
 
-  /** Use this property to override individual strings used by the component. */
+  /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /** @private */

--- a/packages/components/src/components/table-header/table-header.tsx
+++ b/packages/components/src/components/table-header/table-header.tsx
@@ -61,7 +61,7 @@ export class TableHeader extends LitElement {
   /** A description to display beneath heading content. */
   @property({ reflect: true }) description: string;
 
-  /** A heading to display above description content. */
+  /** Specifies the component's heading text. */
   @property({ reflect: true }) heading: string;
 
   /** @private */

--- a/packages/components/src/components/table-header/table-header.tsx
+++ b/packages/components/src/components/table-header/table-header.tsx
@@ -58,7 +58,7 @@ export class TableHeader extends LitElement {
   /** Specifies the number of columns the component should span. */
   @property({ reflect: true }) colSpan: number;
 
-  /** A description to display beneath heading content. */
+  /** Specifies a description for the component. Displays beneath heading content. */
   @property({ reflect: true }) description: string;
 
   /** Specifies the component's heading text. */

--- a/packages/components/src/components/table-header/table-header.tsx
+++ b/packages/components/src/components/table-header/table-header.tsx
@@ -70,7 +70,7 @@ export class TableHeader extends LitElement {
   /** @private */
   @property() lastCell: boolean;
 
-  /** Use this property to override individual strings used by the component. */
+  /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /** @private */

--- a/packages/components/src/components/table/table.tsx
+++ b/packages/components/src/components/table/table.tsx
@@ -106,7 +106,7 @@ export class Table extends LitElement {
   /** Specifies the layout of the component. */
   @property({ reflect: true }) layout: TableLayout = "auto";
 
-  /** Use this property to override individual strings used by the component. */
+  /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /** When `true`, displays the position of the row in numeric form. */

--- a/packages/components/src/components/text-area/text-area.tsx
+++ b/packages/components/src/components/text-area/text-area.tsx
@@ -174,7 +174,7 @@ export class TextArea
   /** When `true`, number values are displayed with a group separator corresponding to the language and country format. */
   @property({ reflect: true }) groupSeparator = false;
 
-  /** Accessible name for the component. */
+  /** Specifies an accessible label for the component. */
   @property() label: string;
 
   /** When provided, displays label text on the component. */

--- a/packages/components/src/components/text-area/text-area.tsx
+++ b/packages/components/src/components/text-area/text-area.tsx
@@ -177,7 +177,7 @@ export class TextArea
   /** Specifies an accessible label for the component. */
   @property() label: string;
 
-  /** When provided, displays label text on the component. */
+  /** Specifies the component's label text. */
   @property() labelText: string;
 
   /**

--- a/packages/components/src/components/text-area/text-area.tsx
+++ b/packages/components/src/components/text-area/text-area.tsx
@@ -207,11 +207,7 @@ export class TextArea
    */
   @property({ reflect: true }) minLength: number;
 
-  /**
-   * Specifies the name of the component.
-   *
-   * @mdn [name](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-name)
-   */
+  /** Specifies the name of the component. Required to pass the component's `value` on form submission.*/
   @property({ reflect: true }) name: string;
 
   /** Specifies the Unicode numeral system used by the component for localization. */

--- a/packages/components/src/components/text-area/text-area.tsx
+++ b/packages/components/src/components/text-area/text-area.tsx
@@ -260,7 +260,7 @@ export class TextArea
   @property() validationMessage: string;
 
   /**
-   * The current validation state of the component.
+   * The component's current validation state.
    *
    * @readonly
    * @mdn [ValidityState](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState)

--- a/packages/components/src/components/text-area/text-area.tsx
+++ b/packages/components/src/components/text-area/text-area.tsx
@@ -165,9 +165,9 @@ export class TextArea
   @property({ reflect: true }) disabled = false;
 
   /**
-   * The `id` of the form that will be associated with the component.
+   * Specifies the `id` of the component's associated form.
    *
-   * When not set, the component will be associated with its ancestor form element, if any.
+   * When not set, the component is associated with its ancestor form element, if one exists.
    */
   @property({ reflect: true }) form: string;
 

--- a/packages/components/src/components/text-area/text-area.tsx
+++ b/packages/components/src/components/text-area/text-area.tsx
@@ -196,7 +196,7 @@ export class TextArea
    */
   @property({ reflect: true }) maxLength: number;
 
-  /** Use this property to override individual strings used by the component. */
+  /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /**

--- a/packages/components/src/components/text-area/text-area.tsx
+++ b/packages/components/src/components/text-area/text-area.tsx
@@ -207,7 +207,7 @@ export class TextArea
    */
   @property({ reflect: true }) minLength: number;
 
-  /** Specifies the name of the component. Required to pass the component's `value` on form submission.*/
+  /** Specifies the name of the component.*/
   @property({ reflect: true }) name: string;
 
   /** Specifies the Unicode numeral system used by the component for localization. */

--- a/packages/components/src/components/tile-group/tile-group.tsx
+++ b/packages/components/src/components/tile-group/tile-group.tsx
@@ -45,7 +45,7 @@ export class TileGroup extends LitElement implements SelectableGroupComponent {
   @property({ reflect: true }) disabled = false;
 
   /**
-   * Accessible name for the component.
+   * Specifies an accessible label for the component.
    *
    * @required
    */

--- a/packages/components/src/components/tile/tile.tsx
+++ b/packages/components/src/components/tile/tile.tsx
@@ -57,7 +57,7 @@ export class Tile extends LitElement implements SelectableComponent {
   /** Specifies the alignment of the Tile's content. */
   @property({ reflect: true }) alignment: Exclude<Alignment, "end"> = "start";
 
-  /** A description for the component, which displays below the heading. */
+  /** Specifies a description for the component. Displays below the heading. */
   @property({ reflect: true }) description: string;
 
   /** When `true`, interaction is prevented and the component is displayed with lower opacity. */

--- a/packages/components/src/components/tile/tile.tsx
+++ b/packages/components/src/components/tile/tile.tsx
@@ -95,7 +95,7 @@ export class Tile extends LitElement implements SelectableComponent {
    */
   @property() interactive = false;
 
-  /** Accessible name for the component. */
+  /** Specifies an accessible label for the component. */
   @property() label: string;
 
   /**

--- a/packages/components/src/components/tile/tile.tsx
+++ b/packages/components/src/components/tile/tile.tsx
@@ -72,7 +72,7 @@ export class Tile extends LitElement implements SelectableComponent {
    */
   @property({ reflect: true }) embed = false;
 
-  /** The component header text, which displays between the icon and description. */
+  /** Specifies the component's heading text. displays between the `icon` and `description`. */
   @property({ reflect: true }) heading: string;
 
   /** Specifies the heading level number of the component's `heading` for proper document structure, without affecting visual styling. */

--- a/packages/components/src/components/tile/tile.tsx
+++ b/packages/components/src/components/tile/tile.tsx
@@ -75,7 +75,7 @@ export class Tile extends LitElement implements SelectableComponent {
   /** The component header text, which displays between the icon and description. */
   @property({ reflect: true }) heading: string;
 
-  /** Specifies the heading level of the component's `heading` for proper document structure, without affecting visual styling. */
+  /** Specifies the heading level number of the component's `heading` for proper document structure, without affecting visual styling. */
   @property({ type: Number, reflect: true }) headingLevel: HeadingLevel;
 
   /** When embed is `"false"`, the URL for the component. */

--- a/packages/components/src/components/time-picker/time-picker.tsx
+++ b/packages/components/src/components/time-picker/time-picker.tsx
@@ -87,7 +87,7 @@ export class TimePicker extends LitElement implements TimeComponent {
    */
   @property({ reflect: true }) hourFormat: HourFormat = "user";
 
-  /** Use this property to override individual strings used by the component. */
+  /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /** Specifies the Unicode numeral system used by the component for localization. */

--- a/packages/components/src/components/tooltip/tooltip.tsx
+++ b/packages/components/src/components/tooltip/tooltip.tsx
@@ -102,11 +102,11 @@ export class Tooltip extends LitElement implements FloatingUIComponent {
   @property({ reflect: true }) open = false;
 
   /**
-   * Determines the type of positioning to use for the overlaid content.
+   * Specifies the type of positioning to use for overlaid content, where:
    *
-   * Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout.
+   * `"absolute"` works for most cases - positioning the component inside of overflowing parent containers, which affects the container's layout, and
    *
-   * The `"fixed"` value should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
+   * `"fixed"` is used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
    */
   @property({ reflect: true }) overlayPositioning: OverlayPositioning = "absolute";
 

--- a/packages/components/src/components/tooltip/tooltip.tsx
+++ b/packages/components/src/components/tooltip/tooltip.tsx
@@ -114,11 +114,11 @@ export class Tooltip extends LitElement implements FloatingUIComponent {
   @property({ reflect: true }) placement: LogicalPlacement = "auto";
 
   /**
-   * The `referenceElement` to position the component according to its `"placement"` value.
+   * The `referenceElement` used to position the component according to its `placement` value.
    *
-   * Setting to the `HTMLElement` is preferred so the component does not need to query the DOM for the `referenceElement`.
+   * Setting to an `HTMLElement` is preferred so the component does not need to query the DOM.
    *
-   * However, a string ID of the reference element can be used.
+   * However, a string `id` of the reference element can also be used.
    *
    * The component should not be placed within its own `referenceElement` to avoid unintended behavior.
    */

--- a/packages/components/src/components/tooltip/tooltip.tsx
+++ b/packages/components/src/components/tooltip/tooltip.tsx
@@ -82,7 +82,7 @@ export class Tooltip extends LitElement implements FloatingUIComponent {
   @property({ reflect: true }) closeOnClick = false;
 
   /**
-   * Accessible name for the component.
+   * Specifies an accessible label for the component.
    *
    * @deprecated in v1.5.0, removal target v6.0.0 - No longer necessary. Overrides the context of the component's text description, which could confuse assistive technology users.
    */

--- a/packages/components/src/components/tooltip/tooltip.tsx
+++ b/packages/components/src/components/tooltip/tooltip.tsx
@@ -125,7 +125,7 @@ export class Tooltip extends LitElement implements FloatingUIComponent {
   @property() referenceElement: ReferenceElement | string;
 
   /**
-   * When true, disables top layer placement when the component is open.
+   * When `true` and the component is `open`, disables top layer placement.
    *
    * Only set this if you need complex z-index control or if top layer placement causes conflicts with third-party components.
    *

--- a/packages/components/src/components/tree-item/tree-item.tsx
+++ b/packages/components/src/components/tree-item/tree-item.tsx
@@ -96,7 +96,7 @@ export class TreeItem extends LitElement {
    */
   @property({ reflect: true }) indeterminate = false;
 
-  /** Accessible name for the component. */
+  /** Specifies an accessible label for the component. */
   @property() label: string;
 
   /** @private */


### PR DESCRIPTION
**Related Issue:** #12833

## Summary
Update/align the descriptions of the following shared properties across components:
- `closed`
- `closable`
- `description`
- `flipPlacements`
- `form`
- `heading`
- `headingLevel`
- `label`
- `labelText`
- `menuFlipPlacements`
- `messageOverrides`
- `messageOverrides`
- `name`
- `overlayPositioning`
- `referenceElement`
- `topLayerDisabled`
- `validity`