### PR TITLE
docs(action): make the aria property public

### DIFF
--- a/packages/components/src/components/action/action.tsx
+++ b/packages/components/src/components/action/action.tsx
@@ -76,7 +76,7 @@ export class Action extends LitElement implements FormOwner {
   //#region Public Properties
 
   /**
-   * When specified, overrides or extends ARIA properties and attributes on the component's button.
+   * When specified, overrides or extends ARIA properties and attributes on the component's button. Refer to the component's accessibility section for configuration considerations.
    */
   @property() aria?: Partial<
     Pick<

--- a/packages/components/src/components/action/action.tsx
+++ b/packages/components/src/components/action/action.tsx
@@ -76,9 +76,7 @@ export class Action extends LitElement implements FormOwner {
   //#region Public Properties
 
   /**
-   * Use this property to override or extend ARIA properties and attributes on the component's button.
-   *
-   * @internal
+   * When specified, overrides or extends ARIA properties and attributes on the component's button.
    */
   @property() aria?: Partial<
     Pick<


### PR DESCRIPTION
**Related Issue:** #10706 

## Summary
Updates `action`'s `aria` property to be publicized. _Note: will be adding additional context to setup to the component's "Accessibility" section (on the doc site) soon._

cc @isaacbraun - used the doc local build for a doc preview ✨🏆✨  

<img width="991" height="160" alt="image" src="https://github.com/user-attachments/assets/92450e43-2a4d-40ca-a47c-5c0c243742b3" />




