### PR TITLE
refactor(src-tokens): remove unnecessary "default" group from semantic size token file

### DIFF
--- a/packages/design-tokens/src/tokens/semantic/size.json
+++ b/packages/design-tokens/src/tokens/semantic/size.json
@@ -90,108 +90,106 @@
         "description": "deprecated"
       }
     },
-    "default": {
-      "px": {
-        "value": "{core.size.default.1}",
-        "type": "sizing",
-        "attributes": {
-          "category": "size"
-        }
+    "px": {
+      "value": "{core.size.default.1}",
+      "type": "sizing",
+      "attributes": {
+        "category": "size"
+      }
+    },
+    "xxxs": {
+      "value": "{core.size.default.12}",
+      "type": "dimension",
+      "attributes": {
+        "category": "size"
       },
-      "xxxs": {
-        "value": "{core.size.default.12}",
-        "type": "dimension",
-        "attributes": {
-          "category": "size"
-        },
-        "description": "Deprecated, use --calcite-size-3xs instead."
+      "description": "Deprecated, use --calcite-size-3xs instead."
+    },
+    "3xs": {
+      "value": "{core.size.default.12}",
+      "type": "dimension",
+      "attributes": {
+        "category": "size"
+      }
+    },
+    "xxs": {
+      "value": "{core.size.default.14}",
+      "type": "dimension",
+      "attributes": {
+        "category": "size"
       },
-      "3xs": {
-        "value": "{core.size.default.12}",
-        "type": "dimension",
-        "attributes": {
-          "category": "size"
-        }
+      "description": "Deprecated, use --calcite-size-2xs instead."
+    },
+    "2xs": {
+      "value": "{core.size.default.14}",
+      "type": "dimension",
+      "attributes": {
+        "category": "size"
+      }
+    },
+    "xs": {
+      "value": "{core.size.default.16}",
+      "type": "dimension",
+      "attributes": {
+        "category": "size"
+      }
+    },
+    "sm": {
+      "value": "{core.size.default.24}",
+      "type": "dimension",
+      "attributes": {
+        "category": "size"
+      }
+    },
+    "md": {
+      "value": "{core.size.default.32}",
+      "type": "dimension",
+      "attributes": {
+        "category": "size"
+      }
+    },
+    "lg": {
+      "value": "{core.size.default.44}",
+      "type": "dimension",
+      "attributes": {
+        "category": "size"
+      }
+    },
+    "xl": {
+      "value": "{core.size.default.48}",
+      "type": "dimension",
+      "attributes": {
+        "category": "size"
+      }
+    },
+    "xxl": {
+      "value": "{core.size.default.64}",
+      "type": "dimension",
+      "attributes": {
+        "category": "size"
       },
-      "xxs": {
-        "value": "{core.size.default.14}",
-        "type": "dimension",
-        "attributes": {
-          "category": "size"
-        },
-        "description": "Deprecated, use --calcite-size-2xs instead."
+      "description": "Deprecated, use --calcite-size-2xl instead."
+    },
+    "2xl": {
+      "value": "{core.size.default.64}",
+      "type": "dimension",
+      "attributes": {
+        "category": "size"
+      }
+    },
+    "xxxl": {
+      "value": "{core.size.default.96}",
+      "type": "dimension",
+      "attributes": {
+        "category": "size"
       },
-      "2xs": {
-        "value": "{core.size.default.14}",
-        "type": "dimension",
-        "attributes": {
-          "category": "size"
-        }
-      },
-      "xs": {
-        "value": "{core.size.default.16}",
-        "type": "dimension",
-        "attributes": {
-          "category": "size"
-        }
-      },
-      "sm": {
-        "value": "{core.size.default.24}",
-        "type": "dimension",
-        "attributes": {
-          "category": "size"
-        }
-      },
-      "md": {
-        "value": "{core.size.default.32}",
-        "type": "dimension",
-        "attributes": {
-          "category": "size"
-        }
-      },
-      "lg": {
-        "value": "{core.size.default.44}",
-        "type": "dimension",
-        "attributes": {
-          "category": "size"
-        }
-      },
-      "xl": {
-        "value": "{core.size.default.48}",
-        "type": "dimension",
-        "attributes": {
-          "category": "size"
-        }
-      },
-      "xxl": {
-        "value": "{core.size.default.64}",
-        "type": "dimension",
-        "attributes": {
-          "category": "size"
-        },
-        "description": "Deprecated, use --calcite-size-2xl instead."
-      },
-      "2xl": {
-        "value": "{core.size.default.64}",
-        "type": "dimension",
-        "attributes": {
-          "category": "size"
-        }
-      },
-      "xxxl": {
-        "value": "{core.size.default.96}",
-        "type": "dimension",
-        "attributes": {
-          "category": "size"
-        },
-        "description": "Deprecated, use --calcite-size-3xl instead."
-      },
-      "3xl": {
-        "value": "{core.size.default.96}",
-        "type": "dimension",
-        "attributes": {
-          "category": "size"
-        }
+      "description": "Deprecated, use --calcite-size-3xl instead."
+    },
+    "3xl": {
+      "value": "{core.size.default.96}",
+      "type": "dimension",
+      "attributes": {
+        "category": "size"
       }
     }
   }

--- a/packages/design-tokens/src/tokens/semantic/size.json
+++ b/packages/design-tokens/src/tokens/semantic/size.json
@@ -90,115 +90,113 @@
         "description": "deprecated"
       }
     },
-    "default": {
-      "px": {
-        "value": "{core.size.default.1}",
-        "type": "sizing",
-        "attributes": {
-          "category": "size"
-        }
+    "px": {
+      "value": "{core.size.default.1}",
+      "type": "sizing",
+      "attributes": {
+        "category": "size"
+      }
+    },
+    "4xs": {
+      "value": "{core.size.default.10}",
+      "type": "dimension",
+      "attributes": {
+        "category": "size"
+      }
+    },
+    "xxxs": {
+      "value": "{core.size.default.12}",
+      "type": "dimension",
+      "attributes": {
+        "category": "size"
       },
-      "4xs": {
-        "value": "{core.size.default.10}",
-        "type": "dimension",
-        "attributes": {
-          "category": "size"
-        }
+      "description": "Deprecated, use --calcite-size-3xs instead."
+    },
+    "3xs": {
+      "value": "{core.size.default.12}",
+      "type": "dimension",
+      "attributes": {
+        "category": "size"
+      }
+    },
+    "xxs": {
+      "value": "{core.size.default.14}",
+      "type": "dimension",
+      "attributes": {
+        "category": "size"
       },
-      "xxxs": {
-        "value": "{core.size.default.12}",
-        "type": "dimension",
-        "attributes": {
-          "category": "size"
-        },
-        "description": "Deprecated, use --calcite-size-3xs instead."
+      "description": "Deprecated, use --calcite-size-2xs instead."
+    },
+    "2xs": {
+      "value": "{core.size.default.14}",
+      "type": "dimension",
+      "attributes": {
+        "category": "size"
+      }
+    },
+    "xs": {
+      "value": "{core.size.default.16}",
+      "type": "dimension",
+      "attributes": {
+        "category": "size"
+      }
+    },
+    "sm": {
+      "value": "{core.size.default.24}",
+      "type": "dimension",
+      "attributes": {
+        "category": "size"
+      }
+    },
+    "md": {
+      "value": "{core.size.default.32}",
+      "type": "dimension",
+      "attributes": {
+        "category": "size"
+      }
+    },
+    "lg": {
+      "value": "{core.size.default.44}",
+      "type": "dimension",
+      "attributes": {
+        "category": "size"
+      }
+    },
+    "xl": {
+      "value": "{core.size.default.48}",
+      "type": "dimension",
+      "attributes": {
+        "category": "size"
+      }
+    },
+    "xxl": {
+      "value": "{core.size.default.64}",
+      "type": "dimension",
+      "attributes": {
+        "category": "size"
       },
-      "3xs": {
-        "value": "{core.size.default.12}",
-        "type": "dimension",
-        "attributes": {
-          "category": "size"
-        }
+      "description": "Deprecated, use --calcite-size-2xl instead."
+    },
+    "2xl": {
+      "value": "{core.size.default.64}",
+      "type": "dimension",
+      "attributes": {
+        "category": "size"
+      }
+    },
+    "xxxl": {
+      "value": "{core.size.default.96}",
+      "type": "dimension",
+      "attributes": {
+        "category": "size"
       },
-      "xxs": {
-        "value": "{core.size.default.14}",
-        "type": "dimension",
-        "attributes": {
-          "category": "size"
-        },
-        "description": "Deprecated, use --calcite-size-2xs instead."
-      },
-      "2xs": {
-        "value": "{core.size.default.14}",
-        "type": "dimension",
-        "attributes": {
-          "category": "size"
-        }
-      },
-      "xs": {
-        "value": "{core.size.default.16}",
-        "type": "dimension",
-        "attributes": {
-          "category": "size"
-        }
-      },
-      "sm": {
-        "value": "{core.size.default.24}",
-        "type": "dimension",
-        "attributes": {
-          "category": "size"
-        }
-      },
-      "md": {
-        "value": "{core.size.default.32}",
-        "type": "dimension",
-        "attributes": {
-          "category": "size"
-        }
-      },
-      "lg": {
-        "value": "{core.size.default.44}",
-        "type": "dimension",
-        "attributes": {
-          "category": "size"
-        }
-      },
-      "xl": {
-        "value": "{core.size.default.48}",
-        "type": "dimension",
-        "attributes": {
-          "category": "size"
-        }
-      },
-      "xxl": {
-        "value": "{core.size.default.64}",
-        "type": "dimension",
-        "attributes": {
-          "category": "size"
-        },
-        "description": "Deprecated, use --calcite-size-2xl instead."
-      },
-      "2xl": {
-        "value": "{core.size.default.64}",
-        "type": "dimension",
-        "attributes": {
-          "category": "size"
-        }
-      },
-      "xxxl": {
-        "value": "{core.size.default.96}",
-        "type": "dimension",
-        "attributes": {
-          "category": "size"
-        },
-        "description": "Deprecated, use --calcite-size-3xl instead."
-      },
-      "3xl": {
-        "value": "{core.size.default.96}",
-        "type": "dimension",
-        "attributes": {
-          "category": "size"
-        }
+      "description": "Deprecated, use --calcite-size-3xl instead."
+    },
+    "3xl": {
+      "value": "{core.size.default.96}",
+      "type": "dimension",
+      "attributes": {
+        "category": "size"
       }
     }
   }

--- a/packages/design-tokens/tests/spec/__snapshots__/index.spec.ts.snap
+++ b/packages/design-tokens/tests/spec/__snapshots__/index.spec.ts.snap
@@ -23094,17 +23094,16 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "comment": "deprecated"
     },
     {
-      "key": "{size.default.px}",
+      "key": "{size.px}",
       "value": "1px",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "default",
-        "item": "px",
+        "type": "px",
         "names": {
           "scss": "$calcite-size-px",
           "css": "var(--calcite-size-px)",
-          "docs": "size.default.px",
+          "docs": "size.px",
           "es6": "calciteSizePx"
         },
         "calcite-schema": {
@@ -23116,20 +23115,19 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Px",
-      "path": ["size", "default", "px"]
+      "path": ["size", "px"]
     },
     {
-      "key": "{size.default.4xs}",
+      "key": "{size.4xs}",
       "value": "0.625rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "default",
-        "item": "4xs",
+        "type": "4xs",
         "names": {
           "scss": "$calcite-size-4xs",
           "css": "var(--calcite-size-4xs)",
-          "docs": "size.default.4xs",
+          "docs": "size.4xs",
           "es6": "calciteSize4xs"
         },
         "calcite-schema": {
@@ -23141,28 +23139,27 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size 4xs",
-      "path": ["size", "default", "4xs"]
+      "path": ["size", "4xs"]
     },
     {
-      "key": "{size.default.xxxs}",
+      "key": "{size.xxxs}",
       "value": "0.75rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
         "type": "dimension",
-        "item": "xxxs",
         "value": "12px",
         "description": "Deprecated, use --calcite-size-3xs instead.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
-        "key": "{size.default.xxxs}",
-        "name": "calcite-size-default-xxxs",
-        "path": ["size", "default", "xxxs"],
+        "key": "{size.xxxs}",
+        "name": "calcite-size-xxxs",
+        "path": ["size", "xxxs"],
         "comment": "Deprecated, use --calcite-size-3xs instead.",
         "names": {
           "scss": "$calcite-size-xxxs",
           "css": "var(--calcite-size-xxxs)",
-          "docs": "size.default.xxxs",
+          "docs": "size.xxxs",
           "es6": "calciteSizeXxxs"
         },
         "calcite-schema": {
@@ -23175,21 +23172,20 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Xxxs",
-      "path": ["size", "default", "xxxs"],
+      "path": ["size", "xxxs"],
       "comment": "Deprecated, use --calcite-size-3xs instead."
     },
     {
-      "key": "{size.default.3xs}",
+      "key": "{size.3xs}",
       "value": "0.75rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "default",
-        "item": "3xs",
+        "type": "3xs",
         "names": {
           "scss": "$calcite-size-3xs",
           "css": "var(--calcite-size-3xs)",
-          "docs": "size.default.3xs",
+          "docs": "size.3xs",
           "es6": "calciteSize3xs"
         },
         "calcite-schema": {
@@ -23201,28 +23197,27 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size 3xs",
-      "path": ["size", "default", "3xs"]
+      "path": ["size", "3xs"]
     },
     {
-      "key": "{size.default.xxs}",
+      "key": "{size.xxs}",
       "value": "0.875rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
         "type": "dimension",
-        "item": "xxs",
         "value": "14px",
         "description": "Deprecated, use --calcite-size-2xs instead.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
-        "key": "{size.default.xxs}",
-        "name": "calcite-size-default-xxs",
-        "path": ["size", "default", "xxs"],
+        "key": "{size.xxs}",
+        "name": "calcite-size-xxs",
+        "path": ["size", "xxs"],
         "comment": "Deprecated, use --calcite-size-2xs instead.",
         "names": {
           "scss": "$calcite-size-xxs",
           "css": "var(--calcite-size-xxs)",
-          "docs": "size.default.xxs",
+          "docs": "size.xxs",
           "es6": "calciteSizeXxs"
         },
         "calcite-schema": {
@@ -23235,21 +23230,20 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Xxs",
-      "path": ["size", "default", "xxs"],
+      "path": ["size", "xxs"],
       "comment": "Deprecated, use --calcite-size-2xs instead."
     },
     {
-      "key": "{size.default.2xs}",
+      "key": "{size.2xs}",
       "value": "0.875rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "default",
-        "item": "2xs",
+        "type": "2xs",
         "names": {
           "scss": "$calcite-size-2xs",
           "css": "var(--calcite-size-2xs)",
-          "docs": "size.default.2xs",
+          "docs": "size.2xs",
           "es6": "calciteSize2xs"
         },
         "calcite-schema": {
@@ -23261,20 +23255,19 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size 2xs",
-      "path": ["size", "default", "2xs"]
+      "path": ["size", "2xs"]
     },
     {
-      "key": "{size.default.xs}",
+      "key": "{size.xs}",
       "value": "1rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "default",
-        "item": "xs",
+        "type": "xs",
         "names": {
           "scss": "$calcite-size-xs",
           "css": "var(--calcite-size-xs)",
-          "docs": "size.default.xs",
+          "docs": "size.xs",
           "es6": "calciteSizeXs"
         },
         "calcite-schema": {
@@ -23286,20 +23279,19 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Xs",
-      "path": ["size", "default", "xs"]
+      "path": ["size", "xs"]
     },
     {
-      "key": "{size.default.sm}",
+      "key": "{size.sm}",
       "value": "1.5rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "default",
-        "item": "sm",
+        "type": "sm",
         "names": {
           "scss": "$calcite-size-sm",
           "css": "var(--calcite-size-sm)",
-          "docs": "size.default.sm",
+          "docs": "size.sm",
           "es6": "calciteSizeSm"
         },
         "calcite-schema": {
@@ -23311,20 +23303,19 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Sm",
-      "path": ["size", "default", "sm"]
+      "path": ["size", "sm"]
     },
     {
-      "key": "{size.default.md}",
+      "key": "{size.md}",
       "value": "2rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "default",
-        "item": "md",
+        "type": "md",
         "names": {
           "scss": "$calcite-size-md",
           "css": "var(--calcite-size-md)",
-          "docs": "size.default.md",
+          "docs": "size.md",
           "es6": "calciteSizeMd"
         },
         "calcite-schema": {
@@ -23336,20 +23327,19 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Md",
-      "path": ["size", "default", "md"]
+      "path": ["size", "md"]
     },
     {
-      "key": "{size.default.lg}",
+      "key": "{size.lg}",
       "value": "2.75rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "default",
-        "item": "lg",
+        "type": "lg",
         "names": {
           "scss": "$calcite-size-lg",
           "css": "var(--calcite-size-lg)",
-          "docs": "size.default.lg",
+          "docs": "size.lg",
           "es6": "calciteSizeLg"
         },
         "calcite-schema": {
@@ -23361,20 +23351,19 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Lg",
-      "path": ["size", "default", "lg"]
+      "path": ["size", "lg"]
     },
     {
-      "key": "{size.default.xl}",
+      "key": "{size.xl}",
       "value": "3rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "default",
-        "item": "xl",
+        "type": "xl",
         "names": {
           "scss": "$calcite-size-xl",
           "css": "var(--calcite-size-xl)",
-          "docs": "size.default.xl",
+          "docs": "size.xl",
           "es6": "calciteSizeXl"
         },
         "calcite-schema": {
@@ -23386,28 +23375,27 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Xl",
-      "path": ["size", "default", "xl"]
+      "path": ["size", "xl"]
     },
     {
-      "key": "{size.default.xxl}",
+      "key": "{size.xxl}",
       "value": "4rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
         "type": "dimension",
-        "item": "xxl",
         "value": "64px",
         "description": "Deprecated, use --calcite-size-2xl instead.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
-        "key": "{size.default.xxl}",
-        "name": "calcite-size-default-xxl",
-        "path": ["size", "default", "xxl"],
+        "key": "{size.xxl}",
+        "name": "calcite-size-xxl",
+        "path": ["size", "xxl"],
         "comment": "Deprecated, use --calcite-size-2xl instead.",
         "names": {
           "scss": "$calcite-size-xxl",
           "css": "var(--calcite-size-xxl)",
-          "docs": "size.default.xxl",
+          "docs": "size.xxl",
           "es6": "calciteSizeXxl"
         },
         "calcite-schema": {
@@ -23420,21 +23408,20 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Xxl",
-      "path": ["size", "default", "xxl"],
+      "path": ["size", "xxl"],
       "comment": "Deprecated, use --calcite-size-2xl instead."
     },
     {
-      "key": "{size.default.2xl}",
+      "key": "{size.2xl}",
       "value": "4rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "default",
-        "item": "2xl",
+        "type": "2xl",
         "names": {
           "scss": "$calcite-size-2xl",
           "css": "var(--calcite-size-2xl)",
-          "docs": "size.default.2xl",
+          "docs": "size.2xl",
           "es6": "calciteSize2xl"
         },
         "calcite-schema": {
@@ -23446,28 +23433,27 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size 2xl",
-      "path": ["size", "default", "2xl"]
+      "path": ["size", "2xl"]
     },
     {
-      "key": "{size.default.xxxl}",
+      "key": "{size.xxxl}",
       "value": "6rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
         "type": "dimension",
-        "item": "xxxl",
         "value": "96px",
         "description": "Deprecated, use --calcite-size-3xl instead.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
-        "key": "{size.default.xxxl}",
-        "name": "calcite-size-default-xxxl",
-        "path": ["size", "default", "xxxl"],
+        "key": "{size.xxxl}",
+        "name": "calcite-size-xxxl",
+        "path": ["size", "xxxl"],
         "comment": "Deprecated, use --calcite-size-3xl instead.",
         "names": {
           "scss": "$calcite-size-xxxl",
           "css": "var(--calcite-size-xxxl)",
-          "docs": "size.default.xxxl",
+          "docs": "size.xxxl",
           "es6": "calciteSizeXxxl"
         },
         "calcite-schema": {
@@ -23480,21 +23466,20 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Xxxl",
-      "path": ["size", "default", "xxxl"],
+      "path": ["size", "xxxl"],
       "comment": "Deprecated, use --calcite-size-3xl instead."
     },
     {
-      "key": "{size.default.3xl}",
+      "key": "{size.3xl}",
       "value": "6rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "default",
-        "item": "3xl",
+        "type": "3xl",
         "names": {
           "scss": "$calcite-size-3xl",
           "css": "var(--calcite-size-3xl)",
-          "docs": "size.default.3xl",
+          "docs": "size.3xl",
           "es6": "calciteSize3xl"
         },
         "calcite-schema": {
@@ -23506,7 +23491,7 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size 3xl",
-      "path": ["size", "default", "3xl"]
+      "path": ["size", "3xl"]
     },
     {
       "key": "{spacing.fixed.xxs}",
@@ -30055,17 +30040,16 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "comment": "deprecated"
     },
     {
-      "key": "{size.default.px}",
+      "key": "{size.px}",
       "value": "1px",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "default",
-        "item": "px",
+        "type": "px",
         "names": {
           "scss": "$calcite-size-px",
           "css": "var(--calcite-size-px)",
-          "docs": "size.default.px",
+          "docs": "size.px",
           "es6": "calciteSizePx"
         },
         "calcite-schema": {
@@ -30077,20 +30061,19 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Px",
-      "path": ["size", "default", "px"]
+      "path": ["size", "px"]
     },
     {
-      "key": "{size.default.4xs}",
+      "key": "{size.4xs}",
       "value": "0.625rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "default",
-        "item": "4xs",
+        "type": "4xs",
         "names": {
           "scss": "$calcite-size-4xs",
           "css": "var(--calcite-size-4xs)",
-          "docs": "size.default.4xs",
+          "docs": "size.4xs",
           "es6": "calciteSize4xs"
         },
         "calcite-schema": {
@@ -30102,28 +30085,27 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size 4xs",
-      "path": ["size", "default", "4xs"]
+      "path": ["size", "4xs"]
     },
     {
-      "key": "{size.default.xxxs}",
+      "key": "{size.xxxs}",
       "value": "0.75rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
         "type": "dimension",
-        "item": "xxxs",
         "value": "12px",
         "description": "Deprecated, use --calcite-size-3xs instead.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
-        "key": "{size.default.xxxs}",
-        "name": "calcite-size-default-xxxs",
-        "path": ["size", "default", "xxxs"],
+        "key": "{size.xxxs}",
+        "name": "calcite-size-xxxs",
+        "path": ["size", "xxxs"],
         "comment": "Deprecated, use --calcite-size-3xs instead.",
         "names": {
           "scss": "$calcite-size-xxxs",
           "css": "var(--calcite-size-xxxs)",
-          "docs": "size.default.xxxs",
+          "docs": "size.xxxs",
           "es6": "calciteSizeXxxs"
         },
         "calcite-schema": {
@@ -30136,21 +30118,20 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Xxxs",
-      "path": ["size", "default", "xxxs"],
+      "path": ["size", "xxxs"],
       "comment": "Deprecated, use --calcite-size-3xs instead."
     },
     {
-      "key": "{size.default.3xs}",
+      "key": "{size.3xs}",
       "value": "0.75rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "default",
-        "item": "3xs",
+        "type": "3xs",
         "names": {
           "scss": "$calcite-size-3xs",
           "css": "var(--calcite-size-3xs)",
-          "docs": "size.default.3xs",
+          "docs": "size.3xs",
           "es6": "calciteSize3xs"
         },
         "calcite-schema": {
@@ -30162,28 +30143,27 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size 3xs",
-      "path": ["size", "default", "3xs"]
+      "path": ["size", "3xs"]
     },
     {
-      "key": "{size.default.xxs}",
+      "key": "{size.xxs}",
       "value": "0.875rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
         "type": "dimension",
-        "item": "xxs",
         "value": "14px",
         "description": "Deprecated, use --calcite-size-2xs instead.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
-        "key": "{size.default.xxs}",
-        "name": "calcite-size-default-xxs",
-        "path": ["size", "default", "xxs"],
+        "key": "{size.xxs}",
+        "name": "calcite-size-xxs",
+        "path": ["size", "xxs"],
         "comment": "Deprecated, use --calcite-size-2xs instead.",
         "names": {
           "scss": "$calcite-size-xxs",
           "css": "var(--calcite-size-xxs)",
-          "docs": "size.default.xxs",
+          "docs": "size.xxs",
           "es6": "calciteSizeXxs"
         },
         "calcite-schema": {
@@ -30196,21 +30176,20 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Xxs",
-      "path": ["size", "default", "xxs"],
+      "path": ["size", "xxs"],
       "comment": "Deprecated, use --calcite-size-2xs instead."
     },
     {
-      "key": "{size.default.2xs}",
+      "key": "{size.2xs}",
       "value": "0.875rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "default",
-        "item": "2xs",
+        "type": "2xs",
         "names": {
           "scss": "$calcite-size-2xs",
           "css": "var(--calcite-size-2xs)",
-          "docs": "size.default.2xs",
+          "docs": "size.2xs",
           "es6": "calciteSize2xs"
         },
         "calcite-schema": {
@@ -30222,20 +30201,19 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size 2xs",
-      "path": ["size", "default", "2xs"]
+      "path": ["size", "2xs"]
     },
     {
-      "key": "{size.default.xs}",
+      "key": "{size.xs}",
       "value": "1rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "default",
-        "item": "xs",
+        "type": "xs",
         "names": {
           "scss": "$calcite-size-xs",
           "css": "var(--calcite-size-xs)",
-          "docs": "size.default.xs",
+          "docs": "size.xs",
           "es6": "calciteSizeXs"
         },
         "calcite-schema": {
@@ -30247,20 +30225,19 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Xs",
-      "path": ["size", "default", "xs"]
+      "path": ["size", "xs"]
     },
     {
-      "key": "{size.default.sm}",
+      "key": "{size.sm}",
       "value": "1.5rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "default",
-        "item": "sm",
+        "type": "sm",
         "names": {
           "scss": "$calcite-size-sm",
           "css": "var(--calcite-size-sm)",
-          "docs": "size.default.sm",
+          "docs": "size.sm",
           "es6": "calciteSizeSm"
         },
         "calcite-schema": {
@@ -30272,20 +30249,19 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Sm",
-      "path": ["size", "default", "sm"]
+      "path": ["size", "sm"]
     },
     {
-      "key": "{size.default.md}",
+      "key": "{size.md}",
       "value": "2rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "default",
-        "item": "md",
+        "type": "md",
         "names": {
           "scss": "$calcite-size-md",
           "css": "var(--calcite-size-md)",
-          "docs": "size.default.md",
+          "docs": "size.md",
           "es6": "calciteSizeMd"
         },
         "calcite-schema": {
@@ -30297,20 +30273,19 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Md",
-      "path": ["size", "default", "md"]
+      "path": ["size", "md"]
     },
     {
-      "key": "{size.default.lg}",
+      "key": "{size.lg}",
       "value": "2.75rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "default",
-        "item": "lg",
+        "type": "lg",
         "names": {
           "scss": "$calcite-size-lg",
           "css": "var(--calcite-size-lg)",
-          "docs": "size.default.lg",
+          "docs": "size.lg",
           "es6": "calciteSizeLg"
         },
         "calcite-schema": {
@@ -30322,20 +30297,19 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Lg",
-      "path": ["size", "default", "lg"]
+      "path": ["size", "lg"]
     },
     {
-      "key": "{size.default.xl}",
+      "key": "{size.xl}",
       "value": "3rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "default",
-        "item": "xl",
+        "type": "xl",
         "names": {
           "scss": "$calcite-size-xl",
           "css": "var(--calcite-size-xl)",
-          "docs": "size.default.xl",
+          "docs": "size.xl",
           "es6": "calciteSizeXl"
         },
         "calcite-schema": {
@@ -30347,28 +30321,27 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Xl",
-      "path": ["size", "default", "xl"]
+      "path": ["size", "xl"]
     },
     {
-      "key": "{size.default.xxl}",
+      "key": "{size.xxl}",
       "value": "4rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
         "type": "dimension",
-        "item": "xxl",
         "value": "64px",
         "description": "Deprecated, use --calcite-size-2xl instead.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
-        "key": "{size.default.xxl}",
-        "name": "calcite-size-default-xxl",
-        "path": ["size", "default", "xxl"],
+        "key": "{size.xxl}",
+        "name": "calcite-size-xxl",
+        "path": ["size", "xxl"],
         "comment": "Deprecated, use --calcite-size-2xl instead.",
         "names": {
           "scss": "$calcite-size-xxl",
           "css": "var(--calcite-size-xxl)",
-          "docs": "size.default.xxl",
+          "docs": "size.xxl",
           "es6": "calciteSizeXxl"
         },
         "calcite-schema": {
@@ -30381,21 +30354,20 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Xxl",
-      "path": ["size", "default", "xxl"],
+      "path": ["size", "xxl"],
       "comment": "Deprecated, use --calcite-size-2xl instead."
     },
     {
-      "key": "{size.default.2xl}",
+      "key": "{size.2xl}",
       "value": "4rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "default",
-        "item": "2xl",
+        "type": "2xl",
         "names": {
           "scss": "$calcite-size-2xl",
           "css": "var(--calcite-size-2xl)",
-          "docs": "size.default.2xl",
+          "docs": "size.2xl",
           "es6": "calciteSize2xl"
         },
         "calcite-schema": {
@@ -30407,28 +30379,27 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size 2xl",
-      "path": ["size", "default", "2xl"]
+      "path": ["size", "2xl"]
     },
     {
-      "key": "{size.default.xxxl}",
+      "key": "{size.xxxl}",
       "value": "6rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
         "type": "dimension",
-        "item": "xxxl",
         "value": "96px",
         "description": "Deprecated, use --calcite-size-3xl instead.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
-        "key": "{size.default.xxxl}",
-        "name": "calcite-size-default-xxxl",
-        "path": ["size", "default", "xxxl"],
+        "key": "{size.xxxl}",
+        "name": "calcite-size-xxxl",
+        "path": ["size", "xxxl"],
         "comment": "Deprecated, use --calcite-size-3xl instead.",
         "names": {
           "scss": "$calcite-size-xxxl",
           "css": "var(--calcite-size-xxxl)",
-          "docs": "size.default.xxxl",
+          "docs": "size.xxxl",
           "es6": "calciteSizeXxxl"
         },
         "calcite-schema": {
@@ -30441,21 +30412,20 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Xxxl",
-      "path": ["size", "default", "xxxl"],
+      "path": ["size", "xxxl"],
       "comment": "Deprecated, use --calcite-size-3xl instead."
     },
     {
-      "key": "{size.default.3xl}",
+      "key": "{size.3xl}",
       "value": "6rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "default",
-        "item": "3xl",
+        "type": "3xl",
         "names": {
           "scss": "$calcite-size-3xl",
           "css": "var(--calcite-size-3xl)",
-          "docs": "size.default.3xl",
+          "docs": "size.3xl",
           "es6": "calciteSize3xl"
         },
         "calcite-schema": {
@@ -30467,7 +30437,7 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size 3xl",
-      "path": ["size", "default", "3xl"]
+      "path": ["size", "3xl"]
     },
     {
       "key": "{spacing.fixed.xxs}",

--- a/packages/design-tokens/tests/spec/__snapshots__/index.spec.ts.snap
+++ b/packages/design-tokens/tests/spec/__snapshots__/index.spec.ts.snap
@@ -23094,16 +23094,17 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "comment": "deprecated"
     },
     {
-      "key": "{size.px}",
+      "key": "{size.default.px}",
       "value": "1px",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "px",
+        "type": "default",
+        "item": "px",
         "names": {
           "scss": "$calcite-size-px",
           "css": "var(--calcite-size-px)",
-          "docs": "size.px",
+          "docs": "size.default.px",
           "es6": "calciteSizePx"
         },
         "calcite-schema": {
@@ -23149,18 +23150,19 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "attributes": {
         "category": "size",
         "type": "dimension",
+        "item": "xxxs",
         "value": "12px",
         "description": "Deprecated, use --calcite-size-3xs instead.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
-        "key": "{size.xxxs}",
-        "name": "calcite-size-xxxs",
-        "path": ["size", "xxxs"],
+        "key": "{size.default.xxxs}",
+        "name": "calcite-size-default-xxxs",
+        "path": ["size", "default", "xxxs"],
         "comment": "Deprecated, use --calcite-size-3xs instead.",
         "names": {
           "scss": "$calcite-size-xxxs",
           "css": "var(--calcite-size-xxxs)",
-          "docs": "size.xxxs",
+          "docs": "size.default.xxxs",
           "es6": "calciteSizeXxxs"
         },
         "calcite-schema": {
@@ -23173,20 +23175,21 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Xxxs",
-      "path": ["size", "xxxs"],
+      "path": ["size", "default", "xxxs"],
       "comment": "Deprecated, use --calcite-size-3xs instead."
     },
     {
-      "key": "{size.3xs}",
+      "key": "{size.default.3xs}",
       "value": "0.75rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "3xs",
+        "type": "default",
+        "item": "3xs",
         "names": {
           "scss": "$calcite-size-3xs",
           "css": "var(--calcite-size-3xs)",
-          "docs": "size.3xs",
+          "docs": "size.default.3xs",
           "es6": "calciteSize3xs"
         },
         "calcite-schema": {
@@ -23198,27 +23201,28 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size 3xs",
-      "path": ["size", "3xs"]
+      "path": ["size", "default", "3xs"]
     },
     {
-      "key": "{size.xxs}",
+      "key": "{size.default.xxs}",
       "value": "0.875rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
         "type": "dimension",
+        "item": "xxs",
         "value": "14px",
         "description": "Deprecated, use --calcite-size-2xs instead.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
-        "key": "{size.xxs}",
-        "name": "calcite-size-xxs",
-        "path": ["size", "xxs"],
+        "key": "{size.default.xxs}",
+        "name": "calcite-size-default-xxs",
+        "path": ["size", "default", "xxs"],
         "comment": "Deprecated, use --calcite-size-2xs instead.",
         "names": {
           "scss": "$calcite-size-xxs",
           "css": "var(--calcite-size-xxs)",
-          "docs": "size.xxs",
+          "docs": "size.default.xxs",
           "es6": "calciteSizeXxs"
         },
         "calcite-schema": {
@@ -23231,20 +23235,21 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Xxs",
-      "path": ["size", "xxs"],
+      "path": ["size", "default", "xxs"],
       "comment": "Deprecated, use --calcite-size-2xs instead."
     },
     {
-      "key": "{size.2xs}",
+      "key": "{size.default.2xs}",
       "value": "0.875rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "2xs",
+        "type": "default",
+        "item": "2xs",
         "names": {
           "scss": "$calcite-size-2xs",
           "css": "var(--calcite-size-2xs)",
-          "docs": "size.2xs",
+          "docs": "size.default.2xs",
           "es6": "calciteSize2xs"
         },
         "calcite-schema": {
@@ -23256,19 +23261,20 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size 2xs",
-      "path": ["size", "2xs"]
+      "path": ["size", "default", "2xs"]
     },
     {
-      "key": "{size.xs}",
+      "key": "{size.default.xs}",
       "value": "1rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "xs",
+        "type": "default",
+        "item": "xs",
         "names": {
           "scss": "$calcite-size-xs",
           "css": "var(--calcite-size-xs)",
-          "docs": "size.xs",
+          "docs": "size.default.xs",
           "es6": "calciteSizeXs"
         },
         "calcite-schema": {
@@ -23280,19 +23286,20 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Xs",
-      "path": ["size", "xs"]
+      "path": ["size", "default", "xs"]
     },
     {
-      "key": "{size.sm}",
+      "key": "{size.default.sm}",
       "value": "1.5rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "sm",
+        "type": "default",
+        "item": "sm",
         "names": {
           "scss": "$calcite-size-sm",
           "css": "var(--calcite-size-sm)",
-          "docs": "size.sm",
+          "docs": "size.default.sm",
           "es6": "calciteSizeSm"
         },
         "calcite-schema": {
@@ -23304,19 +23311,20 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Sm",
-      "path": ["size", "sm"]
+      "path": ["size", "default", "sm"]
     },
     {
-      "key": "{size.md}",
+      "key": "{size.default.md}",
       "value": "2rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "md",
+        "type": "default",
+        "item": "md",
         "names": {
           "scss": "$calcite-size-md",
           "css": "var(--calcite-size-md)",
-          "docs": "size.md",
+          "docs": "size.default.md",
           "es6": "calciteSizeMd"
         },
         "calcite-schema": {
@@ -23328,19 +23336,20 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Md",
-      "path": ["size", "md"]
+      "path": ["size", "default", "md"]
     },
     {
-      "key": "{size.lg}",
+      "key": "{size.default.lg}",
       "value": "2.75rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "lg",
+        "type": "default",
+        "item": "lg",
         "names": {
           "scss": "$calcite-size-lg",
           "css": "var(--calcite-size-lg)",
-          "docs": "size.lg",
+          "docs": "size.default.lg",
           "es6": "calciteSizeLg"
         },
         "calcite-schema": {
@@ -23352,19 +23361,20 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Lg",
-      "path": ["size", "lg"]
+      "path": ["size", "default", "lg"]
     },
     {
-      "key": "{size.xl}",
+      "key": "{size.default.xl}",
       "value": "3rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "xl",
+        "type": "default",
+        "item": "xl",
         "names": {
           "scss": "$calcite-size-xl",
           "css": "var(--calcite-size-xl)",
-          "docs": "size.xl",
+          "docs": "size.default.xl",
           "es6": "calciteSizeXl"
         },
         "calcite-schema": {
@@ -23376,27 +23386,28 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Xl",
-      "path": ["size", "xl"]
+      "path": ["size", "default", "xl"]
     },
     {
-      "key": "{size.xxl}",
+      "key": "{size.default.xxl}",
       "value": "4rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
         "type": "dimension",
+        "item": "xxl",
         "value": "64px",
         "description": "Deprecated, use --calcite-size-2xl instead.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
-        "key": "{size.xxl}",
-        "name": "calcite-size-xxl",
-        "path": ["size", "xxl"],
+        "key": "{size.default.xxl}",
+        "name": "calcite-size-default-xxl",
+        "path": ["size", "default", "xxl"],
         "comment": "Deprecated, use --calcite-size-2xl instead.",
         "names": {
           "scss": "$calcite-size-xxl",
           "css": "var(--calcite-size-xxl)",
-          "docs": "size.xxl",
+          "docs": "size.default.xxl",
           "es6": "calciteSizeXxl"
         },
         "calcite-schema": {
@@ -23409,20 +23420,21 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Xxl",
-      "path": ["size", "xxl"],
+      "path": ["size", "default", "xxl"],
       "comment": "Deprecated, use --calcite-size-2xl instead."
     },
     {
-      "key": "{size.2xl}",
+      "key": "{size.default.2xl}",
       "value": "4rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "2xl",
+        "type": "default",
+        "item": "2xl",
         "names": {
           "scss": "$calcite-size-2xl",
           "css": "var(--calcite-size-2xl)",
-          "docs": "size.2xl",
+          "docs": "size.default.2xl",
           "es6": "calciteSize2xl"
         },
         "calcite-schema": {
@@ -23434,27 +23446,28 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size 2xl",
-      "path": ["size", "2xl"]
+      "path": ["size", "default", "2xl"]
     },
     {
-      "key": "{size.xxxl}",
+      "key": "{size.default.xxxl}",
       "value": "6rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
         "type": "dimension",
+        "item": "xxxl",
         "value": "96px",
         "description": "Deprecated, use --calcite-size-3xl instead.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
-        "key": "{size.xxxl}",
-        "name": "calcite-size-xxxl",
-        "path": ["size", "xxxl"],
+        "key": "{size.default.xxxl}",
+        "name": "calcite-size-default-xxxl",
+        "path": ["size", "default", "xxxl"],
         "comment": "Deprecated, use --calcite-size-3xl instead.",
         "names": {
           "scss": "$calcite-size-xxxl",
           "css": "var(--calcite-size-xxxl)",
-          "docs": "size.xxxl",
+          "docs": "size.default.xxxl",
           "es6": "calciteSizeXxxl"
         },
         "calcite-schema": {
@@ -23467,20 +23480,21 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Xxxl",
-      "path": ["size", "xxxl"],
+      "path": ["size", "default", "xxxl"],
       "comment": "Deprecated, use --calcite-size-3xl instead."
     },
     {
-      "key": "{size.3xl}",
+      "key": "{size.default.3xl}",
       "value": "6rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "3xl",
+        "type": "default",
+        "item": "3xl",
         "names": {
           "scss": "$calcite-size-3xl",
           "css": "var(--calcite-size-3xl)",
-          "docs": "size.3xl",
+          "docs": "size.default.3xl",
           "es6": "calciteSize3xl"
         },
         "calcite-schema": {
@@ -23492,7 +23506,7 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size 3xl",
-      "path": ["size", "3xl"]
+      "path": ["size", "default", "3xl"]
     },
     {
       "key": "{spacing.fixed.xxs}",
@@ -30041,16 +30055,17 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "comment": "deprecated"
     },
     {
-      "key": "{size.px}",
+      "key": "{size.default.px}",
       "value": "1px",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "px",
+        "type": "default",
+        "item": "px",
         "names": {
           "scss": "$calcite-size-px",
           "css": "var(--calcite-size-px)",
-          "docs": "size.px",
+          "docs": "size.default.px",
           "es6": "calciteSizePx"
         },
         "calcite-schema": {
@@ -30096,18 +30111,19 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "attributes": {
         "category": "size",
         "type": "dimension",
+        "item": "xxxs",
         "value": "12px",
         "description": "Deprecated, use --calcite-size-3xs instead.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
-        "key": "{size.xxxs}",
-        "name": "calcite-size-xxxs",
-        "path": ["size", "xxxs"],
+        "key": "{size.default.xxxs}",
+        "name": "calcite-size-default-xxxs",
+        "path": ["size", "default", "xxxs"],
         "comment": "Deprecated, use --calcite-size-3xs instead.",
         "names": {
           "scss": "$calcite-size-xxxs",
           "css": "var(--calcite-size-xxxs)",
-          "docs": "size.xxxs",
+          "docs": "size.default.xxxs",
           "es6": "calciteSizeXxxs"
         },
         "calcite-schema": {
@@ -30120,20 +30136,21 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Xxxs",
-      "path": ["size", "xxxs"],
+      "path": ["size", "default", "xxxs"],
       "comment": "Deprecated, use --calcite-size-3xs instead."
     },
     {
-      "key": "{size.3xs}",
+      "key": "{size.default.3xs}",
       "value": "0.75rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "3xs",
+        "type": "default",
+        "item": "3xs",
         "names": {
           "scss": "$calcite-size-3xs",
           "css": "var(--calcite-size-3xs)",
-          "docs": "size.3xs",
+          "docs": "size.default.3xs",
           "es6": "calciteSize3xs"
         },
         "calcite-schema": {
@@ -30145,27 +30162,28 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size 3xs",
-      "path": ["size", "3xs"]
+      "path": ["size", "default", "3xs"]
     },
     {
-      "key": "{size.xxs}",
+      "key": "{size.default.xxs}",
       "value": "0.875rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
         "type": "dimension",
+        "item": "xxs",
         "value": "14px",
         "description": "Deprecated, use --calcite-size-2xs instead.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
-        "key": "{size.xxs}",
-        "name": "calcite-size-xxs",
-        "path": ["size", "xxs"],
+        "key": "{size.default.xxs}",
+        "name": "calcite-size-default-xxs",
+        "path": ["size", "default", "xxs"],
         "comment": "Deprecated, use --calcite-size-2xs instead.",
         "names": {
           "scss": "$calcite-size-xxs",
           "css": "var(--calcite-size-xxs)",
-          "docs": "size.xxs",
+          "docs": "size.default.xxs",
           "es6": "calciteSizeXxs"
         },
         "calcite-schema": {
@@ -30178,20 +30196,21 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Xxs",
-      "path": ["size", "xxs"],
+      "path": ["size", "default", "xxs"],
       "comment": "Deprecated, use --calcite-size-2xs instead."
     },
     {
-      "key": "{size.2xs}",
+      "key": "{size.default.2xs}",
       "value": "0.875rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "2xs",
+        "type": "default",
+        "item": "2xs",
         "names": {
           "scss": "$calcite-size-2xs",
           "css": "var(--calcite-size-2xs)",
-          "docs": "size.2xs",
+          "docs": "size.default.2xs",
           "es6": "calciteSize2xs"
         },
         "calcite-schema": {
@@ -30203,19 +30222,20 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size 2xs",
-      "path": ["size", "2xs"]
+      "path": ["size", "default", "2xs"]
     },
     {
-      "key": "{size.xs}",
+      "key": "{size.default.xs}",
       "value": "1rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "xs",
+        "type": "default",
+        "item": "xs",
         "names": {
           "scss": "$calcite-size-xs",
           "css": "var(--calcite-size-xs)",
-          "docs": "size.xs",
+          "docs": "size.default.xs",
           "es6": "calciteSizeXs"
         },
         "calcite-schema": {
@@ -30227,19 +30247,20 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Xs",
-      "path": ["size", "xs"]
+      "path": ["size", "default", "xs"]
     },
     {
-      "key": "{size.sm}",
+      "key": "{size.default.sm}",
       "value": "1.5rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "sm",
+        "type": "default",
+        "item": "sm",
         "names": {
           "scss": "$calcite-size-sm",
           "css": "var(--calcite-size-sm)",
-          "docs": "size.sm",
+          "docs": "size.default.sm",
           "es6": "calciteSizeSm"
         },
         "calcite-schema": {
@@ -30251,19 +30272,20 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Sm",
-      "path": ["size", "sm"]
+      "path": ["size", "default", "sm"]
     },
     {
-      "key": "{size.md}",
+      "key": "{size.default.md}",
       "value": "2rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "md",
+        "type": "default",
+        "item": "md",
         "names": {
           "scss": "$calcite-size-md",
           "css": "var(--calcite-size-md)",
-          "docs": "size.md",
+          "docs": "size.default.md",
           "es6": "calciteSizeMd"
         },
         "calcite-schema": {
@@ -30275,19 +30297,20 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Md",
-      "path": ["size", "md"]
+      "path": ["size", "default", "md"]
     },
     {
-      "key": "{size.lg}",
+      "key": "{size.default.lg}",
       "value": "2.75rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "lg",
+        "type": "default",
+        "item": "lg",
         "names": {
           "scss": "$calcite-size-lg",
           "css": "var(--calcite-size-lg)",
-          "docs": "size.lg",
+          "docs": "size.default.lg",
           "es6": "calciteSizeLg"
         },
         "calcite-schema": {
@@ -30299,19 +30322,20 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Lg",
-      "path": ["size", "lg"]
+      "path": ["size", "default", "lg"]
     },
     {
-      "key": "{size.xl}",
+      "key": "{size.default.xl}",
       "value": "3rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "xl",
+        "type": "default",
+        "item": "xl",
         "names": {
           "scss": "$calcite-size-xl",
           "css": "var(--calcite-size-xl)",
-          "docs": "size.xl",
+          "docs": "size.default.xl",
           "es6": "calciteSizeXl"
         },
         "calcite-schema": {
@@ -30323,27 +30347,28 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Xl",
-      "path": ["size", "xl"]
+      "path": ["size", "default", "xl"]
     },
     {
-      "key": "{size.xxl}",
+      "key": "{size.default.xxl}",
       "value": "4rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
         "type": "dimension",
+        "item": "xxl",
         "value": "64px",
         "description": "Deprecated, use --calcite-size-2xl instead.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
-        "key": "{size.xxl}",
-        "name": "calcite-size-xxl",
-        "path": ["size", "xxl"],
+        "key": "{size.default.xxl}",
+        "name": "calcite-size-default-xxl",
+        "path": ["size", "default", "xxl"],
         "comment": "Deprecated, use --calcite-size-2xl instead.",
         "names": {
           "scss": "$calcite-size-xxl",
           "css": "var(--calcite-size-xxl)",
-          "docs": "size.xxl",
+          "docs": "size.default.xxl",
           "es6": "calciteSizeXxl"
         },
         "calcite-schema": {
@@ -30356,20 +30381,21 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Xxl",
-      "path": ["size", "xxl"],
+      "path": ["size", "default", "xxl"],
       "comment": "Deprecated, use --calcite-size-2xl instead."
     },
     {
-      "key": "{size.2xl}",
+      "key": "{size.default.2xl}",
       "value": "4rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "2xl",
+        "type": "default",
+        "item": "2xl",
         "names": {
           "scss": "$calcite-size-2xl",
           "css": "var(--calcite-size-2xl)",
-          "docs": "size.2xl",
+          "docs": "size.default.2xl",
           "es6": "calciteSize2xl"
         },
         "calcite-schema": {
@@ -30381,27 +30407,28 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size 2xl",
-      "path": ["size", "2xl"]
+      "path": ["size", "default", "2xl"]
     },
     {
-      "key": "{size.xxxl}",
+      "key": "{size.default.xxxl}",
       "value": "6rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
         "type": "dimension",
+        "item": "xxxl",
         "value": "96px",
         "description": "Deprecated, use --calcite-size-3xl instead.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
-        "key": "{size.xxxl}",
-        "name": "calcite-size-xxxl",
-        "path": ["size", "xxxl"],
+        "key": "{size.default.xxxl}",
+        "name": "calcite-size-default-xxxl",
+        "path": ["size", "default", "xxxl"],
         "comment": "Deprecated, use --calcite-size-3xl instead.",
         "names": {
           "scss": "$calcite-size-xxxl",
           "css": "var(--calcite-size-xxxl)",
-          "docs": "size.xxxl",
+          "docs": "size.default.xxxl",
           "es6": "calciteSizeXxxl"
         },
         "calcite-schema": {
@@ -30414,20 +30441,21 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Xxxl",
-      "path": ["size", "xxxl"],
+      "path": ["size", "default", "xxxl"],
       "comment": "Deprecated, use --calcite-size-3xl instead."
     },
     {
-      "key": "{size.3xl}",
+      "key": "{size.default.3xl}",
       "value": "6rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "3xl",
+        "type": "default",
+        "item": "3xl",
         "names": {
           "scss": "$calcite-size-3xl",
           "css": "var(--calcite-size-3xl)",
-          "docs": "size.3xl",
+          "docs": "size.default.3xl",
           "es6": "calciteSize3xl"
         },
         "calcite-schema": {
@@ -30439,7 +30467,7 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size 3xl",
-      "path": ["size", "3xl"]
+      "path": ["size", "default", "3xl"]
     },
     {
       "key": "{spacing.fixed.xxs}",

--- a/packages/design-tokens/tests/spec/__snapshots__/index.spec.ts.snap
+++ b/packages/design-tokens/tests/spec/__snapshots__/index.spec.ts.snap
@@ -23090,17 +23090,16 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "comment": "deprecated"
     },
     {
-      "key": "{size.default.px}",
+      "key": "{size.px}",
       "value": "1px",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "default",
-        "item": "px",
+        "type": "px",
         "names": {
           "scss": "$calcite-size-px",
           "css": "var(--calcite-size-px)",
-          "docs": "size.default.px",
+          "docs": "size.px",
           "es6": "calciteSizePx"
         },
         "calcite-schema": {
@@ -23112,28 +23111,27 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Px",
-      "path": ["size", "default", "px"]
+      "path": ["size", "px"]
     },
     {
-      "key": "{size.default.xxxs}",
+      "key": "{size.xxxs}",
       "value": "0.75rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
         "type": "dimension",
-        "item": "xxxs",
         "value": "12px",
         "description": "Deprecated, use --calcite-size-3xs instead.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
-        "key": "{size.default.xxxs}",
-        "name": "calcite-size-default-xxxs",
-        "path": ["size", "default", "xxxs"],
+        "key": "{size.xxxs}",
+        "name": "calcite-size-xxxs",
+        "path": ["size", "xxxs"],
         "comment": "Deprecated, use --calcite-size-3xs instead.",
         "names": {
           "scss": "$calcite-size-xxxs",
           "css": "var(--calcite-size-xxxs)",
-          "docs": "size.default.xxxs",
+          "docs": "size.xxxs",
           "es6": "calciteSizeXxxs"
         },
         "calcite-schema": {
@@ -23146,21 +23144,20 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Xxxs",
-      "path": ["size", "default", "xxxs"],
+      "path": ["size", "xxxs"],
       "comment": "Deprecated, use --calcite-size-3xs instead."
     },
     {
-      "key": "{size.default.3xs}",
+      "key": "{size.3xs}",
       "value": "0.75rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "default",
-        "item": "3xs",
+        "type": "3xs",
         "names": {
           "scss": "$calcite-size-3xs",
           "css": "var(--calcite-size-3xs)",
-          "docs": "size.default.3xs",
+          "docs": "size.3xs",
           "es6": "calciteSize3xs"
         },
         "calcite-schema": {
@@ -23172,28 +23169,27 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size 3xs",
-      "path": ["size", "default", "3xs"]
+      "path": ["size", "3xs"]
     },
     {
-      "key": "{size.default.xxs}",
+      "key": "{size.xxs}",
       "value": "0.875rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
         "type": "dimension",
-        "item": "xxs",
         "value": "14px",
         "description": "Deprecated, use --calcite-size-2xs instead.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
-        "key": "{size.default.xxs}",
-        "name": "calcite-size-default-xxs",
-        "path": ["size", "default", "xxs"],
+        "key": "{size.xxs}",
+        "name": "calcite-size-xxs",
+        "path": ["size", "xxs"],
         "comment": "Deprecated, use --calcite-size-2xs instead.",
         "names": {
           "scss": "$calcite-size-xxs",
           "css": "var(--calcite-size-xxs)",
-          "docs": "size.default.xxs",
+          "docs": "size.xxs",
           "es6": "calciteSizeXxs"
         },
         "calcite-schema": {
@@ -23206,21 +23202,20 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Xxs",
-      "path": ["size", "default", "xxs"],
+      "path": ["size", "xxs"],
       "comment": "Deprecated, use --calcite-size-2xs instead."
     },
     {
-      "key": "{size.default.2xs}",
+      "key": "{size.2xs}",
       "value": "0.875rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "default",
-        "item": "2xs",
+        "type": "2xs",
         "names": {
           "scss": "$calcite-size-2xs",
           "css": "var(--calcite-size-2xs)",
-          "docs": "size.default.2xs",
+          "docs": "size.2xs",
           "es6": "calciteSize2xs"
         },
         "calcite-schema": {
@@ -23232,20 +23227,19 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size 2xs",
-      "path": ["size", "default", "2xs"]
+      "path": ["size", "2xs"]
     },
     {
-      "key": "{size.default.xs}",
+      "key": "{size.xs}",
       "value": "1rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "default",
-        "item": "xs",
+        "type": "xs",
         "names": {
           "scss": "$calcite-size-xs",
           "css": "var(--calcite-size-xs)",
-          "docs": "size.default.xs",
+          "docs": "size.xs",
           "es6": "calciteSizeXs"
         },
         "calcite-schema": {
@@ -23257,20 +23251,19 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Xs",
-      "path": ["size", "default", "xs"]
+      "path": ["size", "xs"]
     },
     {
-      "key": "{size.default.sm}",
+      "key": "{size.sm}",
       "value": "1.5rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "default",
-        "item": "sm",
+        "type": "sm",
         "names": {
           "scss": "$calcite-size-sm",
           "css": "var(--calcite-size-sm)",
-          "docs": "size.default.sm",
+          "docs": "size.sm",
           "es6": "calciteSizeSm"
         },
         "calcite-schema": {
@@ -23282,20 +23275,19 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Sm",
-      "path": ["size", "default", "sm"]
+      "path": ["size", "sm"]
     },
     {
-      "key": "{size.default.md}",
+      "key": "{size.md}",
       "value": "2rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "default",
-        "item": "md",
+        "type": "md",
         "names": {
           "scss": "$calcite-size-md",
           "css": "var(--calcite-size-md)",
-          "docs": "size.default.md",
+          "docs": "size.md",
           "es6": "calciteSizeMd"
         },
         "calcite-schema": {
@@ -23307,20 +23299,19 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Md",
-      "path": ["size", "default", "md"]
+      "path": ["size", "md"]
     },
     {
-      "key": "{size.default.lg}",
+      "key": "{size.lg}",
       "value": "2.75rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "default",
-        "item": "lg",
+        "type": "lg",
         "names": {
           "scss": "$calcite-size-lg",
           "css": "var(--calcite-size-lg)",
-          "docs": "size.default.lg",
+          "docs": "size.lg",
           "es6": "calciteSizeLg"
         },
         "calcite-schema": {
@@ -23332,20 +23323,19 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Lg",
-      "path": ["size", "default", "lg"]
+      "path": ["size", "lg"]
     },
     {
-      "key": "{size.default.xl}",
+      "key": "{size.xl}",
       "value": "3rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "default",
-        "item": "xl",
+        "type": "xl",
         "names": {
           "scss": "$calcite-size-xl",
           "css": "var(--calcite-size-xl)",
-          "docs": "size.default.xl",
+          "docs": "size.xl",
           "es6": "calciteSizeXl"
         },
         "calcite-schema": {
@@ -23357,28 +23347,27 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Xl",
-      "path": ["size", "default", "xl"]
+      "path": ["size", "xl"]
     },
     {
-      "key": "{size.default.xxl}",
+      "key": "{size.xxl}",
       "value": "4rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
         "type": "dimension",
-        "item": "xxl",
         "value": "64px",
         "description": "Deprecated, use --calcite-size-2xl instead.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
-        "key": "{size.default.xxl}",
-        "name": "calcite-size-default-xxl",
-        "path": ["size", "default", "xxl"],
+        "key": "{size.xxl}",
+        "name": "calcite-size-xxl",
+        "path": ["size", "xxl"],
         "comment": "Deprecated, use --calcite-size-2xl instead.",
         "names": {
           "scss": "$calcite-size-xxl",
           "css": "var(--calcite-size-xxl)",
-          "docs": "size.default.xxl",
+          "docs": "size.xxl",
           "es6": "calciteSizeXxl"
         },
         "calcite-schema": {
@@ -23391,21 +23380,20 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Xxl",
-      "path": ["size", "default", "xxl"],
+      "path": ["size", "xxl"],
       "comment": "Deprecated, use --calcite-size-2xl instead."
     },
     {
-      "key": "{size.default.2xl}",
+      "key": "{size.2xl}",
       "value": "4rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "default",
-        "item": "2xl",
+        "type": "2xl",
         "names": {
           "scss": "$calcite-size-2xl",
           "css": "var(--calcite-size-2xl)",
-          "docs": "size.default.2xl",
+          "docs": "size.2xl",
           "es6": "calciteSize2xl"
         },
         "calcite-schema": {
@@ -23417,28 +23405,27 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size 2xl",
-      "path": ["size", "default", "2xl"]
+      "path": ["size", "2xl"]
     },
     {
-      "key": "{size.default.xxxl}",
+      "key": "{size.xxxl}",
       "value": "6rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
         "type": "dimension",
-        "item": "xxxl",
         "value": "96px",
         "description": "Deprecated, use --calcite-size-3xl instead.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
-        "key": "{size.default.xxxl}",
-        "name": "calcite-size-default-xxxl",
-        "path": ["size", "default", "xxxl"],
+        "key": "{size.xxxl}",
+        "name": "calcite-size-xxxl",
+        "path": ["size", "xxxl"],
         "comment": "Deprecated, use --calcite-size-3xl instead.",
         "names": {
           "scss": "$calcite-size-xxxl",
           "css": "var(--calcite-size-xxxl)",
-          "docs": "size.default.xxxl",
+          "docs": "size.xxxl",
           "es6": "calciteSizeXxxl"
         },
         "calcite-schema": {
@@ -23451,21 +23438,20 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Xxxl",
-      "path": ["size", "default", "xxxl"],
+      "path": ["size", "xxxl"],
       "comment": "Deprecated, use --calcite-size-3xl instead."
     },
     {
-      "key": "{size.default.3xl}",
+      "key": "{size.3xl}",
       "value": "6rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "default",
-        "item": "3xl",
+        "type": "3xl",
         "names": {
           "scss": "$calcite-size-3xl",
           "css": "var(--calcite-size-3xl)",
-          "docs": "size.default.3xl",
+          "docs": "size.3xl",
           "es6": "calciteSize3xl"
         },
         "calcite-schema": {
@@ -23477,7 +23463,7 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size 3xl",
-      "path": ["size", "default", "3xl"]
+      "path": ["size", "3xl"]
     },
     {
       "key": "{spacing.fixed.xxs}",
@@ -30002,17 +29988,16 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "comment": "deprecated"
     },
     {
-      "key": "{size.default.px}",
+      "key": "{size.px}",
       "value": "1px",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "default",
-        "item": "px",
+        "type": "px",
         "names": {
           "scss": "$calcite-size-px",
           "css": "var(--calcite-size-px)",
-          "docs": "size.default.px",
+          "docs": "size.px",
           "es6": "calciteSizePx"
         },
         "calcite-schema": {
@@ -30024,28 +30009,27 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Px",
-      "path": ["size", "default", "px"]
+      "path": ["size", "px"]
     },
     {
-      "key": "{size.default.xxxs}",
+      "key": "{size.xxxs}",
       "value": "0.75rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
         "type": "dimension",
-        "item": "xxxs",
         "value": "12px",
         "description": "Deprecated, use --calcite-size-3xs instead.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
-        "key": "{size.default.xxxs}",
-        "name": "calcite-size-default-xxxs",
-        "path": ["size", "default", "xxxs"],
+        "key": "{size.xxxs}",
+        "name": "calcite-size-xxxs",
+        "path": ["size", "xxxs"],
         "comment": "Deprecated, use --calcite-size-3xs instead.",
         "names": {
           "scss": "$calcite-size-xxxs",
           "css": "var(--calcite-size-xxxs)",
-          "docs": "size.default.xxxs",
+          "docs": "size.xxxs",
           "es6": "calciteSizeXxxs"
         },
         "calcite-schema": {
@@ -30058,21 +30042,20 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Xxxs",
-      "path": ["size", "default", "xxxs"],
+      "path": ["size", "xxxs"],
       "comment": "Deprecated, use --calcite-size-3xs instead."
     },
     {
-      "key": "{size.default.3xs}",
+      "key": "{size.3xs}",
       "value": "0.75rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "default",
-        "item": "3xs",
+        "type": "3xs",
         "names": {
           "scss": "$calcite-size-3xs",
           "css": "var(--calcite-size-3xs)",
-          "docs": "size.default.3xs",
+          "docs": "size.3xs",
           "es6": "calciteSize3xs"
         },
         "calcite-schema": {
@@ -30084,28 +30067,27 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size 3xs",
-      "path": ["size", "default", "3xs"]
+      "path": ["size", "3xs"]
     },
     {
-      "key": "{size.default.xxs}",
+      "key": "{size.xxs}",
       "value": "0.875rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
         "type": "dimension",
-        "item": "xxs",
         "value": "14px",
         "description": "Deprecated, use --calcite-size-2xs instead.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
-        "key": "{size.default.xxs}",
-        "name": "calcite-size-default-xxs",
-        "path": ["size", "default", "xxs"],
+        "key": "{size.xxs}",
+        "name": "calcite-size-xxs",
+        "path": ["size", "xxs"],
         "comment": "Deprecated, use --calcite-size-2xs instead.",
         "names": {
           "scss": "$calcite-size-xxs",
           "css": "var(--calcite-size-xxs)",
-          "docs": "size.default.xxs",
+          "docs": "size.xxs",
           "es6": "calciteSizeXxs"
         },
         "calcite-schema": {
@@ -30118,21 +30100,20 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Xxs",
-      "path": ["size", "default", "xxs"],
+      "path": ["size", "xxs"],
       "comment": "Deprecated, use --calcite-size-2xs instead."
     },
     {
-      "key": "{size.default.2xs}",
+      "key": "{size.2xs}",
       "value": "0.875rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "default",
-        "item": "2xs",
+        "type": "2xs",
         "names": {
           "scss": "$calcite-size-2xs",
           "css": "var(--calcite-size-2xs)",
-          "docs": "size.default.2xs",
+          "docs": "size.2xs",
           "es6": "calciteSize2xs"
         },
         "calcite-schema": {
@@ -30144,20 +30125,19 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size 2xs",
-      "path": ["size", "default", "2xs"]
+      "path": ["size", "2xs"]
     },
     {
-      "key": "{size.default.xs}",
+      "key": "{size.xs}",
       "value": "1rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "default",
-        "item": "xs",
+        "type": "xs",
         "names": {
           "scss": "$calcite-size-xs",
           "css": "var(--calcite-size-xs)",
-          "docs": "size.default.xs",
+          "docs": "size.xs",
           "es6": "calciteSizeXs"
         },
         "calcite-schema": {
@@ -30169,20 +30149,19 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Xs",
-      "path": ["size", "default", "xs"]
+      "path": ["size", "xs"]
     },
     {
-      "key": "{size.default.sm}",
+      "key": "{size.sm}",
       "value": "1.5rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "default",
-        "item": "sm",
+        "type": "sm",
         "names": {
           "scss": "$calcite-size-sm",
           "css": "var(--calcite-size-sm)",
-          "docs": "size.default.sm",
+          "docs": "size.sm",
           "es6": "calciteSizeSm"
         },
         "calcite-schema": {
@@ -30194,20 +30173,19 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Sm",
-      "path": ["size", "default", "sm"]
+      "path": ["size", "sm"]
     },
     {
-      "key": "{size.default.md}",
+      "key": "{size.md}",
       "value": "2rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "default",
-        "item": "md",
+        "type": "md",
         "names": {
           "scss": "$calcite-size-md",
           "css": "var(--calcite-size-md)",
-          "docs": "size.default.md",
+          "docs": "size.md",
           "es6": "calciteSizeMd"
         },
         "calcite-schema": {
@@ -30219,20 +30197,19 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Md",
-      "path": ["size", "default", "md"]
+      "path": ["size", "md"]
     },
     {
-      "key": "{size.default.lg}",
+      "key": "{size.lg}",
       "value": "2.75rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "default",
-        "item": "lg",
+        "type": "lg",
         "names": {
           "scss": "$calcite-size-lg",
           "css": "var(--calcite-size-lg)",
-          "docs": "size.default.lg",
+          "docs": "size.lg",
           "es6": "calciteSizeLg"
         },
         "calcite-schema": {
@@ -30244,20 +30221,19 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Lg",
-      "path": ["size", "default", "lg"]
+      "path": ["size", "lg"]
     },
     {
-      "key": "{size.default.xl}",
+      "key": "{size.xl}",
       "value": "3rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "default",
-        "item": "xl",
+        "type": "xl",
         "names": {
           "scss": "$calcite-size-xl",
           "css": "var(--calcite-size-xl)",
-          "docs": "size.default.xl",
+          "docs": "size.xl",
           "es6": "calciteSizeXl"
         },
         "calcite-schema": {
@@ -30269,28 +30245,27 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Xl",
-      "path": ["size", "default", "xl"]
+      "path": ["size", "xl"]
     },
     {
-      "key": "{size.default.xxl}",
+      "key": "{size.xxl}",
       "value": "4rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
         "type": "dimension",
-        "item": "xxl",
         "value": "64px",
         "description": "Deprecated, use --calcite-size-2xl instead.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
-        "key": "{size.default.xxl}",
-        "name": "calcite-size-default-xxl",
-        "path": ["size", "default", "xxl"],
+        "key": "{size.xxl}",
+        "name": "calcite-size-xxl",
+        "path": ["size", "xxl"],
         "comment": "Deprecated, use --calcite-size-2xl instead.",
         "names": {
           "scss": "$calcite-size-xxl",
           "css": "var(--calcite-size-xxl)",
-          "docs": "size.default.xxl",
+          "docs": "size.xxl",
           "es6": "calciteSizeXxl"
         },
         "calcite-schema": {
@@ -30303,21 +30278,20 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Xxl",
-      "path": ["size", "default", "xxl"],
+      "path": ["size", "xxl"],
       "comment": "Deprecated, use --calcite-size-2xl instead."
     },
     {
-      "key": "{size.default.2xl}",
+      "key": "{size.2xl}",
       "value": "4rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "default",
-        "item": "2xl",
+        "type": "2xl",
         "names": {
           "scss": "$calcite-size-2xl",
           "css": "var(--calcite-size-2xl)",
-          "docs": "size.default.2xl",
+          "docs": "size.2xl",
           "es6": "calciteSize2xl"
         },
         "calcite-schema": {
@@ -30329,28 +30303,27 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size 2xl",
-      "path": ["size", "default", "2xl"]
+      "path": ["size", "2xl"]
     },
     {
-      "key": "{size.default.xxxl}",
+      "key": "{size.xxxl}",
       "value": "6rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
         "type": "dimension",
-        "item": "xxxl",
         "value": "96px",
         "description": "Deprecated, use --calcite-size-3xl instead.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
-        "key": "{size.default.xxxl}",
-        "name": "calcite-size-default-xxxl",
-        "path": ["size", "default", "xxxl"],
+        "key": "{size.xxxl}",
+        "name": "calcite-size-xxxl",
+        "path": ["size", "xxxl"],
         "comment": "Deprecated, use --calcite-size-3xl instead.",
         "names": {
           "scss": "$calcite-size-xxxl",
           "css": "var(--calcite-size-xxxl)",
-          "docs": "size.default.xxxl",
+          "docs": "size.xxxl",
           "es6": "calciteSizeXxxl"
         },
         "calcite-schema": {
@@ -30363,21 +30336,20 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Xxxl",
-      "path": ["size", "default", "xxxl"],
+      "path": ["size", "xxxl"],
       "comment": "Deprecated, use --calcite-size-3xl instead."
     },
     {
-      "key": "{size.default.3xl}",
+      "key": "{size.3xl}",
       "value": "6rem",
       "type": "dimension",
       "attributes": {
         "category": "size",
-        "type": "default",
-        "item": "3xl",
+        "type": "3xl",
         "names": {
           "scss": "$calcite-size-3xl",
           "css": "var(--calcite-size-3xl)",
-          "docs": "size.default.3xl",
+          "docs": "size.3xl",
           "es6": "calciteSize3xl"
         },
         "calcite-schema": {
@@ -30389,7 +30361,7 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size 3xl",
-      "path": ["size", "default", "3xl"]
+      "path": ["size", "3xl"]
     },
     {
       "key": "{spacing.fixed.xxs}",


### PR DESCRIPTION
**Related Issue:** #12089

## Summary

- final token names and values should be unaffected
- removes `default{}` in size.json (similar to #13354)