### PR TITLE
ci(actions): handle corrupted or missing monday sync ID in issue body

### DIFF
--- a/.github/scripts/monday/createTask.js
+++ b/.github/scripts/monday/createTask.js
@@ -1,5 +1,6 @@
 // @ts-check
 const Monday = require("../support/monday");
+const { createUpdateBodyCallback } = require("../support/utils");
 
 /** @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments */
 module.exports = async ({ github, context, core }) => {
@@ -7,22 +8,6 @@ module.exports = async ({ github, context, core }) => {
     /** @type {import('@octokit/webhooks-types').IssuesOpenedEvent | import('@octokit/webhooks-types').IssuesLabeledEvent}*/ (
       context.payload
     );
-  const monday = Monday(issue, core);
-  const { id, source } = await monday.getId();
-  const createdId = await monday.createTask(id);
-
-  if (createdId && source !== "body") {
-    const updatedBody = monday.addSyncLine(createdId);
-    try {
-      await github.rest.issues.update({
-        owner: context.repo.owner,
-        repo: context.repo.repo,
-        issue_number: issue.number,
-        body: updatedBody,
-      });
-    } catch (error) {
-      core.setFailed(`Error adding ID to body: ${error}`);
-      return;
-    }
-  }
+  const monday = Monday(issue, core, createUpdateBodyCallback({ github, context, core }));
+  await monday.createTask();
 };

--- a/.github/scripts/monday/createTask.js
+++ b/.github/scripts/monday/createTask.js
@@ -1,6 +1,6 @@
 // @ts-check
 const Monday = require("../support/monday");
-const { createUpdateBodyCallback } = require("../support/utils");
+const { createBodyUpdater } = require("../support/utils");
 
 /** @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments */
 module.exports = async ({ github, context, core }) => {
@@ -8,6 +8,6 @@ module.exports = async ({ github, context, core }) => {
     /** @type {import('@octokit/webhooks-types').IssuesOpenedEvent | import('@octokit/webhooks-types').IssuesLabeledEvent}*/ (
       context.payload
     );
-  const monday = Monday(issue, core, createUpdateBodyCallback({ github, context, core }));
+  const monday = Monday(issue, core, createBodyUpdater({ github, context, core }));
   await monday.createTask();
 };

--- a/.github/scripts/monday/removeLabel.js
+++ b/.github/scripts/monday/removeLabel.js
@@ -1,6 +1,6 @@
 // @ts-check
 const Monday = require("../support/monday");
-const { assertRequired, includesLabel, createUpdateBodyCallback } = require("../support/utils");
+const { assertRequired, includesLabel, createBodyUpdater } = require("../support/utils");
 const {
   labels: {
     planning: { spike, spikeComplete },
@@ -28,7 +28,7 @@ module.exports = async ({ github, context, core }) => {
     return;
   }
 
-  const monday = Monday(issue, core, createUpdateBodyCallback({ github, context, core }));
+  const monday = Monday(issue, core, createBodyUpdater({ github, context, core }));
   monday.setAssignedStatus();
   monday.clearLabel(labelName, labelColor);
   await monday.commit();

--- a/.github/scripts/monday/removeLabel.js
+++ b/.github/scripts/monday/removeLabel.js
@@ -1,6 +1,6 @@
 // @ts-check
 const Monday = require("../support/monday");
-const { assertRequired, includesLabel } = require("../support/utils");
+const { assertRequired, includesLabel, createUpdateBodyCallback } = require("../support/utils");
 const {
   labels: {
     planning: { spike, spikeComplete },
@@ -10,7 +10,7 @@ const {
 } = require("../support/resources");
 
 /** @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments */
-module.exports = async ({ context, core }) => {
+module.exports = async ({ github, context, core }) => {
   const { issue, label } = /** @type {import('@octokit/webhooks-types').IssuesUnlabeledEvent} */ (context.payload);
   const { labels: issueLabels } = issue;
   const [labelName, labelColor] = assertRequired([label?.name, label?.color], core, "No label found in payload.");
@@ -28,7 +28,7 @@ module.exports = async ({ context, core }) => {
     return;
   }
 
-  const monday = Monday(issue, core);
+  const monday = Monday(issue, core, createUpdateBodyCallback({ github, context, core }));
   monday.setAssignedStatus();
   monday.clearLabel(labelName, labelColor);
   await monday.commit();

--- a/.github/scripts/monday/syncActionChanges.js
+++ b/.github/scripts/monday/syncActionChanges.js
@@ -1,6 +1,6 @@
 // @ts-check
 const Monday = require("../support/monday");
-const { assertRequired, createUpdateBodyCallback } = require("../support/utils");
+const { assertRequired, createBodyUpdater } = require("../support/utils");
 
 /**
  * @typedef {object} SyncActionChangesInputs
@@ -40,7 +40,7 @@ module.exports = async ({ github, context, core }) => {
     issue_number,
   });
 
-  const monday = Monday(issue, core, createUpdateBodyCallback({ github, context, core }));
+  const monday = Monday(issue, core, createBodyUpdater({ github, context, core }));
 
   if (milestone_updated === "true") {
     monday.handleMilestone();

--- a/.github/scripts/monday/syncActionChanges.js
+++ b/.github/scripts/monday/syncActionChanges.js
@@ -1,6 +1,6 @@
 // @ts-check
 const Monday = require("../support/monday");
-const { assertRequired } = require("../support/utils");
+const { assertRequired, createUpdateBodyCallback } = require("../support/utils");
 
 /**
  * @typedef {object} SyncActionChangesInputs
@@ -40,7 +40,7 @@ module.exports = async ({ github, context, core }) => {
     issue_number,
   });
 
-  const monday = Monday(issue, core);
+  const monday = Monday(issue, core, createUpdateBodyCallback({ github, context, core }));
 
   if (milestone_updated === "true") {
     monday.handleMilestone();

--- a/.github/scripts/monday/updateAssignee.js
+++ b/.github/scripts/monday/updateAssignee.js
@@ -1,13 +1,14 @@
 // @ts-check
 const Monday = require("../support/monday");
+const { createUpdateBodyCallback } = require("../support/utils");
 
 /** @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments */
-module.exports = async ({ context, core }) => {
+module.exports = async ({ github, context, core }) => {
   const { issue } =
     /** @type {import('@octokit/webhooks-types').IssuesAssignedEvent | import('@octokit/webhooks-types').IssuesUnassignedEvent } */ (
       context.payload
     );
-  const monday = Monday(issue, core);
+  const monday = Monday(issue, core, createUpdateBodyCallback({ github, context, core }));
   monday.setAssignedStatus();
   monday.handleAssignees();
   await monday.commit();

--- a/.github/scripts/monday/updateAssignee.js
+++ b/.github/scripts/monday/updateAssignee.js
@@ -1,6 +1,6 @@
 // @ts-check
 const Monday = require("../support/monday");
-const { createUpdateBodyCallback } = require("../support/utils");
+const { createBodyUpdater } = require("../support/utils");
 
 /** @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments */
 module.exports = async ({ github, context, core }) => {
@@ -8,7 +8,7 @@ module.exports = async ({ github, context, core }) => {
     /** @type {import('@octokit/webhooks-types').IssuesAssignedEvent | import('@octokit/webhooks-types').IssuesUnassignedEvent } */ (
       context.payload
     );
-  const monday = Monday(issue, core, createUpdateBodyCallback({ github, context, core }));
+  const monday = Monday(issue, core, createBodyUpdater({ github, context, core }));
   monday.setAssignedStatus();
   monday.handleAssignees();
   await monday.commit();

--- a/.github/scripts/monday/updateLabels.js
+++ b/.github/scripts/monday/updateLabels.js
@@ -1,6 +1,6 @@
 // @ts-check
 const Monday = require("../support/monday");
-const { assertRequired, createUpdateBodyCallback } = require("../support/utils");
+const { assertRequired, createBodyUpdater } = require("../support/utils");
 
 /** @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments */
 module.exports = async ({ github, context, core }) => {
@@ -9,7 +9,7 @@ module.exports = async ({ github, context, core }) => {
   );
   const [label] = assertRequired([labelPayload], core, "No label found in payload.");
 
-  const monday = Monday(issue, core, createUpdateBodyCallback({ github, context, core }));
+  const monday = Monday(issue, core, createBodyUpdater({ github, context, core }));
   monday.addLabel(label.name, label.color);
   await monday.commit();
 };

--- a/.github/scripts/monday/updateLabels.js
+++ b/.github/scripts/monday/updateLabels.js
@@ -1,15 +1,15 @@
 // @ts-check
 const Monday = require("../support/monday");
-const { assertRequired } = require("../support/utils");
+const { assertRequired, createUpdateBodyCallback } = require("../support/utils");
 
 /** @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments */
-module.exports = async ({ context, core }) => {
+module.exports = async ({ github, context, core }) => {
   const { issue, label: labelPayload } = /** @type {import('@octokit/webhooks-types').IssuesLabeledEvent} */ (
     context.payload
   );
   const [label] = assertRequired([labelPayload], core, "No label found in payload.");
 
-  const monday = Monday(issue, core);
+  const monday = Monday(issue, core, createUpdateBodyCallback({ github, context, core }));
   monday.addLabel(label.name, label.color);
   await monday.commit();
 };

--- a/.github/scripts/monday/updateMilestone.js
+++ b/.github/scripts/monday/updateMilestone.js
@@ -1,10 +1,11 @@
 // @ts-check
 const Monday = require("../support/monday");
+const { createUpdateBodyCallback } = require("../support/utils");
 
 /** @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments */
-module.exports = async ({ context, core }) => {
+module.exports = async ({ github, context, core }) => {
   const { issue } = /** @type {import('@octokit/webhooks-types').IssuesMilestonedEvent} */ (context.payload);
-  const monday = Monday(issue, core);
+  const monday = Monday(issue, core, createUpdateBodyCallback({ github, context, core }));
   monday.handleMilestone();
   await monday.commit();
 };

--- a/.github/scripts/monday/updateMilestone.js
+++ b/.github/scripts/monday/updateMilestone.js
@@ -1,11 +1,11 @@
 // @ts-check
 const Monday = require("../support/monday");
-const { createUpdateBodyCallback } = require("../support/utils");
+const { createBodyUpdater } = require("../support/utils");
 
 /** @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments */
 module.exports = async ({ github, context, core }) => {
   const { issue } = /** @type {import('@octokit/webhooks-types').IssuesMilestonedEvent} */ (context.payload);
-  const monday = Monday(issue, core, createUpdateBodyCallback({ github, context, core }));
+  const monday = Monday(issue, core, createBodyUpdater({ github, context, core }));
   monday.handleMilestone();
   await monday.commit();
 };

--- a/.github/scripts/monday/updateState.js
+++ b/.github/scripts/monday/updateState.js
@@ -1,6 +1,6 @@
 // @ts-check
 const Monday = require("../support/monday");
-const { createUpdateBodyCallback } = require("../support/utils");
+const { createBodyUpdater } = require("../support/utils");
 
 /** @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments */
 module.exports = async ({ github, context, core }) => {
@@ -8,7 +8,7 @@ module.exports = async ({ github, context, core }) => {
     /** @type {import('@octokit/webhooks-types').IssuesClosedEvent | import('@octokit/webhooks-types').IssuesReopenedEvent}*/ (
       context.payload
     );
-  const monday = Monday(issue, core, createUpdateBodyCallback({ github, context, core }));
+  const monday = Monday(issue, core, createBodyUpdater({ github, context, core }));
   monday.handleState(action);
   await monday.commit();
 };

--- a/.github/scripts/monday/updateState.js
+++ b/.github/scripts/monday/updateState.js
@@ -1,13 +1,14 @@
 // @ts-check
 const Monday = require("../support/monday");
+const { createUpdateBodyCallback } = require("../support/utils");
 
 /** @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments */
-module.exports = async ({ context, core }) => {
+module.exports = async ({ github, context, core }) => {
   const { issue, action } =
     /** @type {import('@octokit/webhooks-types').IssuesClosedEvent | import('@octokit/webhooks-types').IssuesReopenedEvent}*/ (
       context.payload
     );
-  const monday = Monday(issue, core);
+  const monday = Monday(issue, core, createUpdateBodyCallback({ github, context, core }));
   monday.handleState(action);
   await monday.commit();
 };

--- a/.github/scripts/monday/updateTitle.js
+++ b/.github/scripts/monday/updateTitle.js
@@ -1,16 +1,16 @@
 // @ts-check
 const Monday = require("../support/monday");
-const { assertRequired } = require("../support/utils");
+const { assertRequired, createUpdateBodyCallback } = require("../support/utils");
 
 /** @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments */
-module.exports = async ({ context, core }) => {
+module.exports = async ({ github, context, core }) => {
   const { issue, changes } =
     /** @type {import('@octokit/webhooks-types').IssuesEditedEvent} */ (
       context.payload
     );
   assertRequired([changes?.title?.from], core, "Title unedited: no previous title found in payload.");
 
-  const monday = Monday(issue, core);
+  const monday = Monday(issue, core, createUpdateBodyCallback({ github, context, core }));
   monday.setColumnValue(monday.mondayColumns.title, issue.title, {
     title: "Update Title",
   });

--- a/.github/scripts/monday/updateTitle.js
+++ b/.github/scripts/monday/updateTitle.js
@@ -1,6 +1,6 @@
 // @ts-check
 const Monday = require("../support/monday");
-const { assertRequired, createUpdateBodyCallback } = require("../support/utils");
+const { assertRequired, createBodyUpdater } = require("../support/utils");
 
 /** @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments */
 module.exports = async ({ github, context, core }) => {
@@ -10,7 +10,7 @@ module.exports = async ({ github, context, core }) => {
     );
   assertRequired([changes?.title?.from], core, "Title unedited: no previous title found in payload.");
 
-  const monday = Monday(issue, core, createUpdateBodyCallback({ github, context, core }));
+  const monday = Monday(issue, core, createBodyUpdater({ github, context, core }));
   monday.setColumnValue(monday.mondayColumns.title, issue.title, {
     title: "Update Title",
   });

--- a/.github/scripts/support/monday.js
+++ b/.github/scripts/support/monday.js
@@ -9,7 +9,7 @@ const {
     designEstimate,
     planning,
     handoff,
-    productColor
+    productColor,
   },
   milestone,
   packages,
@@ -30,9 +30,10 @@ function assertMondayEnv(env, core) {
 
 /**
  * @param {import('@octokit/webhooks-types').Issue} issue - The GitHub issue object
- * @param {import('@actions/core')} core
+ * @param {import('@actions/core')} core - The core library for logging and reporting workflow status
+ * @param {import('./utils').UpdateBodyCallback} updateIssueBody - A callback to update the Issue body with correct context
  */
-module.exports = function Monday(issue, core) {
+module.exports = function Monday(issue, core, updateIssueBody) {
   assertMondayEnv(process.env, core);
   const { MONDAY_KEY, MONDAY_BOARD } = process.env;
   if (!issue) {
@@ -238,7 +239,7 @@ module.exports = function Monday(issue, core) {
         column: mondayColumns.typeDropdown,
         value: "i18n-l10n",
         clearable: true,
-      }
+      },
     ],
     [
       issueType.newComponent,
@@ -526,19 +527,20 @@ module.exports = function Monday(issue, core) {
       }
       return { response: await response.json(), error: null };
     } catch (error) {
-      return { response: null, error: error?.message || String(error) };
+      const message = error instanceof Error ? error.message : String(error);
+      return { response: null, error: message };
     }
   }
 
   /**
    * Creates and runs a query to update columns in a Monday.com item
    * @private
-   * @param {string} id - The ID of the Monday.com item to update
+   * @param {string} syncId - The ID of the Monday.com item to update
    * @returns {Promise<{ error: null | { message: string, expected?: boolean } }>}
    */
-  async function updateMultipleColumns(id = "") {
-    const mondayId = id || (await getId())?.id;
-    if (!mondayId) {
+  async function updateMultipleColumns(syncId = "") {
+    const id = syncId || (await getId())?.id;
+    if (!id) {
       return {
         error: {
           expected: true,
@@ -561,17 +563,32 @@ module.exports = function Monday(issue, core) {
     /** @type {QueryVariables} */
     const queryVariables = {
       board_id: MONDAY_BOARD,
-      item_id: mondayId,
+      item_id: id,
       column_values: JSON.stringify(columnUpdates),
     };
 
+    /** @type {(error: string | null) => { error: { message: string } }} */
+    const errorMessage = (error) => ({
+      error: {
+        message: `Failed to update columns for item ID ${id}. ${error || ""}`,
+      },
+    });
+
     const { response, error } = await runQuery(query, queryVariables);
     if (error || !response?.data?.change_multiple_column_values) {
-      return {
-        error: {
-          message: `Failed to update columns for item ID ${mondayId}. ${error || ""}`,
-        },
-      };
+      // Retry once with queried ID
+      const queriedId = await queryForId();
+      if (!queriedId || queriedId === id) {
+        return errorMessage(error);
+      }
+
+      queryVariables.item_id = queriedId;
+      const { response: retryResponse, error: retryError } = await runQuery(query, queryVariables);
+      if (retryError || !retryResponse?.data?.change_multiple_column_values) {
+        return errorMessage(retryError);
+      }
+
+      await updateBodyWithId(queriedId);
     }
     return { error: null };
   }
@@ -625,6 +642,7 @@ module.exports = function Monday(issue, core) {
     }
 
     const [{ id }] = items;
+    await updateBodyWithId(id);
     core.info(`Found existing Monday task for Issue #${issueNumber}: ${id}.`);
     return id;
   }
@@ -727,8 +745,8 @@ module.exports = function Monday(issue, core) {
   /** Public functions */
 
   /**
-   * Find the Monday.com item ID for a issue and its source
-   * ID is parsed from the issue body or fetched based on the issue number
+   * Find the Monday.com item ID for a issue and its source.
+   * The ID is parsed from the issue body or queried from the Monday.com API based on the issue number.
    * @return {Promise<{ id: string | undefined, source: ("body" | "query")}>} - The Monday.com item ID
    */
   async function getId() {
@@ -763,11 +781,10 @@ module.exports = function Monday(issue, core) {
   }
 
   /**
-   * Create a new task in Monday.com, or update an existing one if syncId is provided
-   * @param {string} syncId - When provided, updates item in Monday instead of creating new
-   * @returns {Promise<string | undefined>} - The ID of the created Monday.com item
+   * Create a new item in Monday.com, or update an existing one if found
+   * @returns {Promise<void>}
    */
-  async function createTask(syncId = "") {
+  async function createTask() {
     const logParams = { title: "Create Task" };
     columnUpdates = {
       [mondayColumns.issueNumber.id]: `${issueNumber}`,
@@ -794,6 +811,7 @@ module.exports = function Monday(issue, core) {
       handleMilestone();
     }
 
+    const { id: syncId } = await getId();
     if (syncId) {
       core.notice(
         `Sync ID "${syncId}" provided, updating existing item instead of creating new.`,
@@ -813,10 +831,9 @@ module.exports = function Monday(issue, core) {
         } else {
           core.setFailed(`Error syncing item ${syncId}: ${error.message}`);
         }
-        return;
       }
 
-      return syncId;
+      return;
     }
 
     const query = `mutation CreateItem($board_id: ID!, $item_name: String!, $column_values: JSON!) {
@@ -837,13 +854,13 @@ module.exports = function Monday(issue, core) {
     };
 
     const { response, error } = await runQuery(query, queryVariables);
-    const id = response?.data?.create_item?.id;
-    if (error || !id) {
+    const createdId = response?.data?.create_item?.id;
+    if (error || !createdId) {
       core.setFailed(error || `Failed creating item for issue #${issueNumber}`);
       return;
     }
 
-    return id;
+    await updateBodyWithId(createdId);
   }
 
   /**
@@ -1024,16 +1041,15 @@ module.exports = function Monday(issue, core) {
   /**
    * Inserts or replaces the Monday sync line in the issue body string
    * @param {string} mondayID - The Monday.com item ID
-   * @returns {string} - The updated issue body
    */
-  function addSyncLine(mondayID) {
+  async function updateBodyWithId(mondayID) {
     const syncMarkdown = `**monday.com sync:** #${mondayID}\n\n`;
-    const syncLineRegex = /^\*\*monday\.com sync:\*\* #\d+\n\n?/m;
-    if (body && syncLineRegex.test(body)) {
-      return body.replace(syncLineRegex, syncMarkdown);
-    } else {
-      return syncMarkdown + (body || "");
-    }
+    const syncLineRegex = /^\*\*monday\.com sync:\*\* ?#?\d*\n?\n?/m;
+    const updatedBody =
+      body && syncLineRegex.test(body)
+        ? body.replace(syncLineRegex, syncMarkdown)
+        : syncMarkdown + (body || "");
+    await updateIssueBody(issueNumber, updatedBody);
   }
 
   /**
@@ -1076,7 +1092,6 @@ module.exports = function Monday(issue, core) {
 
   return {
     mondayColumns,
-    getId,
     commit,
     createTask,
     setColumnValue,
@@ -1086,7 +1101,6 @@ module.exports = function Monday(issue, core) {
     handleAssignees,
     addLabel,
     clearLabel,
-    addSyncLine,
     inMilestoneStatus,
   };
 };

--- a/.github/scripts/support/monday.js
+++ b/.github/scripts/support/monday.js
@@ -567,25 +567,39 @@ module.exports = function Monday(issue, core, updateIssueBody) {
       column_values: JSON.stringify(columnUpdates),
     };
 
-    /** @type {(error: string | null) => { error: { message: string } }} */
-    const errorMessage = (error) => ({
-      error: {
-        message: `Failed to update columns for item ID ${id}. ${error || ""}`,
-      },
-    });
+    /**
+     * @param {string} message - Required custom error message
+     * @param {Array<string | null>} detailsArray - Optional array of detailed error messages
+     * @returns {{ error : { message: string } }}
+     */
+    const buildErrorMessage = (message, detailsArray) => {
+      return {
+        error: {
+          message: `Failed to update columns for ID ${id}. ${message}. ${detailsArray.filter(Boolean).join(" ")}`,
+        },
+      };
+    };
 
     const { response, error } = await runQuery(query, queryVariables);
     if (error || !response?.data?.change_multiple_column_values) {
-      // Retry once with queried ID
       const queriedId = await queryForId();
       if (!queriedId || queriedId === id) {
-        return errorMessage(error);
+        const skippedMessage = queriedId
+          ? `Retry skipped because the queried ID (${queriedId}) matches the current item ID`
+          : `Retry skipped because no alternate item ID was found`;
+        return buildErrorMessage(skippedMessage, [error]);
       }
 
       queryVariables.item_id = queriedId;
-      const { response: retryResponse, error: retryError } = await runQuery(query, queryVariables);
+      const { response: retryResponse, error: retryError } = await runQuery(
+        query,
+        queryVariables,
+      );
       if (retryError || !retryResponse?.data?.change_multiple_column_values) {
-        return errorMessage(retryError);
+        return buildErrorMessage(`Retry failed for queried ID ${queriedId}`, [
+          retryError,
+          error,
+        ]);
       }
 
       await updateBodyWithId(queriedId);

--- a/.github/scripts/support/monday.js
+++ b/.github/scripts/support/monday.js
@@ -533,20 +533,47 @@ module.exports = function Monday(issue, core, updateIssueBody) {
   }
 
   /**
+   * @typedef {object} UpdateError
+   * @property {boolean} expected
+   * @property {string} [message]
+   */
+  /**
+   * @typedef {object} UpdateResponse
+   * @property {UpdateError | null} error
+   */
+  /**
+   * Builds an error object for multiple column update returns
+   * @private
+   * @param {object} params
+   * @param {boolean} [params.expected] - Whether the error is expected or not
+   * @param {Array<string | null>} params.messages - Array of error messages to be joined
+   * @returns {UpdateResponse}
+   */
+  function buildUpdateError({ messages, expected }) {
+    /** @type {UpdateError} */
+    const updateError = { expected: !!expected };
+
+    const filteredMessages = messages.filter(Boolean);
+    if (filteredMessages.length) {
+      updateError.message = filteredMessages.join(" ");
+    }
+
+    return { error: updateError };
+  }
+
+  /**
    * Creates and runs a query to update columns in a Monday.com item
    * @private
    * @param {string} syncId - The ID of the Monday.com item to update
-   * @returns {Promise<{ error: null | { message: string, expected?: boolean } }>}
+   * @returns {Promise<UpdateResponse>}
    */
   async function updateMultipleColumns(syncId = "") {
     const id = syncId || (await getId())?.id;
     if (!id) {
-      return {
-        error: {
-          expected: true,
-          message: "Monday Task not found, cannot update columns.",
-        },
-      };
+      return buildUpdateError({
+        expected: true,
+        messages: ["Monday Task ID not found, cannot update columns."],
+      });
     }
 
     const query = `mutation ChangeMultipleColumnValues($board_id: ID!, $item_id: ID!, $column_values: JSON!) {
@@ -567,27 +594,17 @@ module.exports = function Monday(issue, core, updateIssueBody) {
       column_values: JSON.stringify(columnUpdates),
     };
 
-    /**
-     * @param {string} message - Required custom error message
-     * @param {Array<string | null>} detailsArray - Optional array of detailed error messages
-     * @returns {{ error : { message: string } }}
-     */
-    const buildErrorMessage = (message, detailsArray) => {
-      return {
-        error: {
-          message: `Failed to update columns for ID ${id}. ${message}. ${detailsArray.filter(Boolean).join(" ")}`,
-        },
-      };
-    };
-
     const { response, error } = await runQuery(query, queryVariables);
     if (error || !response?.data?.change_multiple_column_values) {
+      const baseMessage = `Failed to update columns for ID ${id}.`;
       const queriedId = await queryForId();
       if (!queriedId || queriedId === id) {
         const skippedMessage = queriedId
-          ? `Retry skipped because the queried ID (${queriedId}) matches the current item ID`
-          : `Retry skipped because no alternate item ID was found`;
-        return buildErrorMessage(skippedMessage, [error]);
+          ? `Retry skipped because the queried ID (${queriedId}) matches the current item ID.`
+          : `Retry skipped because no alternate item ID was found.`;
+        return buildUpdateError({
+          messages: [baseMessage, skippedMessage, error],
+        });
       }
 
       queryVariables.item_id = queriedId;
@@ -596,10 +613,14 @@ module.exports = function Monday(issue, core, updateIssueBody) {
         queryVariables,
       );
       if (retryError || !retryResponse?.data?.change_multiple_column_values) {
-        return buildErrorMessage(`Retry failed for queried ID ${queriedId}`, [
-          retryError,
-          error,
-        ]);
+        return buildUpdateError({
+          messages: [
+            baseMessage,
+            `Retry failed for queried ID ${queriedId}.`,
+            `Original error: ${error}.`,
+            `Retry error: ${retryError}.`,
+          ],
+        });
       }
 
       await updateBodyWithId(queriedId);

--- a/.github/scripts/support/utils.js
+++ b/.github/scripts/support/utils.js
@@ -3,6 +3,8 @@ const {
   labels: { issueWorkflow },
 } = require("./resources");
 
+/** @typedef {(issueNumber: number, updatedBody: string) => Promise<void>} UpdateBodyCallback */
+
 module.exports = {
   /**
    * @typedef {object} removeLabelParam
@@ -105,4 +107,24 @@ module.exports = {
 
     return /** @type {{ [K in keyof T]: NonNullable<T[K]> }} */ (array);
   },
+  /**
+   * Creates a callback to update the body of an issue
+   * @param {Pick<import('github-script').AsyncFunctionArguments, "github" | "context" | "core">} params
+   * @returns {UpdateBodyCallback}
+   */
+  createUpdateBodyCallback: ({ github, context, core }) => {
+    return async (issueNumber, updatedBody) => {
+      try {
+        await github.rest.issues.update({
+          owner: context.repo.owner,
+          repo: context.repo.repo,
+          issue_number: issueNumber,
+          body: updatedBody,
+        });
+      } catch (error) {
+        core.setFailed(`Error updating issue body: ${error}`);
+        return;
+      }
+    };
+  }
 };

--- a/.github/scripts/support/utils.js
+++ b/.github/scripts/support/utils.js
@@ -112,7 +112,7 @@ module.exports = {
    * @param {Pick<import('github-script').AsyncFunctionArguments, "github" | "context" | "core">} params
    * @returns {UpdateBodyCallback}
    */
-  createUpdateBodyCallback: ({ github, context, core }) => {
+  createBodyUpdater: ({ github, context, core }) => {
     return async (issueNumber, updatedBody) => {
       try {
         await github.rest.issues.update({

--- a/.github/workflows/issue-monday-sync.yml
+++ b/.github/workflows/issue-monday-sync.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           script: |
             const action = require('${{ github.workspace }}/.github/scripts/monday/updateLabels.js')
-            await action({context, core})
+            await action({github, context, core})
 
       - name: "Remove Label from Task"
         if: github.event.action == 'unlabeled'
@@ -77,7 +77,7 @@ jobs:
         with:
           script: |
             const action = require('${{ github.workspace }}/.github/scripts/monday/removeLabel.js')
-            await action({context, core})
+            await action({github, context, core})
 
       - name: "Update Milestone"
         if: github.event.action == 'milestoned' || github.event.action == 'demilestoned'
@@ -85,7 +85,7 @@ jobs:
         with:
           script: |
             const action = require('${{ github.workspace }}/.github/scripts/monday/updateMilestone.js')
-            await action({context, core})
+            await action({github, context, core})
 
       - name: "Update Task Title"
         if: github.event.action == 'edited'
@@ -93,7 +93,7 @@ jobs:
         with:
           script: |
             const action = require('${{ github.workspace }}/.github/scripts/monday/updateTitle.js')
-            await action({context, core})
+            await action({github, context, core})
 
       - name: "Update Task Assignee"
         if: github.event.action == 'assigned' || github.event.action == 'unassigned'
@@ -101,7 +101,7 @@ jobs:
         with:
           script: |
             const action = require('${{ github.workspace }}/.github/scripts/monday/updateAssignee.js')
-            await action({context, core})
+            await action({github, context, core})
 
       - name: "Update Task Status"
         if: github.event.action == 'closed' || github.event.action == 'reopened'
@@ -109,7 +109,7 @@ jobs:
         with:
           script: |
             const action = require('${{ github.workspace }}/.github/scripts/monday/updateState.js')
-            await action({context, core})
+            await action({github, context, core})
 
       - name: "Sync Action Changes"
         if: github.event.inputs.event_type == 'SyncActionChanges'


### PR DESCRIPTION
**Related Issue:** #12932

## Summary
Adds support for handling missing or corrupted Monday Sync IDs in issue bodies for issues that have a Monday.com counterpart task. Instead of erroring due to an improper ID found from the body, it will query Monday.com for the ID and retry the sync API call.

In any scenario where an ID is found by querying Monday.com, the issue body will be updated with the correct sync ID.

This requires the `github` object to be passed to all Monday scripts in order to create a callback that can update the issue body.
