### PR TITLE
fix(slider): handle falsy values to reset

### DIFF
--- a/packages/components/src/components/slider/slider.browser.e2e.tsx
+++ b/packages/components/src/components/slider/slider.browser.e2e.tsx
@@ -123,11 +123,6 @@ describe("calcite-slider", () => {
       el.value = 0;
       el.value = null;
       expect(el.value).toBe(initialValue);
-
-      el.value = 100;
-      // @ts-expect-error - intentionally using unsupported type
-      el.value = "";
-      expect(el.value).toBe(initialValue);
     });
 
     it("range", async () => {
@@ -139,11 +134,6 @@ describe("calcite-slider", () => {
 
       el.value = [20, 80];
       el.value = null;
-      expect(el.value).toEqual(initialValue);
-
-      el.value = [25, 75];
-      // @ts-expect-error - intentionally using unsupported type
-      el.value = "";
       expect(el.value).toEqual(initialValue);
     });
   });

--- a/packages/components/src/components/slider/slider.browser.e2e.tsx
+++ b/packages/components/src/components/slider/slider.browser.e2e.tsx
@@ -1,4 +1,5 @@
-import { describe } from "vitest";
+import { describe, expect, it } from "vitest";
+import { h } from "@arcgis/lumina";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import {
   defaults,
@@ -9,6 +10,7 @@ import {
   t9n,
   disabled,
 } from "../../tests/commonTests/browser";
+import { Slider } from "./slider";
 
 describe("calcite-slider", () => {
   describe("defaults", () => {
@@ -108,5 +110,49 @@ describe("calcite-slider", () => {
 
   describe("disabled", () => {
     disabled(() => mount("calcite-slider"));
+  });
+
+  describe("resetting value", () => {
+    it("single value", async () => {
+      const { el } = await mount("calcite-slider");
+      const initialValue = el.value;
+
+      // @ts-expect-error - intentionally using unsupported type
+      el.value = undefined;
+      expect(el.value).toBe(initialValue);
+
+      el.value = 0;
+
+      // @ts-expect-error - intentionally using unsupported type
+      el.value = null;
+      expect(el.value).toBe(initialValue);
+
+      el.value = 100;
+
+      // @ts-expect-error - intentionally using unsupported type
+      el.value = "";
+      expect(el.value).toBe(initialValue);
+    });
+
+    it("range", async () => {
+      const { el } = await mount<Slider>(<calcite-slider maxValue={100} minValue={0} />);
+      const initialValue = el.value;
+
+      // @ts-expect-error - intentionally using unsupported type
+      el.value = undefined;
+      expect(el.value).toEqual(initialValue);
+
+      el.value = [20, 80];
+
+      // @ts-expect-error - intentionally using unsupported type
+      el.value = null;
+      expect(el.value).toEqual(initialValue);
+
+      el.value = [25, 75];
+
+      // @ts-expect-error - intentionally using unsupported type
+      el.value = "";
+      expect(el.value).toEqual(initialValue);
+    });
   });
 });

--- a/packages/components/src/components/slider/slider.browser.e2e.tsx
+++ b/packages/components/src/components/slider/slider.browser.e2e.tsx
@@ -117,18 +117,14 @@ describe("calcite-slider", () => {
       const { el } = await mount("calcite-slider");
       const initialValue = el.value;
 
-      // @ts-expect-error - intentionally using unsupported type
       el.value = undefined;
       expect(el.value).toBe(initialValue);
 
       el.value = 0;
-
-      // @ts-expect-error - intentionally using unsupported type
       el.value = null;
       expect(el.value).toBe(initialValue);
 
       el.value = 100;
-
       // @ts-expect-error - intentionally using unsupported type
       el.value = "";
       expect(el.value).toBe(initialValue);
@@ -138,18 +134,14 @@ describe("calcite-slider", () => {
       const { el } = await mount<Slider>(<calcite-slider maxValue={100} minValue={0} />);
       const initialValue = el.value;
 
-      // @ts-expect-error - intentionally using unsupported type
       el.value = undefined;
       expect(el.value).toEqual(initialValue);
 
       el.value = [20, 80];
-
-      // @ts-expect-error - intentionally using unsupported type
       el.value = null;
       expect(el.value).toEqual(initialValue);
 
       el.value = [25, 75];
-
       // @ts-expect-error - intentionally using unsupported type
       el.value = "";
       expect(el.value).toEqual(initialValue);

--- a/packages/components/src/components/slider/slider.tsx
+++ b/packages/components/src/components/slider/slider.tsx
@@ -351,9 +351,9 @@ export class Slider extends LitElement implements LabelableComponent, FormCompon
   get value(): number | number[] {
     return this._value;
   }
-  set value(val: number | number[]) {
-    if (Array.isArray(val)) {
-      this._value = val;
+  set value(value: number | number[]) {
+    if (Array.isArray(value)) {
+      this._value = value;
       return;
     }
 
@@ -366,7 +366,7 @@ export class Slider extends LitElement implements LabelableComponent, FormCompon
       this._value = Array.isArray(this._value) ? [this.minValue, this.maxValue] : defaultValue;
       return;
     }
-    this._value = Number(val);
+    this._value = Number(value);
   }
 
   //#endregion

--- a/packages/components/src/components/slider/slider.tsx
+++ b/packages/components/src/components/slider/slider.tsx
@@ -51,6 +51,8 @@ function isRange(value: number | number[]): value is number[] {
   return Array.isArray(value);
 }
 
+const defaultValue = 0;
+
 /**
  * @slot label-content - A slot for rendering content next to the component's `labelText`.
  */
@@ -185,6 +187,8 @@ export class Slider extends LitElement implements LabelableComponent, FormCompon
   private focusSetter = useSetFocus<this>()(this);
 
   private interactiveContainer = useInteractive(this);
+
+  private _value: number | number[] = defaultValue;
 
   //#endregion
 
@@ -343,7 +347,27 @@ export class Slider extends LitElement implements LabelableComponent, FormCompon
   };
 
   /** The component's value. */
-  @property({ type: Number, reflect: true }) value: null | number | number[] = 0;
+  @property({ reflect: true })
+  get value(): number | number[] {
+    return this._value;
+  }
+  set value(val: number | number[]) {
+    if (Array.isArray(val)) {
+      this._value = val;
+      return;
+    }
+
+    if (
+      // intentional loose null check
+      value == null ||
+      // @ts-expect-error - intentionally allowing empty string
+      value === ""
+    ) {
+      this._value = Array.isArray(this._value) ? [this.minValue, this.maxValue] : defaultValue;
+      return;
+    }
+    this._value = Number(val);
+  }
 
   //#endregion
 
@@ -402,9 +426,7 @@ export class Slider extends LitElement implements LabelableComponent, FormCompon
   }
 
   load(): void {
-    if (!isRange(this.value)) {
-      this.value = this.snap ? this.getClosestStep(this.value) : this.clamp(this.value);
-    }
+    this.setInitialValue();
     afterConnectDefaultValueSet(this, this.value);
   }
 
@@ -452,6 +474,12 @@ export class Slider extends LitElement implements LabelableComponent, FormCompon
   //#endregion
 
   //#region Private Methods
+
+  private setInitialValue() {
+    if (!isRange(this.value)) {
+      this.value = this.snap ? this.getClosestStep(this.value) : this.clamp(this.value);
+    }
+  }
 
   private handleKeyDown(event: KeyboardEvent): void {
     const mirror = this.shouldMirror();

--- a/packages/components/src/components/slider/slider.tsx
+++ b/packages/components/src/components/slider/slider.tsx
@@ -357,16 +357,12 @@ export class Slider extends LitElement implements LabelableComponent, FormCompon
       return;
     }
 
-    if (
-      // intentional loose null check
-      value == null ||
-      // @ts-expect-error - intentionally allowing empty string
-      value === ""
-    ) {
-      this._value = Array.isArray(this._value) ? [this.minValue, this.maxValue] : defaultValue;
+    if (/* intentional loose null check */ value != null) {
+      this._value = Number(value);
       return;
     }
-    this._value = Number(value);
+
+    this._value = Array.isArray(this._value) ? [this.minValue, this.maxValue] : defaultValue;
   }
 
   //#endregion


### PR DESCRIPTION
**Related Issue:** #8881

## Summary

This updates the slider to handle resetting the value when set to `null` or `undefined`.

**Note**: empty string is not supported since it doesn't match the property type.