### PR TITLE
docs: prepare for API Extractor (2)

### DIFF
--- a/packages/components/src/components/flow/types/index.ts
+++ b/packages/components/src/components/flow/types/index.ts
@@ -1,1 +1,2 @@
+/** @public */
 export type { FlowItemLike } from "../interfaces";

--- a/packages/components/src/utils/config.ts
+++ b/packages/components/src/utils/config.ts
@@ -1,5 +1,5 @@
 import { isServer } from "lit";
-import { FocusTrap } from "../controllers/useFocusTrap";
+import { FocusTrap } from "focus-trap";
 import { LogLevel } from "./logger";
 
 export interface CalciteConfig {


### PR DESCRIPTION
Followup from https://github.com/Esri/calcite-design-system/pull/13684

API Extractor has been merged and released on NPM. [CDC announcement](https://teams.microsoft.com/l/message/19:cb4003bd1b2e4336851133e3e40e25b8@thread.skype/1768932388626?tenantId=aee6e3c9-711e-4c7c-bd27-04f2307db20d&groupId=7711b3bb-549e-42dd-af7b-3688b395b0c2&parentMessageId=1768932388626&teamName=ArcGIS%20Online%20Development&channelName=Code%20dependency%20coordination&createdTime=1768932388626)

I tested a Calcite build using the newest Lumina version.
Verified in JSAPI and AWC.
Fixed two minor detected issues.
Otherwise, all looks good.