### PR TITLE
fix(panel, action-menu): pass `scale` down to nested `calcite-popover`

### DIFF
--- a/packages/components/src/components/action-menu/action-menu.tsx
+++ b/packages/components/src/components/action-menu/action-menu.tsx
@@ -538,6 +538,7 @@ export class ActionMenu extends LitElement {
         pointerDisabled={true}
         ref={this.setPopoverEl}
         referenceElement={menuButtonEl}
+        scale={this.scale}
         topLayerDisabled={this.topLayerDisabled}
         triggerDisabled={true}
       >

--- a/packages/components/src/components/panel/panel.tsx
+++ b/packages/components/src/components/panel/panel.tsx
@@ -534,7 +534,7 @@ export class Panel extends LitElement {
   }
 
   private renderMenu(): JsxNode {
-    const { hasMenuItems, messages, menuOpen, menuFlipPlacements, menuPlacement } = this;
+    const { hasMenuItems, messages, menuOpen, menuFlipPlacements, menuPlacement, scale } = this;
 
     return (
       <calcite-action-menu
@@ -545,12 +545,13 @@ export class Panel extends LitElement {
         open={menuOpen}
         overlayPositioning={this.overlayPositioning}
         placement={menuPlacement}
+        scale={scale}
         topLayerDisabled={this.topLayerDisabled}
       >
         <calcite-action
           class={CSS.menuAction}
           icon={ICONS.menu}
-          scale={this.scale}
+          scale={scale}
           slot={ACTION_MENU_SLOTS.trigger}
           text={messages.options}
         />


### PR DESCRIPTION
**Related Issue:** #13714

## Summary
Passes down the `scale` property value from `calcite-action-menu` to the internal `calcite-popover`, as well as from `calcite-panel` to `calcite-action-menu` when the `header-menu-actions` slot is populated. Creates more consistent padding/sizing.
