### PR TITLE
chore: release next

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33563,7 +33563,7 @@
     },
     "packages/components": {
       "name": "@esri/calcite-components",
-      "version": "5.0.0-next.77",
+      "version": "5.0.0-next.78",
       "license": "SEE LICENSE.md",
       "dependencies": {
         "@arcgis/lumina": ">=5.0.0-next.144 <6.0.0",
@@ -33594,11 +33594,11 @@
     },
     "packages/components-react": {
       "name": "@esri/calcite-components-react",
-      "version": "5.0.0-next.77",
+      "version": "5.0.0-next.78",
       "license": "SEE LICENSE.md",
       "dependencies": {
         "@arcgis/lumina": ">=5.0.0-next.144 <6.0.0",
-        "@esri/calcite-components": "5.0.0-next.77",
+        "@esri/calcite-components": "5.0.0-next.78",
         "@lit/react": "^1.0.8",
         "lit": "^3.3.0"
       },

--- a/packages/components-react/CHANGELOG.md
+++ b/packages/components-react/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [5.0.0-next.78](https://github.com/Esri/calcite-design-system/compare/@esri/calcite-components-react@5.0.0-next.77...@esri/calcite-components-react@5.0.0-next.78) (2026-01-22)
+
+**Note:** Version bump only for package @esri/calcite-components-react
+
 ## [5.0.0-next.77](https://github.com/Esri/calcite-design-system/compare/@esri/calcite-components-react@5.0.0-next.76...@esri/calcite-components-react@5.0.0-next.77) (2026-01-22)
 
 **Note:** Version bump only for package @esri/calcite-components-react

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/calcite-components-react",
-  "version": "5.0.0-next.77",
+  "version": "5.0.0-next.78",
   "description": "A set of React components that wrap calcite components",
   "homepage": "https://developers.arcgis.com/calcite-design-system/",
   "repository": {
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@arcgis/lumina": ">=5.0.0-next.144 <6.0.0",
-    "@esri/calcite-components": "5.0.0-next.77",
+    "@esri/calcite-components": "5.0.0-next.78",
     "@lit/react": "^1.0.8",
     "lit": "^3.3.0"
   },

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [5.0.0-next.78](https://github.com/Esri/calcite-design-system/compare/@esri/calcite-components@5.0.0-next.77...@esri/calcite-components@5.0.0-next.78) (2026-01-22)
+
+### Bug Fixes
+
+- **input-date-picker:** Fix border display in RTL ([#13755](https://github.com/Esri/calcite-design-system/issues/13755)) ([f157845](https://github.com/Esri/calcite-design-system/commit/99f0a0f1e8d9edb270064c6d3aef47fefe8dd34c)), closes [#13127](https://github.com/Esri/calcite-design-system/issues/13127)
+
 ## [5.0.0-next.77](https://github.com/Esri/calcite-design-system/compare/@esri/calcite-components@5.0.0-next.76...@esri/calcite-components@5.0.0-next.77) (2026-01-22)
 
 ### Bug Fixes

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/calcite-components",
-  "version": "5.0.0-next.77",
+  "version": "5.0.0-next.78",
   "description": "Web Components for Esri's Calcite Design System.",
   "homepage": "https://developers.arcgis.com/calcite-design-system/",
   "repository": {


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Our [deploy prerelease action](https://github.com/Esri/calcite-design-system/blob/dev/.github/workflows/deploy-prerelease.yml) ran into an issue where  both `@esri/calcite-components@5.0.0-next.78` and `@esri/calcite-components-react@5.0.0-next.78`, were published to NPM, but associated tags were disconnected from `dev`. 

Not sure if this was a rare timing issue caused by having two PRs land at specific intervals ([example](https://github.com/Esri/calcite-design-system/compare/f157845~...29f61a1)) and/or by [recent](https://github.com/Esri/calcite-design-system/pull/13279/changes) [changes](https://github.com/Esri/calcite-design-system/pull/13308/changes) to `publishPrerelease.sh`. 

We'll have to investigate and keep an eye out for this. Here are the related action runs:

https://github.com/Esri/calcite-design-system/actions/runs/21265940839
https://github.com/Esri/calcite-design-system/actions/runs/21265309514