### PR TITLE
fix(input, input-number): stop active nudging when `readOnly` is set

### DIFF
--- a/packages/components/src/components/input-number/input-number.browser.e2e.tsx
+++ b/packages/components/src/components/input-number/input-number.browser.e2e.tsx
@@ -1,4 +1,5 @@
-import { describe } from "vitest";
+import { describe, it, expect } from "vitest";
+import { page, userEvent } from "vitest/browser";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import {
   defaults,
@@ -10,6 +11,8 @@ import {
   renders,
   t9n,
 } from "../../tests/commonTests/browser";
+import { InputNumber } from "./input-number";
+import { NUDGE_DELAY_IN_MS } from "./resources";
 
 describe("calcite-input-number", () => {
   describe("defaults", () => {
@@ -100,5 +103,42 @@ describe("calcite-input-number", () => {
 
   describe("disabled", () => {
     disabled(() => mount("calcite-input-number"));
+  });
+
+  describe("nudging", () => {
+    function nudgeReadOnlyToggle(el: InputNumber["el"]): Promise<void> {
+      return new Promise<void>((resolve) => {
+        el.addEventListener(
+          "calciteInputNumberInput",
+          () => {
+            el.readOnly = true;
+            window.setTimeout(() => {
+              el.readOnly = false;
+              resolve();
+            }, NUDGE_DELAY_IN_MS * 2);
+          },
+          { once: true },
+        );
+      });
+    }
+
+    it("stops nudging if readOnly is modified", async () => {
+      const { el } = await mount("calcite-input-number");
+
+      const nudgeUpReadOnlyToggle = nudgeReadOnlyToggle(el);
+      const nudgeUpButton = page.getByTestId("number-button-up");
+      await userEvent.click(nudgeUpButton);
+      await nudgeUpReadOnlyToggle;
+
+      expect(el.value).toBe("1");
+
+      const nudgeDownReadOnlyToggle = nudgeReadOnlyToggle(el);
+
+      const nudgeDownButton = page.getByTestId("number-button-down");
+      await userEvent.click(nudgeDownButton);
+      await nudgeDownReadOnlyToggle;
+
+      expect(el.value).toBe("0");
+    });
   });
 });

--- a/packages/components/src/components/input-number/input-number.tsx
+++ b/packages/components/src/components/input-number/input-number.tsx
@@ -50,7 +50,7 @@ import type { InlineEditable } from "../inline-editable/inline-editable";
 import type { Label } from "../label/label";
 import { useSetFocus } from "../../controllers/useSetFocus";
 import { useInteractive } from "../../controllers/useInteractive";
-import { CSS, ICONS, IDS, SLOTS, DIRECTION } from "./resources";
+import { CSS, ICONS, IDS, SLOTS, DIRECTION, NUDGE_DELAY_IN_MS } from "./resources";
 import T9nStrings from "./assets/t9n/messages.en.json";
 import { styles } from "./input-number.scss";
 
@@ -455,11 +455,16 @@ export class InputNumber
         useGrouping: false,
       };
     }
+
+    if (changes.has("readOnly")) {
+      this.stopNudging();
+    }
   }
 
   override disconnectedCallback(): void {
     disconnectLabel(this);
     disconnectForm(this);
+    this.stopNudging();
     this.el.removeEventListener(
       internalHiddenInputInputEvent,
       this.onHiddenFormInputInput,
@@ -469,6 +474,10 @@ export class InputNumber
   //#endregion
 
   //#region Private Methods
+
+  private stopNudging() {
+    window.clearInterval(this.nudgeNumberValueIntervalId);
+  }
 
   private handleGlobalAttributesChanged(): void {
     this.requestUpdate();
@@ -577,7 +586,7 @@ export class InputNumber
   }
 
   private inputNumberBlurHandler() {
-    window.clearInterval(this.nudgeNumberValueIntervalId);
+    this.stopNudging();
     this.calciteInternalInputNumberBlur.emit();
     this.emitChangeIfUserModified();
   }
@@ -733,12 +742,11 @@ export class InputNumber
 
     const inputMax = this.maxString ? parseFloat(this.maxString) : null;
     const inputMin = this.minString ? parseFloat(this.minString) : null;
-    const valueNudgeDelayInMs = 150;
 
     this.incrementOrDecrementNumberValue(direction, inputMax, inputMin, nativeEvent);
 
     if (this.nudgeNumberValueIntervalId) {
-      window.clearInterval(this.nudgeNumberValueIntervalId);
+      this.stopNudging();
     }
     let firstValueNudge = true;
     this.nudgeNumberValueIntervalId = window.setInterval(() => {
@@ -748,18 +756,18 @@ export class InputNumber
       }
 
       this.incrementOrDecrementNumberValue(direction, inputMax, inputMin, nativeEvent);
-    }, valueNudgeDelayInMs);
+    }, NUDGE_DELAY_IN_MS);
   }
 
   private nudgeButtonPointerUpHandler(event: PointerEvent): void {
     if (!isPrimaryPointerButton(event)) {
       return;
     }
-    window.clearInterval(this.nudgeNumberValueIntervalId);
+    this.stopNudging();
   }
 
   private nudgeButtonPointerOutHandler(): void {
-    window.clearInterval(this.nudgeNumberValueIntervalId);
+    this.stopNudging();
   }
 
   private nudgeButtonPointerDownHandler(event: PointerEvent): void {
@@ -910,7 +918,7 @@ export class InputNumber
   }
 
   private inputNumberKeyUpHandler(): void {
-    window.clearInterval(this.nudgeNumberValueIntervalId);
+    this.stopNudging();
   }
 
   private warnAboutInvalidNumberValue(value: string): void {
@@ -962,6 +970,7 @@ export class InputNumber
           [CSS.buttonItemHorizontal]: isHorizontalNumberButton,
         }}
         data-adjustment={DIRECTION.up}
+        data-testid="number-button-up"
         disabled={this.disabled || this.readOnly}
         onPointerDown={this.nudgeButtonPointerDownHandler}
         onPointerOut={this.nudgeButtonPointerOutHandler}
@@ -981,6 +990,7 @@ export class InputNumber
           [CSS.buttonItemHorizontal]: isHorizontalNumberButton,
         }}
         data-adjustment={DIRECTION.down}
+        data-testid="number-button-down"
         disabled={this.disabled || this.readOnly}
         onPointerDown={this.nudgeButtonPointerDownHandler}
         onPointerOut={this.nudgeButtonPointerOutHandler}

--- a/packages/components/src/components/input-number/resources.ts
+++ b/packages/components/src/components/input-number/resources.ts
@@ -38,3 +38,5 @@ export const DIRECTION = {
   up: "up",
   down: "down",
 };
+
+export const NUDGE_DELAY_IN_MS = 150;

--- a/packages/components/src/components/input/input.browser.e2e.tsx
+++ b/packages/components/src/components/input/input.browser.e2e.tsx
@@ -1,5 +1,7 @@
-import { describe } from "vitest";
+import { describe, expect, it } from "vitest";
+import { h } from "@arcgis/lumina";
 import { mount } from "@arcgis/lumina-compiler/testing";
+import { page, userEvent } from "vitest/browser";
 import {
   defaults,
   disabled,
@@ -10,6 +12,8 @@ import {
   renders,
   t9n,
 } from "../../tests/commonTests/browser";
+import { NUDGE_DELAY_IN_MS } from "../input/resources";
+import { Input } from "./input";
 
 describe("calcite-input", () => {
   describe("defaults", () => {
@@ -108,5 +112,42 @@ describe("calcite-input", () => {
 
   describe("disabled", () => {
     disabled(() => mount("calcite-input"));
+  });
+
+  describe("nudging", () => {
+    function nudgeReadOnlyToggle(el: Input["el"]): Promise<void> {
+      return new Promise<void>((resolve) => {
+        el.addEventListener(
+          "calciteInputInput",
+          () => {
+            el.readOnly = true;
+            window.setTimeout(() => {
+              el.readOnly = false;
+              resolve();
+            }, NUDGE_DELAY_IN_MS * 2);
+          },
+          { once: true },
+        );
+      });
+    }
+
+    it("stops nudging if readOnly is modified", async () => {
+      const { el } = await mount<Input>(<calcite-input type="number" />);
+
+      const nudgeUpReadOnlyToggle = nudgeReadOnlyToggle(el);
+      const nudgeUpButton = page.getByTestId("number-button-up");
+      await userEvent.click(nudgeUpButton);
+      await nudgeUpReadOnlyToggle;
+
+      expect(el.value).toBe("1");
+
+      const nudgeDownReadOnlyToggle = nudgeReadOnlyToggle(el);
+
+      const nudgeDownButton = page.getByTestId("number-button-down");
+      await userEvent.click(nudgeDownButton);
+      await nudgeDownReadOnlyToggle;
+
+      expect(el.value).toBe("0");
+    });
   });
 });

--- a/packages/components/src/components/input/input.browser.e2e.tsx
+++ b/packages/components/src/components/input/input.browser.e2e.tsx
@@ -12,7 +12,7 @@ import {
   renders,
   t9n,
 } from "../../tests/commonTests/browser";
-import { NUDGE_DELAY_IN_MS } from "../input/resources";
+import { NUDGE_DELAY_IN_MS } from "./esources";
 import { Input } from "./input";
 
 describe("calcite-input", () => {

--- a/packages/components/src/components/input/input.browser.e2e.tsx
+++ b/packages/components/src/components/input/input.browser.e2e.tsx
@@ -12,7 +12,7 @@ import {
   renders,
   t9n,
 } from "../../tests/commonTests/browser";
-import { NUDGE_DELAY_IN_MS } from "./esources";
+import { NUDGE_DELAY_IN_MS } from "./resources";
 import { Input } from "./input";
 
 describe("calcite-input", () => {

--- a/packages/components/src/components/input/input.tsx
+++ b/packages/components/src/components/input/input.tsx
@@ -46,7 +46,15 @@ import { useSetFocus } from "../../controllers/useSetFocus";
 import { useInteractive } from "../../controllers/useInteractive";
 import T9nStrings from "./assets/t9n/messages.en.json";
 import { InputPlacement, NumberNudgeDirection, SetValueOrigin } from "./interfaces";
-import { CSS, IDS, INPUT_TYPE_ICONS, SLOTS, ICONS, DIRECTION } from "./resources";
+import {
+  CSS,
+  IDS,
+  INPUT_TYPE_ICONS,
+  SLOTS,
+  ICONS,
+  DIRECTION,
+  NUDGE_DELAY_IN_MS,
+} from "./resources";
 import { NumericInputComponent, syncHiddenFormInput, TextualInputComponent } from "./common/input";
 import { styles } from "./input.scss";
 
@@ -135,6 +143,10 @@ export class Input
   private focusSetter = useSetFocus<this>()(this);
 
   private interactiveContainer = useInteractive(this);
+
+  get isClearable(): boolean {
+    return (this.clearable || this.type === "search") && this.value?.length > 0;
+  }
 
   //#endregion
 
@@ -498,11 +510,16 @@ export class Input
     if (changes.has("icon") || (changes.has("type") && (this.hasUpdated || this.type !== "text"))) {
       this.requestedIcon = setRequestedIcon(INPUT_TYPE_ICONS, this.icon, this.type);
     }
+
+    if (changes.has("readOnly")) {
+      this.stopNudging();
+    }
   }
 
   override disconnectedCallback(): void {
     disconnectLabel(this);
     disconnectForm(this);
+    this.stopNudging();
     this.el.removeEventListener(
       internalHiddenInputInputEvent,
       this.onHiddenFormInputInput,
@@ -513,8 +530,8 @@ export class Input
 
   //#region Private Methods
 
-  get isClearable(): boolean {
-    return (this.clearable || this.type === "search") && this.value?.length > 0;
+  private stopNudging() {
+    window.clearInterval(this.nudgeNumberValueIntervalId);
   }
 
   private handleGlobalAttributesChanged(): void {
@@ -624,7 +641,7 @@ export class Input
   }
 
   private inputBlurHandler() {
-    window.clearInterval(this.nudgeNumberValueIntervalId);
+    this.stopNudging();
     this.calciteInternalInputBlur.emit();
     this.emitChangeIfUserModified();
   }
@@ -799,12 +816,11 @@ export class Input
 
     const inputMax = this.maxString ? parseFloat(this.maxString) : null;
     const inputMin = this.minString ? parseFloat(this.minString) : null;
-    const valueNudgeDelayInMs = 150;
 
     this.incrementOrDecrementNumberValue(direction, inputMax, inputMin, nativeEvent);
 
     if (this.nudgeNumberValueIntervalId) {
-      window.clearInterval(this.nudgeNumberValueIntervalId);
+      this.stopNudging();
     }
     let firstValueNudge = true;
     this.nudgeNumberValueIntervalId = window.setInterval(() => {
@@ -814,11 +830,11 @@ export class Input
       }
 
       this.incrementOrDecrementNumberValue(direction, inputMax, inputMin, nativeEvent);
-    }, valueNudgeDelayInMs);
+    }, NUDGE_DELAY_IN_MS);
   }
 
   private numberButtonPointerUpAndOutHandler(): void {
-    window.clearInterval(this.nudgeNumberValueIntervalId);
+    this.stopNudging();
   }
 
   private numberButtonPointerDownHandler(event: PointerEvent): void {
@@ -938,7 +954,7 @@ export class Input
   }
 
   private inputKeyUpHandler(): void {
-    window.clearInterval(this.nudgeNumberValueIntervalId);
+    this.stopNudging();
   }
 
   private warnAboutInvalidNumberValue(value: string): void {
@@ -991,6 +1007,7 @@ export class Input
           [CSS.buttonItemHorizontal]: isHorizontalNumberButton,
         }}
         data-adjustment={DIRECTION.up}
+        data-testid="number-button-up"
         disabled={this.disabled || this.readOnly}
         onPointerDown={this.numberButtonPointerDownHandler}
         onPointerOut={this.numberButtonPointerUpAndOutHandler}
@@ -1010,6 +1027,7 @@ export class Input
           [CSS.buttonItemHorizontal]: isHorizontalNumberButton,
         }}
         data-adjustment={DIRECTION.down}
+        data-testid="number-button-down"
         disabled={this.disabled || this.readOnly}
         onPointerDown={this.numberButtonPointerDownHandler}
         onPointerOut={this.numberButtonPointerUpAndOutHandler}

--- a/packages/components/src/components/input/resources.ts
+++ b/packages/components/src/components/input/resources.ts
@@ -45,3 +45,5 @@ export const ICONS: Record<string, IconName> = {
   chevronDown: "chevron-down",
   close: "x",
 };
+
+export const NUDGE_DELAY_IN_MS = 150;


### PR DESCRIPTION
**Related Issue:** #12407 

## Summary

This fixes a bug that caused nudging to become stuck due to timer not being cleared when stepper buttons were removed from the DOM.

### Notable changes

* wraps interval clearing logic
* extracts nudge interval delay constant
* clears intervals when disconnected