### PR TITLE
fix(input-date-picker): Fix border display in RTL

### DIFF
--- a/packages/components/src/components/input-date-picker/input-date-picker.scss
+++ b/packages/components/src/components/input-date-picker/input-date-picker.scss
@@ -156,7 +156,9 @@
 }
 
 :host([layout="vertical"]) .divider-container {
-  @apply w-full h-px border-t-0 border-b-0 border-l border-r-0;
+  @apply w-full h-px border-t-0 border-b-0;
+  border-inline-start-width: var(--calcite-border-width-sm);
+  border-inline-end-width: var(--calcite-border-width-none);
   padding-inline: var(--calcite-spacing-md);
   & .divider {
     @apply w-full h-px my-0;


### PR DESCRIPTION
**Related Issue:** #13127 

## Summary
Additional fix for RTL display:

| Before    | After |
| -------- | ------- |
|  <img width="529" height="107" alt="Screenshot 2026-01-22 at 12 39 36 PM" src="https://github.com/user-attachments/assets/3b4a191a-9e66-4b07-b8ba-07976e0c188d" /> |  <img width="529" height="107" alt="Screenshot 2026-01-22 at 12 39 28 PM" src="https://github.com/user-attachments/assets/188c28ae-e629-4a0b-b2a2-cfbe0e0db63f" />  |
