### PR TITLE
fix(action-bar, action-pad): remove topLayerDisabled property 

### DIFF
--- a/packages/components/src/components/action-bar/action-bar.tsx
+++ b/packages/components/src/components/action-bar/action-bar.tsx
@@ -216,15 +216,6 @@ export class ActionBar extends LitElement {
     SelectionAppearance
   > = "neutral";
 
-  /**
-   * When `true` and the component is `open`, disables top layer placement.
-   *
-   * Only set this if you need complex z-index control or if top layer placement causes conflicts with third-party components.
-   *
-   * @mdn [Top Layer](https://developer.mozilla.org/en-US/docs/Glossary/Top_layer)
-   */
-  @property({ reflect: true }) topLayerDisabled = false;
-
   //#endregion
 
   //#region Public Methods
@@ -504,7 +495,6 @@ export class ActionBar extends LitElement {
         layout={layout}
         overlayPositioning={overlayPositioning}
         scale={scale}
-        topLayerDisabled={this.topLayerDisabled}
       >
         <slot name={SLOTS.actionsEnd} onSlotChange={this.handleActionsEndSlotChange} />
         <slot name={SLOTS.expandTooltip} onSlotChange={this.handleTooltipSlotChange} />

--- a/packages/components/src/components/action-pad/action-pad.tsx
+++ b/packages/components/src/components/action-pad/action-pad.tsx
@@ -107,15 +107,6 @@ export class ActionPad extends LitElement {
     SelectionAppearance
   > = "neutral";
 
-  /**
-   * When `true` and the component is `open`, disables top layer placement.
-   *
-   * Only set this if you need complex z-index control or if top layer placement causes conflicts with third-party components.
-   *
-   * @mdn [Top Layer](https://developer.mozilla.org/en-US/docs/Glossary/Top_layer)
-   */
-  @property({ reflect: true }) topLayerDisabled = false;
-
   //#endregion
 
   //#region Public Methods
@@ -337,7 +328,6 @@ export class ActionPad extends LitElement {
         layout={layout}
         overlayPositioning={overlayPositioning}
         scale={scale}
-        topLayerDisabled={this.topLayerDisabled}
       >
         <slot name={SLOTS.expandTooltip} onSlotChange={this.handleTooltipSlotChange} />
         {expandToggleNode}


### PR DESCRIPTION
**Related Issue:** #13698

## Summary

Removes the `topLayerDisabled` property from `action-bar` and `action-pad` since the use of this property is not necessary as the `action-group` within the shadow DOM would never show an `action-menu`.