### PR TITLE
docs(label, link): align api descriptions with style guide

### DIFF
--- a/packages/components/src/components/label/label.tsx
+++ b/packages/components/src/components/label/label.tsx
@@ -25,13 +25,13 @@ export class Label extends LitElement {
 
   // #region Public Properties
 
-  /** Specifies the text alignment of the component. */
+  /** Specifies the component's text alignment. */
   @property({ reflect: true }) alignment: Alignment = "start";
 
   /** Specifies the `id` of the component the label is bound to. Use when the component the label is bound to does not reside within the component. */
   @property({ reflect: true }) for?: string;
 
-  /** Defines the layout of the label in relation to the component. Use `"inline"` positions to wrap the label and component on the same line.  [Deprecated] The `"default"` value is deprecated, use `"block"` instead. */
+  /** Defines the component's layout in relation to the slotted component. Use `"inline"` positions to wrap the label and slotted component on the same line.  [Deprecated] The `"default"` value is deprecated, use `"block"` instead. */
   @property({ reflect: true }) layout: "block" | "inline" | "inline-space-between" | "default" =
     "default";
 

--- a/packages/components/src/components/link/link.tsx
+++ b/packages/components/src/components/link/link.tsx
@@ -45,11 +45,11 @@ export class Link extends LitElement {
 
   //#region Public Properties
 
-  /** When `true`, interaction is prevented and the component is displayed with lower opacity. */
+  /** When `true`, prevents interaction and decreases the component's opacity. */
   @property({ reflect: true }) disabled = false;
 
   /**
-   * Prompts the user to save the linked URL instead of navigating to it. Can be used with or without a value:
+   * When specified, prompts the user to save the linked URL instead of navigating to it. Can be used with or without a value:
    * Without a value, the browser will suggest a filename/extension.
    *
    * @see [Global download attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#download).
@@ -62,16 +62,16 @@ export class Link extends LitElement {
   /** Specifies an icon to display at the end of the component. */
   @property({ reflect: true, type: String }) iconEnd: IconName;
 
-  /** Displays the `iconStart` and/or `iconEnd` as flipped when the element direction is right-to-left (`"rtl"`). */
+  /** When `true` and the element direction is right-to-left (`"rtl"`), flips the component's `iconStart` and/or `iconEnd`. */
   @property({ reflect: true }) iconFlipRtl: FlipContext;
 
   /** Specifies an icon to display at the start of the component. */
   @property({ reflect: true, type: String }) iconStart: IconName;
 
-  /** Specifies the relationship to the linked document defined in `href`. */
+  /** Specifies the relationship to the linked resource defined in `href`. */
   @property() rel: string;
 
-  /** Specifies the frame or window to open the linked document. */
+  /** Specifies the frame or window to open the linked resource. */
   @property() target: string;
 
   //#endregion


### PR DESCRIPTION
**Related Issue:** #12833

## Summary
Aligns API documentation with the style guide for the following components:
- `label`
- `link`
