### PR TITLE
chore(action-menu): fix lint error

### DIFF
--- a/packages/components/src/components/action-menu/action-menu.tsx
+++ b/packages/components/src/components/action-menu/action-menu.tsx
@@ -123,9 +123,7 @@ export class ActionMenu extends LitElement {
 
   private actionMouseDownHandler = (event): void => {
     event.stopPropagation();
-    this.activeMenuItemIndex = this.actionElements?.findIndex((action) => {
-      action === event.target;
-    });
+    this.activeMenuItemIndex = this.actionElements?.findIndex((action) => action === event.target);
   };
 
   //#endregion


### PR DESCRIPTION
**Related Issue:** #

## Summary

Resolves lint error caused by  `@typescript-eslint/no-unused-expressions` rule in action-menu.

Stems from https://github.com/Esri/calcite-design-system/commit/ca8ef20c4edf0c4cafb5db33e71465e20026c380#r174804113

reported by @isaacbraun 