### PR TITLE
docs: audit api reference descriptions for b and c components

### DIFF
--- a/packages/components/src/components/block-group/block-group.tsx
+++ b/packages/components/src/components/block-group/block-group.tsx
@@ -94,7 +94,7 @@ export class BlockGroup extends LitElement implements SortableComponent {
   @property({ reflect: true }) dragEnabled = false;
 
   /**
-   * The block-group's group identifier.
+   * Specifies the component's group identifier.
    *
    * To drag elements from one group into another, both groups must have the same group value.
    */

--- a/packages/components/src/components/block/block.tsx
+++ b/packages/components/src/components/block/block.tsx
@@ -92,7 +92,7 @@ export class Block extends LitElement {
   /** When `true`, interaction is prevented and the component is displayed with lower opacity. */
   @property({ reflect: true }) disabled = false;
 
-  /** When `true`, and a parent Block Group is `dragEnabled`, the component is not draggable. */
+  /** When `true`, and a parent `calcite-block-group` is `dragEnabled`, the component is not draggable. */
   @property({ reflect: true }) dragDisabled = false;
 
   /**

--- a/packages/components/src/components/card-group/card-group.tsx
+++ b/packages/components/src/components/card-group/card-group.tsx
@@ -81,7 +81,7 @@ export class CardGroup extends LitElement {
 
   //#region Events
 
-  /** Emits when the component's selection changes and the `selectionMode` is not `none`. */
+  /** Fires when the component's selection changes and the `selectionMode` is not `none`. */
   calciteCardGroupSelect = createEvent({ cancelable: false });
 
   //#endregion

--- a/packages/components/src/components/carousel/carousel.tsx
+++ b/packages/components/src/components/carousel/carousel.tsx
@@ -171,7 +171,7 @@ export class Carousel extends LitElement {
 
   //#region Public Methods
 
-  /** Play the carousel. If `autoplay` is not enabled (initialized either to `true` or `"paused"`), these methods will have no effect. */
+  /** Plays the carousel. If `autoplay` is not enabled (initialized either to `true` or `"paused"`), these methods will have no effect. */
   @method()
   async play(): Promise<void> {
     /* When the 'autoplay' property of type 'boolean | string' is set to true, the value is "". */
@@ -197,7 +197,7 @@ export class Carousel extends LitElement {
     return this.focusSetter(() => this.containerRef.value, options);
   }
 
-  /** Stop the carousel. If `autoplay` is not enabled (initialized either to `true` or `"paused"`), these methods will have no effect. */
+  /** Stops the carousel. If `autoplay` is not enabled (initialized either to `true` or `"paused"`), these methods will have no effect. */
   @method()
   async stop(): Promise<void> {
     if (!this.playing) {

--- a/packages/components/src/components/chip/chip.tsx
+++ b/packages/components/src/components/chip/chip.tsx
@@ -110,7 +110,11 @@ export class Chip extends LitElement {
   /** @private */
   @property() parentChipGroup: ChipGroup["el"];
 
-  /** Specifies the size of the component. When contained in a parent `calcite-chip-group` inherits the parent's `scale` value. */
+  /**
+   * Specifies the size of the component.
+   *
+   * When contained in a parent `calcite-chip-group`, inherits the parent's `scale` value.
+   */
   @property({ reflect: true }) scale: Scale = "m";
 
   /** When `true`, the component is selected. */


### PR DESCRIPTION
**Related Issue:** #12833 

## Summary
Audit following components for doc style guid consistency:

- block-group
- block-section
- block
- button
- card-group
- card
- carousel-item
- carousel
- checkbox
- chip-group
- chip
- ~~color-picker-hex-input~~ (Internal)
- ~~color-picker-swatch~~ (Internal)
- color-picker

Not many changes in this PR as it looks like most of the changes to be made were addressed as a part of the [shared properties alignment PR](https://github.com/Esri/calcite-design-system/pull/13721). There were also some remaining properties that still need discussion and have been added to the list in the discussion.
