### PR TITLE
feat: add `topLayerDisabled` property to additional components

### DIFF
--- a/packages/components/src/components/action-bar/action-bar.tsx
+++ b/packages/components/src/components/action-bar/action-bar.tsx
@@ -223,6 +223,7 @@ export class ActionBar extends LitElement {
    * @mdn [Top Layer](https://developer.mozilla.org/en-US/docs/Glossary/Top_layer)
    */
   @property({ reflect: true }) topLayerDisabled = false;
+
   //#endregion
 
   //#region Public Methods

--- a/packages/components/src/components/action-bar/action-bar.tsx
+++ b/packages/components/src/components/action-bar/action-bar.tsx
@@ -215,6 +215,14 @@ export class ActionBar extends LitElement {
     SelectionAppearance
   > = "neutral";
 
+  /**
+   * When true, disables top layer placement when the component is open.
+   *
+   * Only set this if you need complex z-index control or if top layer placement causes conflicts with third-party components.
+   *
+   * @mdn [Top Layer](https://developer.mozilla.org/en-US/docs/Glossary/Top_layer)
+   */
+  @property({ reflect: true }) topLayerDisabled = false;
   //#endregion
 
   //#region Public Methods
@@ -494,6 +502,7 @@ export class ActionBar extends LitElement {
         layout={layout}
         overlayPositioning={overlayPositioning}
         scale={scale}
+        topLayerDisabled={this.topLayerDisabled}
       >
         <slot name={SLOTS.actionsEnd} onSlotChange={this.handleActionsEndSlotChange} />
         <slot name={SLOTS.expandTooltip} onSlotChange={this.handleTooltipSlotChange} />

--- a/packages/components/src/components/action-bar/action-bar.tsx
+++ b/packages/components/src/components/action-bar/action-bar.tsx
@@ -216,7 +216,7 @@ export class ActionBar extends LitElement {
   > = "neutral";
 
   /**
-   * When true, disables top layer placement when the component is open.
+   * When `true` and the component is `open`, disables top layer placement.
    *
    * Only set this if you need complex z-index control or if top layer placement causes conflicts with third-party components.
    *

--- a/packages/components/src/components/action-group/action-group.tsx
+++ b/packages/components/src/components/action-group/action-group.tsx
@@ -126,7 +126,7 @@ export class ActionGroup extends LitElement {
   > = "none";
 
   /**
-   * When true, disables top layer placement when the component is open.
+   * When `true` and the component is `open`, disables top layer placement.
    *
    * Only set this if you need complex z-index control or if top layer placement causes conflicts with third-party components.
    *

--- a/packages/components/src/components/action-group/action-group.tsx
+++ b/packages/components/src/components/action-group/action-group.tsx
@@ -125,6 +125,15 @@ export class ActionGroup extends LitElement {
     SelectionMode
   > = "none";
 
+  /**
+   * When true, disables top layer placement when the component is open.
+   *
+   * Only set this if you need complex z-index control or if top layer placement causes conflicts with third-party components.
+   *
+   * @mdn [Top Layer](https://developer.mozilla.org/en-US/docs/Glossary/Top_layer)
+   */
+  @property({ reflect: true }) topLayerDisabled = false;
+
   //#endregion
 
   //#region Public Methods
@@ -298,6 +307,7 @@ export class ActionGroup extends LitElement {
         overlayPositioning={overlayPositioning}
         placement={menuPlacement ?? (layout === "horizontal" ? "bottom-start" : "leading-start")}
         scale={scale}
+        topLayerDisabled={this.topLayerDisabled}
       >
         <calcite-action
           aria={{ expanded }}

--- a/packages/components/src/components/action-menu/action-menu.tsx
+++ b/packages/components/src/components/action-menu/action-menu.tsx
@@ -178,6 +178,15 @@ export class ActionMenu extends LitElement {
   /** Determines where the component will be positioned relative to the `referenceElement`. */
   @property({ reflect: true }) placement: LogicalPlacement = "auto";
 
+  /**
+   * When true, disables top layer placement when the component is open.
+   *
+   * Only set this if you need complex z-index control or if top layer placement causes conflicts with third-party components.
+   *
+   * @mdn [Top Layer](https://developer.mozilla.org/en-US/docs/Glossary/Top_layer)
+   */
+  @property({ reflect: true }) topLayerDisabled = false;
+
   /** Specifies the size of the component's trigger `calcite-action`. */
   @property({ reflect: true }) scale: Scale = "m";
 
@@ -528,6 +537,7 @@ export class ActionMenu extends LitElement {
         pointerDisabled={true}
         ref={this.setPopoverEl}
         referenceElement={menuButtonEl}
+        topLayerDisabled={this.topLayerDisabled}
         triggerDisabled={true}
       >
         <div

--- a/packages/components/src/components/action-menu/action-menu.tsx
+++ b/packages/components/src/components/action-menu/action-menu.tsx
@@ -179,7 +179,7 @@ export class ActionMenu extends LitElement {
   @property({ reflect: true }) placement: LogicalPlacement = "auto";
 
   /**
-   * When true, disables top layer placement when the component is open.
+   * When `true` and the component is `open`, disables top layer placement.
    *
    * Only set this if you need complex z-index control or if top layer placement causes conflicts with third-party components.
    *

--- a/packages/components/src/components/action-pad/action-pad.tsx
+++ b/packages/components/src/components/action-pad/action-pad.tsx
@@ -108,7 +108,7 @@ export class ActionPad extends LitElement {
   > = "neutral";
 
   /**
-   * When true, disables top layer placement when the component is open.
+   * When `true` and the component is `open`, disables top layer placement.
    *
    * Only set this if you need complex z-index control or if top layer placement causes conflicts with third-party components.
    *

--- a/packages/components/src/components/action-pad/action-pad.tsx
+++ b/packages/components/src/components/action-pad/action-pad.tsx
@@ -107,6 +107,15 @@ export class ActionPad extends LitElement {
     SelectionAppearance
   > = "neutral";
 
+  /**
+   * When true, disables top layer placement when the component is open.
+   *
+   * Only set this if you need complex z-index control or if top layer placement causes conflicts with third-party components.
+   *
+   * @mdn [Top Layer](https://developer.mozilla.org/en-US/docs/Glossary/Top_layer)
+   */
+  @property({ reflect: true }) topLayerDisabled = false;
+
   //#endregion
 
   //#region Public Methods
@@ -328,6 +337,7 @@ export class ActionPad extends LitElement {
         layout={layout}
         overlayPositioning={overlayPositioning}
         scale={scale}
+        topLayerDisabled={this.topLayerDisabled}
       >
         <slot name={SLOTS.expandTooltip} onSlotChange={this.handleTooltipSlotChange} />
         {expandToggleNode}

--- a/packages/components/src/components/block/block.tsx
+++ b/packages/components/src/components/block/block.tsx
@@ -217,7 +217,7 @@ export class Block extends LitElement {
   @property({ reflect: true }) status: Status;
 
   /**
-   * When true, disables top layer placement when the component is open.
+   * When `true` and the component is `open`, disables top layer placement.
    *
    * Only set this if you need complex z-index control or if top layer placement causes conflicts with third-party components.
    *

--- a/packages/components/src/components/block/block.tsx
+++ b/packages/components/src/components/block/block.tsx
@@ -216,6 +216,15 @@ export class Block extends LitElement {
    */
   @property({ reflect: true }) status: Status;
 
+  /**
+   * When true, disables top layer placement when the component is open.
+   *
+   * Only set this if you need complex z-index control or if top layer placement causes conflicts with third-party components.
+   *
+   * @mdn [Top Layer](https://developer.mozilla.org/en-US/docs/Glossary/Top_layer)
+   */
+  @property({ reflect: true }) topLayerDisabled = false;
+
   //#endregion
 
   //#region Public Methods
@@ -579,6 +588,7 @@ export class Block extends LitElement {
             setPosition={setPosition}
             setSize={setSize}
             sortDisabled={sortDisabled}
+            topLayerDisabled={this.topLayerDisabled}
           />
         ) : null}
         {collapsible ? (
@@ -620,6 +630,7 @@ export class Block extends LitElement {
           overlayPositioning={this.overlayPositioning}
           placement={menuPlacement}
           scale={this.scale}
+          topLayerDisabled={this.topLayerDisabled}
         >
           <slot name={SLOTS.headerMenuActions} onSlotChange={this.menuActionsSlotChangeHandler} />
         </calcite-action-menu>

--- a/packages/components/src/components/dialog/dialog.tsx
+++ b/packages/components/src/components/dialog/dialog.tsx
@@ -817,6 +817,7 @@ export class Dialog extends LitElement {
               overlayPositioning={this.overlayPositioning}
               ref={this.panelRef}
               scale={this.scale}
+              topLayerDisabled={this.topLayerDisabled}
             >
               <slot name={SLOTS.actionBar} slot={PANEL_SLOTS.actionBar} />
               <slot name={SLOTS.alerts} slot={PANEL_SLOTS.alerts} />

--- a/packages/components/src/components/flow-item/flow-item.tsx
+++ b/packages/components/src/components/flow-item/flow-item.tsx
@@ -140,6 +140,15 @@ export class FlowItem extends LitElement {
    */
   @property() showBackButton = false;
 
+  /**
+   * When true, disables top layer placement when the component is open.
+   *
+   * Only set this if you need complex z-index control or if top layer placement causes conflicts with third-party components.
+   *
+   * @mdn [Top Layer](https://developer.mozilla.org/en-US/docs/Glossary/Top_layer)
+   */
+  @property({ reflect: true }) topLayerDisabled = false;
+
   //#endregion
 
   //#region Public Methods
@@ -328,6 +337,7 @@ export class FlowItem extends LitElement {
           overlayPositioning={overlayPositioning}
           ref={this.containerRef}
           scale={this.scale}
+          topLayerDisabled={this.topLayerDisabled}
         >
           {this.renderBackButton()}
           <slot name={SLOTS.actionBar} slot={PANEL_SLOTS.actionBar} />

--- a/packages/components/src/components/flow-item/flow-item.tsx
+++ b/packages/components/src/components/flow-item/flow-item.tsx
@@ -141,7 +141,7 @@ export class FlowItem extends LitElement {
   @property() showBackButton = false;
 
   /**
-   * When true, disables top layer placement when the component is open.
+   * When `true` and the component is `open`, disables top layer placement.
    *
    * Only set this if you need complex z-index control or if top layer placement causes conflicts with third-party components.
    *

--- a/packages/components/src/components/input-time-zone/input-time-zone.tsx
+++ b/packages/components/src/components/input-time-zone/input-time-zone.tsx
@@ -187,6 +187,15 @@ export class InputTimeZone extends LitElement implements FormComponent, Labelabl
   /** Specifies the status of the input field, which determines message and icons. */
   @property({ reflect: true }) status: Status = "idle";
 
+  /**
+   * When true, disables top layer placement when the component is open.
+   *
+   * Only set this if you need complex z-index control or if top layer placement causes conflicts with third-party components.
+   *
+   * @mdn [Top Layer](https://developer.mozilla.org/en-US/docs/Glossary/Top_layer)
+   */
+  @property({ reflect: true }) topLayerDisabled = false;
+
   /** Specifies the validation icon to display under the component. */
   @property({ reflect: true, converter: stringOrBoolean, type: String }) validationIcon:
     | IconName
@@ -522,6 +531,7 @@ export class InputTimeZone extends LitElement implements FormComponent, Labelabl
           scale={this.scale}
           selectionMode={this.clearable ? "single" : "single-persist"}
           status={this.status}
+          topLayerDisabled={this.topLayerDisabled}
           validationIcon={this.validationIcon}
           validationMessage={this.validationMessage}
         >

--- a/packages/components/src/components/input-time-zone/input-time-zone.tsx
+++ b/packages/components/src/components/input-time-zone/input-time-zone.tsx
@@ -188,7 +188,7 @@ export class InputTimeZone extends LitElement implements FormComponent, Labelabl
   @property({ reflect: true }) status: Status = "idle";
 
   /**
-   * When true, disables top layer placement when the component is open.
+   * When `true` and the component is `open`, disables top layer placement.
    *
    * Only set this if you need complex z-index control or if top layer placement causes conflicts with third-party components.
    *

--- a/packages/components/src/components/list-item/list-item.tsx
+++ b/packages/components/src/components/list-item/list-item.tsx
@@ -270,7 +270,7 @@ export class ListItem extends LitElement implements SortableComponentItem {
   @property({ reflect: true }) iconFlipRtl: FlipContext;
 
   /**
-   * When true, disables top layer placement when the component is open.
+   * When `true` and the component is `open`, disables top layer placement.
    *
    * Only set this if you need complex z-index control or if top layer placement causes conflicts with third-party components.
    *

--- a/packages/components/src/components/list-item/list-item.tsx
+++ b/packages/components/src/components/list-item/list-item.tsx
@@ -269,6 +269,15 @@ export class ListItem extends LitElement implements SortableComponentItem {
   /** Displays the `iconStart` and/or `iconEnd` as flipped when the element direction is right-to-left (`"rtl"`). */
   @property({ reflect: true }) iconFlipRtl: FlipContext;
 
+  /**
+   * When true, disables top layer placement when the component is open.
+   *
+   * Only set this if you need complex z-index control or if top layer placement causes conflicts with third-party components.
+   *
+   * @mdn [Top Layer](https://developer.mozilla.org/en-US/docs/Glossary/Top_layer)
+   */
+  @property({ reflect: true }) topLayerDisabled = false;
+
   //#endregion
 
   //#region Public Methods
@@ -802,6 +811,7 @@ export class ListItem extends LitElement implements SortableComponentItem {
           setPosition={setPosition}
           setSize={setSize}
           sortDisabled={sortDisabled}
+          topLayerDisabled={this.topLayerDisabled}
         />
       </div>
     ) : null;

--- a/packages/components/src/components/panel/panel.tsx
+++ b/packages/components/src/components/panel/panel.tsx
@@ -178,6 +178,15 @@ export class Panel extends LitElement {
   /** Specifies the size of the component. */
   @property({ reflect: true }) scale: Scale = "m";
 
+  /**
+   * When true, disables top layer placement when the component is open.
+   *
+   * Only set this if you need complex z-index control or if top layer placement causes conflicts with third-party components.
+   *
+   * @mdn [Top Layer](https://developer.mozilla.org/en-US/docs/Glossary/Top_layer)
+   */
+  @property({ reflect: true }) topLayerDisabled = false;
+
   //#endregion
 
   //#region Public Methods
@@ -536,6 +545,7 @@ export class Panel extends LitElement {
         open={menuOpen}
         overlayPositioning={this.overlayPositioning}
         placement={menuPlacement}
+        topLayerDisabled={this.topLayerDisabled}
       >
         <calcite-action
           class={CSS.menuAction}

--- a/packages/components/src/components/panel/panel.tsx
+++ b/packages/components/src/components/panel/panel.tsx
@@ -179,7 +179,7 @@ export class Panel extends LitElement {
   @property({ reflect: true }) scale: Scale = "m";
 
   /**
-   * When true, disables top layer placement when the component is open.
+   * When `true` and the component is `open`, disables top layer placement.
    *
    * Only set this if you need complex z-index control or if top layer placement causes conflicts with third-party components.
    *

--- a/packages/components/src/components/sort-handle/sort-handle.tsx
+++ b/packages/components/src/components/sort-handle/sort-handle.tsx
@@ -121,7 +121,7 @@ export class SortHandle extends LitElement {
   @property({ reflect: true }) sortDisabled = false;
 
   /**
-   * When true, disables top layer placement when the component is open.
+   * When `true` and the component is `open`, disables top layer placement.
    *
    * Only set this if you need complex z-index control or if top layer placement causes conflicts with third-party components.
    *

--- a/packages/components/src/components/sort-handle/sort-handle.tsx
+++ b/packages/components/src/components/sort-handle/sort-handle.tsx
@@ -120,6 +120,15 @@ export class SortHandle extends LitElement {
   /** When `true`, items are no longer sortable. */
   @property({ reflect: true }) sortDisabled = false;
 
+  /**
+   * When true, disables top layer placement when the component is open.
+   *
+   * Only set this if you need complex z-index control or if top layer placement causes conflicts with third-party components.
+   *
+   * @mdn [Top Layer](https://developer.mozilla.org/en-US/docs/Glossary/Top_layer)
+   */
+  @property({ reflect: true }) topLayerDisabled = false;
+
   /** Specifies the width of the component. */
   @property({ reflect: true }) widthScale: Scale;
 
@@ -294,6 +303,7 @@ export class SortHandle extends LitElement {
           placement={placement}
           ref={this.setDropdownEl}
           scale={scale}
+          topLayerDisabled={this.topLayerDisabled}
           widthScale={widthScale}
         >
           <calcite-action

--- a/packages/components/src/components/split-button/split-button.tsx
+++ b/packages/components/src/components/split-button/split-button.tsx
@@ -145,7 +145,7 @@ export class SplitButton extends LitElement {
   @property({ reflect: true }) target: string;
 
   /**
-   * When true, disables top layer placement when the component is open.
+   * When `true` and the component is `open`, disables top layer placement.
    *
    * Only set this if you need complex z-index control or if top layer placement causes conflicts with third-party components.
    *

--- a/packages/components/src/components/split-button/split-button.tsx
+++ b/packages/components/src/components/split-button/split-button.tsx
@@ -144,6 +144,15 @@ export class SplitButton extends LitElement {
    */
   @property({ reflect: true }) target: string;
 
+  /**
+   * When true, disables top layer placement when the component is open.
+   *
+   * Only set this if you need complex z-index control or if top layer placement causes conflicts with third-party components.
+   *
+   * @mdn [Top Layer](https://developer.mozilla.org/en-US/docs/Glossary/Top_layer)
+   */
+  @property({ reflect: true }) topLayerDisabled = false;
+
   /** Specifies the width of the component. [Deprecated] The `"half"` value is deprecated, use `"full"` instead. */
   @property({ reflect: true }) width: Extract<Width, "auto" | "half" | "full"> = "auto";
 
@@ -227,6 +236,7 @@ export class SplitButton extends LitElement {
             overlayPositioning={this.overlayPositioning}
             placement={this.placement}
             scale={this.scale}
+            topLayerDisabled={this.topLayerDisabled}
             widthScale={this.scale}
           >
             <calcite-button


### PR DESCRIPTION
**Related Issue:** #13698

## Summary

- Added `topLayerDisabled` property declaration to 11 components (action-menu, action-pad, block, flow-item, input-time-zone, list-item, panel, sort-handle, split-button)
- Updated parent components (dialog, block, list-item, panel, action-group, flow-item, input-time-zone, sort-handle, split-button) to pass `topLayerDisabled` to their child components


