### PR TITLE
fix(sheet): Improve scrolling behavior for slotted content

### DIFF
--- a/packages/components/src/components/sheet/sheet.scss
+++ b/packages/components/src/components/sheet/sheet.scss
@@ -224,6 +224,10 @@
 
 .content-container {
   @apply flex flex-1 relative max-h-full max-w-full overflow-hidden;
+
+  ::slotted(*) {
+    @apply h-auto;
+  }
 }
 
 .container--open .content {

--- a/packages/components/src/components/sheet/sheet.scss
+++ b/packages/components/src/components/sheet/sheet.scss
@@ -226,7 +226,7 @@
   @apply flex flex-1 relative max-h-full max-w-full overflow-hidden;
 
   ::slotted(*) {
-    @apply h-auto;
+    block-size: auto;
   }
 }
 


### PR DESCRIPTION
**Related Issue:** #12393 

## Summary
Ensures slotted content is set to height auto, in the provided example, the `h-full` we set on Panel's `:host` is causing problems.