### PR TITLE
feat(notice): Add css property for shadow

### DIFF
--- a/packages/components/src/components/notice/notice.e2e.ts
+++ b/packages/components/src/components/notice/notice.e2e.ts
@@ -152,6 +152,10 @@ describe("calcite-notice", () => {
           shadowSelector: `.${CSS.container}`,
           targetProp: "borderRadius",
         },
+        "--calcite-notice-shadow": {
+          shadowSelector: `.${CSS.container}`,
+          targetProp: "boxShadow",
+        },
       });
     });
 

--- a/packages/components/src/components/notice/notice.scss
+++ b/packages/components/src/components/notice/notice.scss
@@ -15,6 +15,7 @@
  * @prop --calcite-notice-title-text-color: Specifies the component's slotted `"title"` content text color.
  * @prop --calcite-notice-content-text-color: Specifies the component's slotted `"message"` content text color.
  * @prop --calcite-notice-width: [Deprecated] Specifies the component's width.
+ * @prop --calcite-notice-shadow: Specifies the component's shadow.
  */
 
 @use "sass:list";
@@ -101,6 +102,7 @@
   transition-duration: var(--calcite-animation-timing);
   text-align: start;
   border-radius: var(--calcite-notice-corner-radius, var(--calcite-corner-radius-sm));
+  box-shadow: var(--calcite-notice-shadow, var(--calcite-shadow-none));
 }
 
 :host {

--- a/packages/components/src/custom-theme/notice.ts
+++ b/packages/components/src/custom-theme/notice.ts
@@ -14,6 +14,7 @@ export const noticeTokens = {
   calciteNoticeCornerRadius: "",
   calciteNoticeTitleTextColor: "",
   calciteNoticeContentTextColor: "",
+  calciteNoticeShadow: "",
 };
 
 const noticeHTML = (


### PR DESCRIPTION
**Related Issue:** #13790 

## Summary
Adds the `--calcite-notice-shadow` css property for customization.