### PR TITLE
fix(block-section): fix inconsistent interaction states

### DIFF
--- a/packages/components/src/components/block-section/block-section.e2e.ts
+++ b/packages/components/src/components/block-section/block-section.e2e.ts
@@ -253,16 +253,6 @@ describe("calcite-block-section", () => {
               targetProp: "color",
               state: "hover",
             },
-            {
-              shadowSelector: `.${CSS.iconStart}`,
-              targetProp: "color",
-              state: "hover",
-            },
-            {
-              shadowSelector: `.${CSS.iconEnd}`,
-              targetProp: "color",
-              state: "hover",
-            },
           ],
           "--calcite-block-section-content-space": {
             shadowSelector: `.${CSS.content}`,

--- a/packages/components/src/components/block-section/block-section.scss
+++ b/packages/components/src/components/block-section/block-section.scss
@@ -42,11 +42,23 @@ calcite-switch {
     }
   }
 
+  .icon--end,
+  .icon--start {
+    color: var(--calcite-block-section-text-color, var(--calcite-color-text-1));
+  }
+
   .chevron-icon {
     color: var(--calcite-block-section-text-color, var(--calcite-color-text-3));
 
     &:hover {
       color: var(--calcite-block-section-text-color-hover, var(--calcite-color-text-1));
+    }
+  }
+  .toggle-container {
+    &:hover {
+      calcite-switch {
+        --calcite-switch-background-color: var(--calcite-color-brand-hover);
+      }
     }
   }
 }
@@ -137,9 +149,15 @@ calcite-switch {
     @apply flex items-center;
 
     color: var(--calcite-block-section-text-color, var(--calcite-color-text-3));
+  }
 
-    &:hover {
+  &:hover {
+    .chevron-icon {
       color: var(--calcite-block-section-text-color-hover, var(--calcite-color-text-1));
+    }
+
+    calcite-switch {
+      --calcite-switch-background-color: var(--calcite-color-text-3);
     }
   }
 }

--- a/packages/components/src/components/block-section/block-section.tsx
+++ b/packages/components/src/components/block-section/block-section.tsx
@@ -257,6 +257,7 @@ export class BlockSection extends LitElement {
             <calcite-switch
               checked={expanded}
               class={CSS.switch}
+              inert
               label={toggleLabel}
               scale={this.scale}
             />

--- a/packages/components/src/components/block-section/block-section.tsx
+++ b/packages/components/src/components/block-section/block-section.tsx
@@ -257,7 +257,6 @@ export class BlockSection extends LitElement {
             <calcite-switch
               checked={expanded}
               class={CSS.switch}
-              inert
               label={toggleLabel}
               scale={this.scale}
             />


### PR DESCRIPTION
**Related Issue:** [#12658](https://github.com/Esri/calcite-design-system/issues/12658)

## Summary

- `icon-end` | `start` should not change color on `hover` or `press`.
- The chevron toggle icon should change to `--calcite-color-text-1` on `hover` and the target should be the parent toggle container.
- `icon-end | start` should be `--calcite-color-text-1` when expanded.

When `toggle-display="switch"`:

- State styling of `calcite-switch` should be surfaced and the target should be the parent toggle container.