### PR TITLE
fix(input, input-number, input-text): correctly style affix when `readOnly` is set

### DIFF
--- a/packages/components/src/components/input-number/input-number.scss
+++ b/packages/components/src/components/input-number/input-number.scss
@@ -169,6 +169,13 @@ input[readonly]:focus {
   color: var(--calcite-input-number-text-color-focus, var(--calcite-color-text-1));
 }
 
+:host([read-only]) {
+  .prefix,
+  .suffix {
+    background-color: var(--calcite-input-number-background-color, var(--calcite-color-background));
+  }
+}
+
 //focus
 input {
   @apply focus-base;

--- a/packages/components/src/components/input-text/input-text.scss
+++ b/packages/components/src/components/input-text/input-text.scss
@@ -198,6 +198,14 @@ input[readonly] {
 input[readonly]:focus {
   color: var(--calcite-input-text-text-color-focus, var(--calcite-color-text-1));
 }
+
+:host([read-only]) {
+  .prefix,
+  .suffix {
+    background-color: var(--calcite-input-text-background-color, var(--calcite-color-background));
+  }
+}
+
 calcite-icon {
   color: var(--calcite-input-action-icon-color, var(--calcite-color-text-3));
 }

--- a/packages/components/src/components/input/input.scss
+++ b/packages/components/src/components/input/input.scss
@@ -238,6 +238,13 @@ input[readonly]:focus {
   color: var(--calcite-input-text-color, var(--calcite-color-text-1));
 }
 
+:host([read-only]) {
+  .prefix,
+  .suffix {
+    background-color: var(--calcite-input-background-color, var(--calcite-color-background));
+  }
+}
+
 //focus
 input {
   @apply focus-base;


### PR DESCRIPTION
**Related Issue:** #13792

## Summary
Fixes the styling of prefix and suffix elements in input components when the `read-only` attribute is set. The changes ensure that affix elements use the same background color as the rest of the component in read-only mode.

**Changes:**

- Added CSS rules to set affix background colors to match component background when read-only is applied
- Applied the fix consistently across three input component variants
