### PR TITLE
fix(list-item): fix icon start position when custom content is slotted

### DIFF
--- a/packages/components/src/components/list-item/list-item.tsx
+++ b/packages/components/src/components/list-item/list-item.tsx
@@ -996,8 +996,8 @@ export class ListItem extends LitElement implements SortableComponentItem {
     const hasCenterContent = hasCustomContent || !!label || !!description;
     const content = [
       this.renderContentStart(),
-      this.renderCustomContent(),
       this.renderIconStart(),
+      this.renderCustomContent(),
       this.renderContentProperties(),
       this.renderIconEnd(),
       this.renderContentEnd(),

--- a/packages/components/src/components/list/list.stories.ts
+++ b/packages/components/src/components/list/list.stories.ts
@@ -5742,20 +5742,38 @@ export const customContent_TestOnly = (): string =>
       <div slot="content">
         <strong>Cras iaculis ultricies nulla.</strong>
         <div>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</div>
-      </div></calcite-list-item
-    >
+      </div>
+    </calcite-list-item>
     <calcite-list-item disabled>
       <div slot="content">
         <strong>Cras iaculis ultricies nulla.</strong>
         <div>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</div>
-      </div></calcite-list-item
-    >
-    <calcite-list-item
-      ><div slot="content">
+      </div>
+    </calcite-list-item>
+    <calcite-list-item>
+      <div slot="content">
         <strong>Cras iaculis ultricies nulla.</strong>
         <div>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</div>
-      </div></calcite-list-item
-    >
+      </div>
+    </calcite-list-item>
+    <calcite-list-item icon-start="search" icon-end="banana">
+      <div slot="content">
+        <strong>Cras iaculis ultricies nulla.</strong>
+        <div>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</div>
+      </div>
+    </calcite-list-item>
+    <calcite-list-item disabled icon-start="search" icon-end="banana">
+      <div slot="content">
+        <strong>Cras iaculis ultricies nulla.</strong>
+        <div>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</div>
+      </div>
+    </calcite-list-item>
+    <calcite-list-item icon-start="search" icon-end="banana">
+      <div slot="content">
+        <strong>Cras iaculis ultricies nulla.</strong>
+        <div>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</div>
+      </div>
+    </calcite-list-item>
   </calcite-list>`;
 
 export const singlePersist_TestOnly = (): string =>


### PR DESCRIPTION
**Related Issue:** #11607 

## Summary

Fix issue where icon start was rendered at the end of slotted custom content.