### PR TITLE
feat(dialog): Add fullscreenDisabled prop to prevent full screen layout

### DIFF
--- a/packages/components/src/components/dialog/dialog.browser.e2e.tsx
+++ b/packages/components/src/components/dialog/dialog.browser.e2e.tsx
@@ -263,7 +263,7 @@ describe("calcite-dialog", () => {
   });
 
   describe("fullscreen disabled", () => {
-    it("does not take full screen when fullscreenDisabled is true", async () => {
+    it("does not take fullscreen when fullscreenDisabled is true", async () => {
       const { container } = await mount(
         <div style={{ width: 800, height: 800 }}>
           <calcite-dialog fullscreen-disabled open>

--- a/packages/components/src/components/dialog/dialog.browser.e2e.tsx
+++ b/packages/components/src/components/dialog/dialog.browser.e2e.tsx
@@ -1,5 +1,5 @@
 import { h } from "@arcgis/lumina";
-import { describe } from "vitest";
+import { describe, it, expect } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import { TemplateResult } from "lit/html.js";
 import { page } from "vitest/browser";
@@ -106,6 +106,10 @@ describe("calcite-dialog", () => {
         {
           propertyName: "widthScale",
           defaultValue: "m",
+        },
+        {
+          propertyName: "fullscreenDisabled",
+          defaultValue: false,
         },
       ],
     );
@@ -214,6 +218,10 @@ describe("calcite-dialog", () => {
           propertyName: "width",
           value: "s",
         },
+        {
+          propertyName: "fullscreenDisabled",
+          value: true,
+        },
       ],
     );
   });
@@ -252,5 +260,33 @@ describe("calcite-dialog", () => {
 
   describe("translation support", () => {
     t9n(() => mount("calcite-dialog"));
+  });
+
+  describe("fullscreen disabled", () => {
+    it("does not take full screen when fullscreenDisabled is true", async () => {
+      const { container } = await mount(
+        <div style={{ width: 800, height: 800 }}>
+          <calcite-dialog fullscreen-disabled open>
+            <div>Dialog content</div>
+          </calcite-dialog>
+        </div>,
+      );
+
+      const dialog = container.querySelector("calcite-dialog");
+      const style = dialog
+        ? (() => {
+            const computed = window.getComputedStyle(dialog);
+            return {
+              width: computed.width,
+              height: computed.height,
+            };
+          })()
+        : {
+            width: "",
+            height: "",
+          };
+      expect(parseInt(style.width)).toBeLessThan(800);
+      expect(parseInt(style.height)).toBeLessThan(800);
+    });
   });
 });

--- a/packages/components/src/components/dialog/dialog.e2e.ts
+++ b/packages/components/src/components/dialog/dialog.e2e.ts
@@ -213,22 +213,8 @@ describe("calcite-dialog", () => {
 
     const internalDialog = await page.find(`calcite-dialog >>> .${CSS.dialog}`);
     const style = await internalDialog.getComputedStyle();
-    expect(style.width).toEqual("800px");
-    expect(style.height).toEqual("800px");
-  });
-
-  it("does not take full screen when fullScreenDisabled is true", async () => {
-    const page = await newE2EPage();
-    // set small page to test fullscreen prevention
-    await page.setViewport({ width: 800, height: 800 });
-    await page.setContent(`<calcite-dialog open full-screen-disabled></calcite-dialog>`);
-
-    await page.waitForChanges();
-
-    const internalDialog = await page.find(`calcite-dialog >>> .${CSS.dialog}`);
-    const style = await internalDialog.getComputedStyle();
-    expect(style.width).not.toEqual("800px");
-    expect(style.height).not.toEqual("800px");
+    expect(parseInt(style.width)).toBeLessThanOrEqual(800);
+    expect(parseInt(style.height)).toBeLessThanOrEqual(800);
   });
 
   it("escapeDisabled", async () => {
@@ -1014,7 +1000,7 @@ describe("calcite-dialog", () => {
       async () => {
         const page = await newE2EPage();
         await page.setContent(
-          html`<calcite-dialog icon="banana" width-scale="s" modal open full-screen-disabled
+          html`<calcite-dialog icon="banana" width-scale="s" modal open fullscreen-disabled
             ><p>Hello world!</p></calcite-dialog
           >`,
         );

--- a/packages/components/src/components/dialog/dialog.e2e.ts
+++ b/packages/components/src/components/dialog/dialog.e2e.ts
@@ -199,12 +199,12 @@ describe("calcite-dialog", () => {
     expect(style.height).not.toEqual("600px");
   });
 
-  it("does not overflow page bounds when requested css variable sizes are larger than viewport", async () => {
+  it("does not overflow page bounds when requested css variable sizes are larger than viewport and full-screen is set", async () => {
     const page = await newE2EPage();
     // set small page to test overflow
     await page.setViewport({ width: 800, height: 800 });
     await page.setContent(
-      `<calcite-dialog style="--calcite-dialog-size-y:1200px;--calcite-dialog-size-x:1200px;" open></calcite-dialog>`,
+      `<calcite-dialog style="--calcite-dialog-size-y:1200px;--calcite-dialog-size-x:1200px;" open full-screen></calcite-dialog>`,
     );
 
     const dialog = await page.find("calcite-dialog");

--- a/packages/components/src/components/dialog/dialog.e2e.ts
+++ b/packages/components/src/components/dialog/dialog.e2e.ts
@@ -199,12 +199,12 @@ describe("calcite-dialog", () => {
     expect(style.height).not.toEqual("600px");
   });
 
-  it("does not overflow page bounds when requested css variable sizes are larger than viewport and full-screen is set", async () => {
+  it("does not overflow page bounds when requested css variable sizes are larger than viewport", async () => {
     const page = await newE2EPage();
     // set small page to test overflow
     await page.setViewport({ width: 800, height: 800 });
     await page.setContent(
-      `<calcite-dialog style="--calcite-dialog-size-y:1200px;--calcite-dialog-size-x:1200px;" open full-screen></calcite-dialog>`,
+      `<calcite-dialog style="--calcite-dialog-size-y:1200px;--calcite-dialog-size-x:1200px;" open></calcite-dialog>`,
     );
 
     const dialog = await page.find("calcite-dialog");
@@ -215,6 +215,20 @@ describe("calcite-dialog", () => {
     const style = await internalDialog.getComputedStyle();
     expect(style.width).toEqual("800px");
     expect(style.height).toEqual("800px");
+  });
+
+  it("does not take full screen when fullScreenDisabled is true", async () => {
+    const page = await newE2EPage();
+    // set small page to test fullscreen prevention
+    await page.setViewport({ width: 800, height: 800 });
+    await page.setContent(`<calcite-dialog open full-screen-disabled></calcite-dialog>`);
+
+    await page.waitForChanges();
+
+    const internalDialog = await page.find(`calcite-dialog >>> .${CSS.dialog}`);
+    const style = await internalDialog.getComputedStyle();
+    expect(style.width).not.toEqual("800px");
+    expect(style.height).not.toEqual("800px");
   });
 
   it("escapeDisabled", async () => {
@@ -1000,10 +1014,10 @@ describe("calcite-dialog", () => {
       async () => {
         const page = await newE2EPage();
         await page.setContent(
-          html`<calcite-dialog icon="banana" width-scale="s" modal open><p>Hello world!</p></calcite-dialog>`,
+          html`<calcite-dialog icon="banana" width-scale="s" modal open full-screen-disabled
+            ><p>Hello world!</p></calcite-dialog
+          >`,
         );
-        // set large page to ensure test dialog isn't becoming fullscreen
-        await page.setViewport({ width: 1440, height: 1440 });
         await skipAnimations(page);
         return { page, tag: "calcite-dialog" };
       },

--- a/packages/components/src/components/dialog/dialog.scss
+++ b/packages/components/src/components/dialog/dialog.scss
@@ -304,7 +304,7 @@ calcite-panel {
     inline-size: var(--calcite-dialog-size-x, $width);
     block-size: var(--calcite-dialog-size-y, auto);
   }
-  :host(:not([full-screen-disabled])) {
+  :host(:not([fullscreen-disabled])) {
     @media screen and (max-width: $width + 2 * spacing.$baseline) {
       .width-#{$size} {
         @apply m-0

--- a/packages/components/src/components/dialog/dialog.scss
+++ b/packages/components/src/components/dialog/dialog.scss
@@ -304,16 +304,17 @@ calcite-panel {
     inline-size: var(--calcite-dialog-size-x, $width);
     block-size: var(--calcite-dialog-size-y, auto);
   }
-
-  @media screen and (max-width: $width + 2 * spacing.$baseline) {
-    .width-#{$size} {
-      @apply m-0
-          h-full
-          max-h-full
-          w-full
-          max-w-full;
-      inset-inline-start: 0;
-      inset-block-start: var(--calcite-internal-dialog-animation-offset);
+  :host([full-screen]) {
+    @media screen and (max-width: $width + 2 * spacing.$baseline) {
+      .width-#{$size} {
+        @apply m-0
+            h-full
+            max-h-full
+            w-full
+            max-w-full;
+        inset-inline-start: 0;
+        inset-block-start: var(--calcite-internal-dialog-animation-offset);
+      }
     }
     .width-#{$size}.dialog {
       &--opening {

--- a/packages/components/src/components/dialog/dialog.scss
+++ b/packages/components/src/components/dialog/dialog.scss
@@ -304,7 +304,7 @@ calcite-panel {
     inline-size: var(--calcite-dialog-size-x, $width);
     block-size: var(--calcite-dialog-size-y, auto);
   }
-  :host([full-screen]) {
+  :host(:not([full-screen-disabled])) {
     @media screen and (max-width: $width + 2 * spacing.$baseline) {
       .width-#{$size} {
         @apply m-0

--- a/packages/components/src/components/dialog/dialog.stories.ts
+++ b/packages/components/src/components/dialog/dialog.stories.ts
@@ -552,11 +552,10 @@ export const fullScreenDisabled = (): string => html`
     heading="Full Screen Disabled"
     description="This dialog cannot go fullscreen even on small screens."
     open
-    width-scale="m"
-    full-screen-disabled
+    fullscreen-disabled
   >
     <div>
-      This dialog has <b>fullScreenDisabled</b> set to true. Resize the viewport to a small size and verify it does not
+      This dialog has <b>fullscreenDisabled</b> set to true. Resize the viewport to a small size and verify it does not
       become fullscreen.
     </div>
     <calcite-button slot="footer-end">Close</calcite-button>

--- a/packages/components/src/components/dialog/dialog.stories.ts
+++ b/packages/components/src/components/dialog/dialog.stories.ts
@@ -546,3 +546,19 @@ export const themed = (): string =>
     <div slot="footer">Footer!</div>
     <calcite-fab slot="${SLOTS.fab}"></calcite-fab>
   </calcite-dialog>`;
+
+export const fullScreenDisabled = (): string => html`
+  <calcite-dialog
+    heading="Full Screen Disabled"
+    description="This dialog cannot go fullscreen even on small screens."
+    open
+    width-scale="m"
+    full-screen-disabled
+  >
+    <div>
+      This dialog has <b>fullScreenDisabled</b> set to true. Resize the viewport to a small size and verify it does not
+      become fullscreen.
+    </div>
+    <calcite-button slot="footer-end">Close</calcite-button>
+  </calcite-dialog>
+`;

--- a/packages/components/src/components/dialog/dialog.stories.ts
+++ b/packages/components/src/components/dialog/dialog.stories.ts
@@ -547,9 +547,9 @@ export const themed = (): string =>
     <calcite-fab slot="${SLOTS.fab}"></calcite-fab>
   </calcite-dialog>`;
 
-export const fullScreenDisabled = (): string => html`
+export const fullscreenDisabled = (): string => html`
   <calcite-dialog
-    heading="Full Screen Disabled"
+    heading="fullscreen Disabled"
     description="This dialog cannot go fullscreen even on small screens."
     open
     fullscreen-disabled

--- a/packages/components/src/components/dialog/dialog.tsx
+++ b/packages/components/src/components/dialog/dialog.tsx
@@ -172,6 +172,8 @@ export class Dialog extends LitElement {
    */
   @property() focusTrapOptions: Partial<FocusTrapOptions>;
 
+  @property() fullScreen: boolean = false;
+
   /** Specifies the component's heading text. */
   @property() heading: string;
 

--- a/packages/components/src/components/dialog/dialog.tsx
+++ b/packages/components/src/components/dialog/dialog.tsx
@@ -172,7 +172,7 @@ export class Dialog extends LitElement {
    */
   @property() focusTrapOptions: Partial<FocusTrapOptions>;
 
-  /** When `true`, the component will not allow full screen display. */
+  /** When `true`, the component will not display at fullscreen, which may be desired in limited display areas, such as mobile devices. */
   @property({ reflect: true }) fullscreenDisabled: boolean = false;
 
   /** Specifies the component's heading text. */

--- a/packages/components/src/components/dialog/dialog.tsx
+++ b/packages/components/src/components/dialog/dialog.tsx
@@ -173,7 +173,7 @@ export class Dialog extends LitElement {
   @property() focusTrapOptions: Partial<FocusTrapOptions>;
 
   /** When `true`, the component will not allow full screen display. */
-  @property() fullScreenDisabled: boolean = false;
+  @property({ reflect: true }) fullscreenDisabled: boolean = false;
 
   /** Specifies the component's heading text. */
   @property() heading: string;

--- a/packages/components/src/components/dialog/dialog.tsx
+++ b/packages/components/src/components/dialog/dialog.tsx
@@ -172,7 +172,8 @@ export class Dialog extends LitElement {
    */
   @property() focusTrapOptions: Partial<FocusTrapOptions>;
 
-  @property() fullScreen: boolean = false;
+  /** When `true`, the component will not allow full screen display. */
+  @property() fullScreenDisabled: boolean = false;
 
   /** Specifies the component's heading text. */
   @property() heading: string;


### PR DESCRIPTION
**Related Issue:** [#6191](https://github.com/Esri/calcite-design-system/issues/6191)

## Summary

Add `fullScreenDisabled` prop to prevent full screen layout

