### PR TITLE
test(floating-ui): avoid false positives caused by font rendering diffs

### DIFF
--- a/packages/components/src/floating-ui.stories.ts
+++ b/packages/components/src/floating-ui.stories.ts
@@ -144,3 +144,10 @@ export const stackingWhenTopLayerDisabled = (): string => html`
     </calcite-dialog>
   </div>
 `;
+
+stackingWhenTopLayerDisabled.parameters = {
+  chromatic: {
+    // bump threshold to account for minor font rendering differences
+    diffThreshold: 0.45,
+  },
+};


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Bumps the [diff threshold](https://www.chromatic.com/docs/threshold/) of the `stackingWhenTopLayerDisabled` story to avoid false positives.