### PR TITLE
docs: align component api documentation with style guide

### DIFF
--- a/packages/components/src/components/date-picker/date-picker.scss
+++ b/packages/components/src/components/date-picker/date-picker.scss
@@ -5,29 +5,29 @@
  *
  * @prop --calcite-date-picker-border-color: Specifies the component's border color.
  * @prop --calcite-date-picker-corner-radius: Specifies the component's border radius.
- * @prop --calcite-date-picker-range-calendar-divider-color: Specifies the divider color between calendar's when `range="true"`.
- * @prop --calcite-date-picker-week-header-text-color: Specifies the week header text color.
- * @prop --calcite-date-picker-header-action-background-color: Specifies the background color of header action's of the component.
- * @prop --calcite-date-picker-header-action-background-color-hover: Specifies the background color of header action's of the component when hovered.
- * @prop --calcite-date-picker-header-action-background-color-press: Specifies the background color of header action's of the component when pressed.
- * @prop --calcite-date-picker-header-action-text-color: Specifies the text color of header action's of the component.
- * @prop --calcite-date-picker-header-action-text-color-press: Specifies the text color of header action's of the component when pressed.
- * @prop --calcite-date-picker-year-text-color: Specifies the text color of year & suffix of the component.
- * @prop --calcite-date-picker-month-select-font-size: Specifies the font size of month select of the component.
- * @prop --calcite-date-picker-month-select-text-color: Specifies the text color of month select of the component.
- * @prop --calcite-date-picker-month-select-icon-color: Specifies the icon color of month select of the component.
- * @prop --calcite-date-picker-month-select-icon-color-hover: Specifies the icon color of month select of the component when hovered.
- * @prop --calcite-date-picker-day-background-color: Specifies the background color of day of the component.
- * @prop --calcite-date-picker-day-background-color-hover: Specifies the background color of day of the component when hovered.
- * @prop --calcite-date-picker-day-text-color: Specifies the text color of day of the component.
- * @prop --calcite-date-picker-day-text-color-hover: Specifies the text color of day of the component when hovered.
- * @prop --calcite-date-picker-current-day-text-color: Specifies the text color of current day of the component.
- * @prop --calcite-date-picker-day-background-color-selected: Specifies the background color of selected day of the component.
- * @prop --calcite-date-picker-day-text-color-selected: Specifies the text color of selected day of the component.
- * @prop --calcite-date-picker-day-range-text-color: Specifies the text color of select day range of the component.
- * @prop --calcite-date-picker-day-range-background-color: Specifies the background color of select day range of the component.
- * @prop --calcite-date-picker-day-outside-range-background-color-hover: Specifies the background color of day's outside current range when hovered.
- * @prop --calcite-date-picker-day-outside-range-text-color-hover: Specifies the text color of day's outside current range when hovered.
+ * @prop --calcite-date-picker-range-calendar-divider-color: When `range` is `true`, specifies the divider color between the component's calendars.
+ * @prop --calcite-date-picker-week-header-text-color: Specifies the text color of the component's week header.
+ * @prop --calcite-date-picker-header-action-background-color: Specifies the background color of component`s header actions.
+ * @prop --calcite-date-picker-header-action-background-color-hover: Specifies the background color of component`s header actions when hovered.
+ * @prop --calcite-date-picker-header-action-background-color-press: Specifies the background color of component`s header actions when pressed.
+ * @prop --calcite-date-picker-header-action-text-color: Specifies the text color of the component's header actions.
+ * @prop --calcite-date-picker-header-action-text-color-press: Specifies the text color of the component's header actions when pressed.
+ * @prop --calcite-date-picker-year-text-color: Specifies the text color of the component's year and suffix.
+ * @prop --calcite-date-picker-month-select-font-size: Specifies the font size of the component's month selector.
+ * @prop --calcite-date-picker-month-select-text-color: Specifies the text color of the component's month selector.
+ * @prop --calcite-date-picker-month-select-icon-color: Specifies the icon color of the component's month selector.
+ * @prop --calcite-date-picker-month-select-icon-color-hover: Specifies the icon color of the component's month selector when hovered.
+ * @prop --calcite-date-picker-day-background-color: Specifies the background color of the component's day elements.
+ * @prop --calcite-date-picker-day-background-color-hover: Specifies the background color of the component's day elements when hovered.
+ * @prop --calcite-date-picker-day-text-color: Specifies the text color of the component's day elements.
+ * @prop --calcite-date-picker-day-text-color-hover: Specifies the text color of the component's day elements when hovered.
+ * @prop --calcite-date-picker-current-day-text-color: Specifies the text color of the component's current day.
+ * @prop --calcite-date-picker-day-background-color-selected: Specifies the background color of the component's selected day.
+ * @prop --calcite-date-picker-day-text-color-selected: Specifies the text color of the component's selected day elements.
+ * @prop --calcite-date-picker-day-range-text-color: Specifies the text color of component's selected day range.
+ * @prop --calcite-date-picker-day-range-background-color: Specifies the background color the component's selected day range.
+ * @prop --calcite-date-picker-day-outside-range-background-color-hover: Specifies the background color of the component's day elements outside the current range when hovered.
+ * @prop --calcite-date-picker-day-outside-range-text-color-hover: Specifies the text color of the component's day elements outside the current range when hovered.
  *
 */
 

--- a/packages/components/src/components/date-picker/date-picker.tsx
+++ b/packages/components/src/components/date-picker/date-picker.tsx
@@ -89,16 +89,16 @@ export class DatePicker extends LitElement {
   /** Specifies the component's active date. */
   @property() activeDate: Date;
 
-  /** When `range` is true, specifies the active `range`. Where `"start"` specifies the starting range date and `"end"` the ending range date. */
+  /** When `range` is `true`, specifies the active `range`. Where `"start"` specifies the starting range date and `"end"` the ending range date. */
   @property({ reflect: true }) activeRange: "start" | "end";
 
-  /** Specifies the number of calendars displayed when `range` is `true`. */
+  /** When `range` is `true`, specifies the number of calendars displayed. */
   @property({ type: Number, reflect: true }) calendars: 1 | 2 = 2;
 
   /** Specifies the heading level number of the component's `heading` for proper document structure, without affecting visual styling. */
   @property({ type: Number, reflect: true }) headingLevel: HeadingLevel;
 
-  /** Defines the layout of the component. */
+  /** Defines the component's layout. */
   @property({ reflect: true }) layout: "horizontal" | "vertical" = "horizontal";
 
   /**
@@ -122,7 +122,7 @@ export class DatePicker extends LitElement {
   /** Specifies the earliest allowed date as a full date object (`new Date("yyyy-mm-dd")`). */
   @property() minAsDate: Date;
 
-  /** Specifies the monthStyle used by the component. */
+  /** Specifies the component's month style. */
   @property() monthStyle: "abbreviated" | "wide" = "wide";
 
   /** Specifies the Unicode numeral system used by the component for localization. This property cannot be dynamically changed. */

--- a/packages/components/src/components/dialog/dialog.scss
+++ b/packages/components/src/components/dialog/dialog.scss
@@ -22,11 +22,11 @@
  * @prop --calcite-dialog-heading-text-color: Specifies the text color of the component's `heading`.
  * @prop --calcite-dialog-description-text-color: Specifies the text color of the component's `description`.
  * @prop --calcite-dialog-header-background-color: Specifies the background color of the component's header.
- * @prop --calcite-dialog-header-action-background-color: Specifies the background color of `closable`, `collapsible`, and elements slotted in `header-menu-actions`.
- * @prop --calcite-dialog-header-action-background-color-hover: Specifies the background color of `closable`, `collapsible`, and elements slotted in `header-menu-actions` when hovered.
- * @prop --calcite-dialog-header-action-background-color-press: Specifies the background color of `closable`, `collapsible`, and elements slotted in `header-menu-actions` when pressed.
- * @prop --calcite-dialog-header-action-text-color: Specifies the text color of `closable`, `collapsible`, and elements slotted in `header-menu-actions`.
- * @prop --calcite-dialog-header-action-text-color-press: Specifies the text color of `closable`, `collapsible`, and elements slotted in `header-menu-actions` when pressed or hovered.
+ * @prop --calcite-dialog-header-action-background-color: Specifies the background color of the component's `closable`, `collapsible`, and slotted `header-menu-actions` `calcite-action`s.
+ * @prop --calcite-dialog-header-action-background-color-hover: Specifies the background color of the component's `closable`, `collapsible`, and slotted `header-menu-actions` `calcite-action`s when hovered.
+ * @prop --calcite-dialog-header-action-background-color-press: Specifies the background color of the component's `closable`, `collapsible`, and slotted `header-menu-actions` `calcite-action`s when pressed.
+ * @prop --calcite-dialog-header-action-text-color: Specifies the text color of the component's `closable`, `collapsible`, and slotted `header-menu-actions` `calcite-action`s.
+ * @prop --calcite-dialog-header-action-text-color-press: Specifies the text color of the component's `closable`, `collapsible`, and slotted `header-menu-actions` `calcite-action`s when pressed or hovered.
  * @prop --calcite-dialog-footer-background-color: Specifies the background color of the component's footer.
  * @prop --calcite-dialog-space: Specifies the padding of the component's `unnamed (default)` slot.
  * @prop --calcite-dialog-header-content-space: Specifies the padding of the component's `header-content` slot.

--- a/packages/components/src/components/dialog/dialog.scss
+++ b/packages/components/src/components/dialog/dialog.scss
@@ -4,32 +4,32 @@
  * These properties can be overridden using the component's tag as selector.
  *
  * @prop --calcite-dialog-scrim-background-color: Specifies the background color of the component's scrim.
- * @prop --calcite-dialog-size-x: Specifies the width of the component, using `px`, `em`, `rem`, `vw`, or `%`. Does not exceed the viewport's width - applies when `placement="cover"` is set.
- * @prop --calcite-dialog-min-size-x: Specifies the minimum width of the component, using `px`, `em`, `rem`, `vw`, or `%`.
- * @prop --calcite-dialog-max-size-x: Specifies the maximum width of the component, using `px`, `em`, `rem`, `vw`, or `%`.
- * @prop --calcite-dialog-size-y: Specifies the height of the component, using `px`, `em`, `rem`, `vh`, or `%`. Does not exceed the viewport's height - applies when `placement="cover"` is set.
- * @prop --calcite-dialog-min-size-y: Specifies the minimum height of the component, using `px`, `em`, `rem`, `vh`, or `%`.
- * @prop --calcite-dialog-max-size-y: Specifies the maximum height of the component, using `px`, `em`, `rem`, `vh`, or `%`.
+ * @prop --calcite-dialog-size-x: When `placement` is `"cover"`, specifies the component's width, using `px`, `em`, `rem`, `vw`, or `%`. Does not exceed the viewport's width.
+ * @prop --calcite-dialog-min-size-x: Specifies the component's minimum width, using `px`, `em`, `rem`, `vw`, or `%`.
+ * @prop --calcite-dialog-max-size-x: Specifies the component's maximum width, using `px`, `em`, `rem`, `vw`, or `%`.
+ * @prop --calcite-dialog-size-y: When `placement` is `"cover"`, specifies the component's height, using `px`, `em`, `rem`, `vh`, or `%`. Does not exceed the viewport's height.
+ * @prop --calcite-dialog-min-size-y: Specifies the component's minimum height, using `px`, `em`, `rem`, `vh`, or `%`.
+ * @prop --calcite-dialog-max-size-y: Specifies the component's maximum height, using `px`, `em`, `rem`, `vh`, or `%`.
  * @prop --calcite-dialog-content-space: Specifies the padding of the component's content.
  * @prop --calcite-dialog-footer-space: Specifies the padding of the component's footer.
  * @prop --calcite-dialog-border-color: Specifies the component's border color.
- * @prop --calcite-dialog-offset-x: Specifies the horizontal offset of the component.
- * @prop --calcite-dialog-offset-y: Specifies the vertical offset of the component.
- * @prop --calcite-dialog-background-color: Specifies the background color of the component.
+ * @prop --calcite-dialog-offset-x: Specifies the component's horizontal offset.
+ * @prop --calcite-dialog-offset-y: Specifies the component's vertical offset.
+ * @prop --calcite-dialog-background-color: Specifies the component's background color.
  * @prop --calcite-dialog-icon-color: Specifies the color of the component's icon.
- * @prop --calcite-dialog-accent-color: Specifies the component's accent color when `kind` is specified.
+ * @prop --calcite-dialog-accent-color: When `kind` is specified, specifies the component's accent color.
  * @prop --calcite-dialog-corner-radius: Specifies the component's corner radius.
  * @prop --calcite-dialog-heading-text-color: Specifies the text color of the component's `heading`.
  * @prop --calcite-dialog-description-text-color: Specifies the text color of the component's `description`.
  * @prop --calcite-dialog-header-background-color: Specifies the background color of the component's header.
- * @prop --calcite-dialog-header-action-background-color: Specifies the background color of Panel's `closable`, `collapsible`, and elements slotted in `header-menu-actions`.
- * @prop --calcite-dialog-header-action-background-color-hover: Specifies the background color of Panel's `closable`, `collapsible`, and elements slotted in `header-menu-actions` when hovered.
- * @prop --calcite-dialog-header-action-background-color-press: Specifies the background color of Panel's `closable`, `collapsible`, and elements slotted in `header-menu-actions` when pressed.
- * @prop --calcite-dialog-header-action-text-color: Specifies the text color of Panel's `closable`, `collapsible`, and elements slotted in `header-menu-actions`.
- * @prop --calcite-dialog-header-action-text-color-press: Specifies the text color of Panel's `closable`, `collapsible`, and elements slotted in `header-menu-actions` when pressed or hovered.
+ * @prop --calcite-dialog-header-action-background-color: Specifies the background color of `closable`, `collapsible`, and elements slotted in `header-menu-actions`.
+ * @prop --calcite-dialog-header-action-background-color-hover: Specifies the background color of `closable`, `collapsible`, and elements slotted in `header-menu-actions` when hovered.
+ * @prop --calcite-dialog-header-action-background-color-press: Specifies the background color of `closable`, `collapsible`, and elements slotted in `header-menu-actions` when pressed.
+ * @prop --calcite-dialog-header-action-text-color: Specifies the text color of `closable`, `collapsible`, and elements slotted in `header-menu-actions`.
+ * @prop --calcite-dialog-header-action-text-color-press: Specifies the text color of `closable`, `collapsible`, and elements slotted in `header-menu-actions` when pressed or hovered.
  * @prop --calcite-dialog-footer-background-color: Specifies the background color of the component's footer.
- * @prop --calcite-dialog-space: Specifies the padding of the component's `"unnamed (default)"` slot.
- * @prop --calcite-dialog-header-content-space: Specifies the padding of the `"header-content"` slot.
+ * @prop --calcite-dialog-space: Specifies the padding of the component's `unnamed (default)` slot.
+ * @prop --calcite-dialog-header-content-space: Specifies the padding of the component's `header-content` slot.
  * @prop --calcite-dialog-action-menu-border-color: Specifies the border color of the component's internally rendered `calcite-popover`, which is rendered within a `calcite-action` menu when slotted `calcite-action`s are present in the `header-actions-end` slot. Applies to any slotted `calcite-popover`s.
  */
 

--- a/packages/components/src/components/dialog/dialog.tsx
+++ b/packages/components/src/components/dialog/dialog.tsx
@@ -33,7 +33,7 @@ declare global {
 
 /**
  * @slot - A slot for adding content.
- * @slot custom-content - A slot for displaying custom content. Will prevent the rendering of any default Dialog UI, except for `box-shadow` and `corner-radius`.
+ * @slot custom-content - A slot for displaying custom content. Will prevent the rendering of any default component UI, except for `box-shadow` and `corner-radius`.
  * @slot action-bar - A slot for adding a `calcite-action-bar` to the component.
  * @slot alerts - A slot for adding `calcite-alert`s to the component.
  * @slot content-bottom - A slot for adding content below the unnamed (default) slot and - if populated - the `footer` slot.
@@ -43,9 +43,9 @@ declare global {
  * @slot header-content - A slot for adding custom content to the component's header.
  * @slot header-menu-actions - A slot for adding an overflow menu with actions inside a `calcite-dropdown`.
  * @slot fab - A slot for adding a `calcite-fab` (floating action button) to perform an action.
- * @slot footer - A slot for adding custom content to the component's footer. Should not be used with the `"footer-start"` or `"footer-end"` slots.
- * @slot footer-end - A slot for adding a trailing footer custom content. Should not be used with the `"footer"` slot.
- * @slot footer-start - A slot for adding a leading footer custom content. Should not be used with the `"footer"` slot.
+ * @slot footer - A slot for adding custom content to the component's footer. Should not be used with the `footer-start` or `footer-end` slots.
+ * @slot footer-end - A slot for adding a trailing footer custom content. Should not be used with the `footer` slot.
+ * @slot footer-start - A slot for adding a leading footer custom content. Should not be used with the `footer` slot.
  */
 export class Dialog extends LitElement {
   //#region Static Members
@@ -132,13 +132,13 @@ export class Dialog extends LitElement {
 
   //#region Public Properties
 
-  /** Passes a function to run before the component closes. */
+  /** Specifies a function to run before the component closes. */
   @property() beforeClose: () => Promise<void>;
 
   /** When `true`, disables the component's close button. */
   @property({ reflect: true }) closeDisabled = false;
 
-  /** Specifies a description for the component. */
+  /** Specifies the component's description. */
   @property() description: string;
 
   /** When `true`, the component is draggable. */
@@ -181,7 +181,7 @@ export class Dialog extends LitElement {
   /** Specifies the heading level number of the component's `heading` for proper document structure, without affecting visual styling. */
   @property({ type: Number, reflect: true }) headingLevel: HeadingLevel;
 
-  /** Specifies the kind of the component, which will style the top border. */
+  /** Specifies the component's kind, which determines the top border styling. */
   @property({ reflect: true }) kind: Extract<
     "brand" | "danger" | "info" | "success" | "warning",
     Kind
@@ -190,7 +190,7 @@ export class Dialog extends LitElement {
   /** Specifies an icon to display. */
   @property({ reflect: true, type: String }) icon: IconName;
 
-  /** When `true`, the icon will be flipped when the element direction is right-to-left (`"rtl"`). */
+  /** When `true` and the element direction is right-to-left (`"rtl"`), flips the component`s `icon`. */
   @property({ reflect: true }) iconFlipRtl = false;
 
   /** When `true`, a busy indicator is displayed. */
@@ -232,7 +232,7 @@ export class Dialog extends LitElement {
    */
   @property({ reflect: true }) overlayPositioning: OverlayPositioning = "absolute";
 
-  /** Specifies the placement of the dialog. */
+  /** Specifies the component's placement. */
   @property({ reflect: true }) placement: DialogPlacement = "center";
 
   /** When `true`, the component is resizable. */
@@ -251,13 +251,13 @@ export class Dialog extends LitElement {
   @property({ reflect: true }) topLayerDisabled = false;
 
   /**
-   * Specifies the width of the component.
+   * Specifies the component's width.
    *
    * @deprecated in v3.0.0, removal target v6.0.0 - Use the `width` property instead.
    */
   @property({ reflect: true }) widthScale: Scale = "m";
 
-  /** Specifies the width of the component. */
+  /** Specifies the component's width. */
   @property({ reflect: true }) width: Extract<Width, Scale>;
 
   //#endregion
@@ -320,10 +320,10 @@ export class Dialog extends LitElement {
   /** Fires when the component is closed and animation is complete. */
   calciteDialogClose = createEvent({ cancelable: false });
 
-  /** Fires when the component is open and animation is complete. */
+  /** Fires when the component is opened and animation is complete. */
   calciteDialogOpen = createEvent({ cancelable: false });
 
-  /** Fires when the content is scrolled. */
+  /** Fires when the component's content is scrolled. */
   calciteDialogScroll = createEvent({ cancelable: false });
 
   //#endregion

--- a/packages/components/src/components/dropdown-group/dropdown-group.scss
+++ b/packages/components/src/components/dropdown-group/dropdown-group.scss
@@ -3,7 +3,7 @@
 *
 * These properties can be overridden using the component's tag as selector.
 *
-* @prop --calcite-dropdown-group-border-color: Specifies the `calcite-dropdown`'s border color.
+* @prop --calcite-dropdown-group-border-color: Specifies the components's border color.
 * @prop --calcite-dropdown-group-title-text-color: Specifies the component's `groupTitle` color.
 */
 

--- a/packages/components/src/components/dropdown-group/dropdown-group.tsx
+++ b/packages/components/src/components/dropdown-group/dropdown-group.tsx
@@ -39,7 +39,7 @@ export class DropdownGroup extends LitElement {
 
   // #region Public Properties
 
-  /** Specifies a group title to display. */
+  /** When specified, displays a group title. */
   @property({ reflect: true }) groupTitle: string;
 
   /**

--- a/packages/components/src/components/dropdown-group/dropdown-group.tsx
+++ b/packages/components/src/components/dropdown-group/dropdown-group.tsx
@@ -39,7 +39,7 @@ export class DropdownGroup extends LitElement {
 
   // #region Public Properties
 
-  /** Specifies and displays a group title. */
+  /** Specifies a group title to display. */
   @property({ reflect: true }) groupTitle: string;
 
   /**

--- a/packages/components/src/components/dropdown-item/dropdown-item.scss
+++ b/packages/components/src/components/dropdown-item/dropdown-item.scss
@@ -3,12 +3,12 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-dropdown-item-background-color-hover: Specifies the item's background color when hovered.
- * @prop --calcite-dropdown-item-background-color-press: Specifies the item's background color when selected or active.
- * @prop --calcite-dropdown-item-icon-color-hover: [Deprecated] Specifies the item's icon selection color when hovered.
- * @prop --calcite-dropdown-item-icon-color-press: Specifies the item's icon selection color when selected or active.
- * @prop --calcite-dropdown-item-text-color-press: Specifies the item's text when selected or active.
- * @prop --calcite-dropdown-item-text-color: Specifies the item's text color.
+ * @prop --calcite-dropdown-item-background-color-hover: Specifies the component's background color when hovered.
+ * @prop --calcite-dropdown-item-background-color-press: Specifies the components's background color when `selected` or active.
+ * @prop --calcite-dropdown-item-icon-color-hover: [Deprecated] Specifies the color of the component's selection icon when hovered.
+ * @prop --calcite-dropdown-item-icon-color-press: Specifies the color of the component's selection icon when `selected` or active.
+ * @prop --calcite-dropdown-item-text-color-press: Specifies the component's text color when `selected` or active.
+ * @prop --calcite-dropdown-item-text-color: Specifies the component's text color.
 */
 
 // AUTO-GENERATED — do not modify. Changes will be overwritten.

--- a/packages/components/src/components/dropdown-item/dropdown-item.tsx
+++ b/packages/components/src/components/dropdown-item/dropdown-item.tsx
@@ -56,7 +56,7 @@ export class DropdownItem extends LitElement {
 
   //#region Public Properties
 
-  /** When `true`, interaction is prevented and the component is displayed with lower opacity. */
+  /** When `true`, prevents interaction and decreases the component's opacity. */
   @property({ reflect: true }) disabled = false;
 
   /**
@@ -69,7 +69,7 @@ export class DropdownItem extends LitElement {
   /** Specifies an icon to display at the end of the component. */
   @property({ reflect: true, type: String }) iconEnd: IconName;
 
-  /** Displays the `iconStart` and/or `iconEnd` as flipped when the element direction is right-to-left (`"rtl"`). */
+  /** When the element direction is right-to-left (`"rtl"`), flips the component's `iconStart` and/or `iconEnd`. */
   @property({ reflect: true }) iconFlipRtl: FlipContext;
 
   /** Specifies an icon to display at the start of the component. */
@@ -78,7 +78,7 @@ export class DropdownItem extends LitElement {
   /** Specifies an accessible label for the component. */
   @property() label: string;
 
-  /** Specifies the relationship to the linked document defined in `href`. */
+  /** Specifies the relationship to the linked resource defined in `href`. */
   @property({ reflect: true }) rel: string;
 
   /**
@@ -101,7 +101,7 @@ export class DropdownItem extends LitElement {
    */
   @property() selectionMode: Extract<"none" | "single" | "multiple", SelectionMode> = "single";
 
-  /** Specifies the frame or window to open the linked document. */
+  /** Specifies the frame or window to open the linked resource. */
   @property({ reflect: true }) target: string;
 
   //#endregion

--- a/packages/components/src/components/dropdown/dropdown.tsx
+++ b/packages/components/src/components/dropdown/dropdown.tsx
@@ -40,7 +40,7 @@ declare global {
 
 /**
  * @slot - A slot for adding `calcite-dropdown-group` elements. Every `calcite-dropdown-item` must have a parent `calcite-dropdown-group`, even if the `groupTitle` property is not set.
- * @slot trigger - A slot for the element that triggers the `calcite-dropdown`.
+ * @slot trigger - A slot for the element that triggers the component.
  */
 export class Dropdown extends LitElement implements FloatingUIComponent {
   //#region Static Members
@@ -101,15 +101,15 @@ export class Dropdown extends LitElement implements FloatingUIComponent {
    */
   @property({ reflect: true }) closeOnSelectDisabled = false;
 
-  /** When `true`, interaction is prevented and the component is displayed with lower opacity. */
+  /** When `true`, prevents interaction and decreases the component's opacity. */
   @property({ reflect: true }) disabled = false;
 
-  /** Specifies the component's fallback `placement` for slotted `calcite-dropdown-items` when their initial or specified `placement` has insufficient space available. */
+  /** Specifies the component's fallback `placement` for slotted `calcite-dropdown-item`s when their initial or specified `placement` has insufficient space available. */
   @property() flipPlacements: FlipPlacement[];
 
   /**
-   * Specifies the maximum number of `calcite-dropdown-item`s to display before showing a scroller.
-   * Value must be greater than `0`, and does not include `groupTitle`'s from `calcite-dropdown-group`.
+   * Specifies the maximum number of `calcite-dropdown-item`s to display before showing a scrollbar.
+   * Value must be greater than `0`, and does not include `groupTitle`s from `calcite-dropdown-group`.
    */
   @property({ reflect: true }) maxItems = 0;
 
@@ -134,7 +134,7 @@ export class Dropdown extends LitElement implements FloatingUIComponent {
   @property({ reflect: true }) overlayPositioning: OverlayPositioning = "absolute";
 
   /**
-   * Determines where the component will be positioned relative to the container element.
+   * Determines the component's placement relative to the container element.
    */
   @property({ reflect: true }) placement: MenuPlacement = defaultMenuPlacement;
 
@@ -142,7 +142,7 @@ export class Dropdown extends LitElement implements FloatingUIComponent {
   @property({ reflect: true }) scale: Scale = "m";
 
   /**
-   * Specifies the component's selected items.
+   * The component's selected items.
    *
    * @readonly
    */
@@ -157,17 +157,17 @@ export class Dropdown extends LitElement implements FloatingUIComponent {
    */
   @property({ reflect: true }) topLayerDisabled = false;
 
-  /** Specifies the action to open the component from the container element. */
+  /** Specifies the type of action on the container element to open the component. */
   @property({ reflect: true }) type: "hover" | "click" = "click";
 
   /**
-   * Specifies the width of the component.
+   * Specifies the component's width.
    *
    * @deprecated in v3.0.0, removal target v6.0.0 - Use the `width` property instead.
    */
   @property({ reflect: true }) widthScale: Scale;
 
-  /** Specifies the width of the component. */
+  /** Specifies the component's width. */
   @property({ reflect: true }) width: Extract<Width, Scale>;
 
   //#endregion
@@ -175,7 +175,7 @@ export class Dropdown extends LitElement implements FloatingUIComponent {
   //#region Public Methods
 
   /**
-   * Updates the position of the component.
+   * Updates the component's position.
    *
    * @param delayed
    */
@@ -232,7 +232,7 @@ export class Dropdown extends LitElement implements FloatingUIComponent {
   /** Fires when the component is closed and animation is complete. */
   calciteDropdownClose = createEvent({ cancelable: false });
 
-  /** Fires when the component is open and animation is complete. */
+  /** Fires when the component is opened and animation is complete. */
   calciteDropdownOpen = createEvent({ cancelable: false });
 
   /** Fires when a `calcite-dropdown-item`'s selection changes. */

--- a/packages/components/src/components/dropdown/dropdown.tsx
+++ b/packages/components/src/components/dropdown/dropdown.tsx
@@ -114,11 +114,11 @@ export class Dropdown extends LitElement implements FloatingUIComponent {
   @property({ reflect: true }) maxItems = 0;
 
   /**
-   * Offset the position of the component away from the `referenceElement`.
+   * Specifies the distance to position the component away from the `referenceElement`.
    */
   @property({ type: Number, reflect: true }) offsetDistance = 0;
 
-  /** Offset the position of the component along the `referenceElement`. */
+  /** Specifies the distance to position the component along the `referenceElement`. */
   @property({ reflect: true }) offsetSkidding = 0;
 
   /** When `true`, displays and positions the component. */

--- a/packages/components/src/components/fab/fab.tsx
+++ b/packages/components/src/components/fab/fab.tsx
@@ -33,10 +33,10 @@ export class Fab extends LitElement {
 
   //#region Public Properties
 
-  /** Specifies the appearance style of the component. */
+  /** Specifies the component's appearance style. */
   @property({ reflect: true }) appearance: Extract<"solid" | "outline-fill", Appearance> = "solid";
 
-  /** When `true`, interaction is prevented and the component is displayed with lower opacity. */
+  /** When `true`, prevents interaction and decreases the component's opacity. */
   @property({ reflect: true }) disabled = false;
 
   /**
@@ -44,10 +44,10 @@ export class Fab extends LitElement {
    */
   @property({ reflect: true, type: String }) icon: IconName = ICONS.plus;
 
-  /** When `true`, the icon will be flipped when the element direction is right-to-left (`"rtl"`). */
+  /** When `true` and the element direction is right-to-left (`"rtl"`), flips the component`s `icon`. */
   @property({ reflect: true }) iconFlipRtl = false;
 
-  /** Specifies the kind of the component, which will apply to border and background. */
+  /** Specifies the component's kind, which determines border and background styling. */
   @property({ reflect: true }) kind: Extract<"brand" | "danger" | "inverse" | "neutral", Kind> =
     "brand";
 

--- a/packages/components/src/components/filter/filter.scss
+++ b/packages/components/src/components/filter/filter.scss
@@ -3,21 +3,21 @@
  *
  * @prop --calcite-filter-content-space: Specifies the padding of the component's content.
  *
- * @prop --calcite-filter-input-background-color: Specifies the input's background color.
- * @prop --calcite-filter-input-border-color: Specifies the input's border color.
- * @prop --calcite-filter-input-corner-radius: Specifies the input's corner radius.
- * @prop --calcite-filter-input-shadow: Specifies the shadow around the input.
+ * @prop --calcite-filter-input-background-color: Specifies the component's input background color.
+ * @prop --calcite-filter-input-border-color: Specifies the component's input border color.
+ * @prop --calcite-filter-input-corner-radius: Specifies the component's input corner radius.
+ * @prop --calcite-filter-input-shadow: Specifies the component's input shadow.
  *
- * @prop --calcite-filter-input-icon-color: Specifies the input's icon color.
- * @prop --calcite-filter-input-text-color: Specifies the input's text color.
- * @prop --calcite-filter-input-placeholder-text-color: Specifies the input's placeholder text color.
+ * @prop --calcite-filter-input-icon-color: Specifies the component's input icon color.
+ * @prop --calcite-filter-input-text-color: Specifies the component's input text color.
+ * @prop --calcite-filter-input-placeholder-text-color: Specifies the component's input placeholder text color.
  *
- * @prop --calcite-filter-input-actions-background-color: Specifies the background color of the input's `clearable` element.
- * @prop --calcite-filter-input-actions-background-color-hover: Specifies the background color of the input's `clearable` element when hovered.
- * @prop --calcite-filter-input-actions-background-color-press: Specifies the background color of the input's `clearable` element when pressed.
- * @prop --calcite-filter-input-actions-icon-color: Specifies the icon color of the input's `clearable` element.
- * @prop --calcite-filter-input-actions-icon-color-hover: Specifies the icon color of the input's `clearable` element when hovered.
- * @prop --calcite-filter-input-actions-icon-color-press: Specifies the icon color of the input's `clearable` element when pressed.
+ * @prop --calcite-filter-input-actions-background-color: Specifies the background color of the component's input `clearable` element.
+ * @prop --calcite-filter-input-actions-background-color-hover: Specifies the background color of the component's input `clearable` element when hovered.
+ * @prop --calcite-filter-input-actions-background-color-press: Specifies the background color of the component's input `clearable` element when pressed.
+ * @prop --calcite-filter-input-actions-icon-color: Specifies the icon color of the component's input `clearable` element.
+ * @prop --calcite-filter-input-actions-icon-color-hover: Specifies the icon color of the component's input `clearable` element when hovered.
+ * @prop --calcite-filter-input-actions-icon-color-press: Specifies the icon color of the component's input `clearable` element when pressed.
  */
 
 @use "../../styles/includes";

--- a/packages/components/src/components/filter/filter.tsx
+++ b/packages/components/src/components/filter/filter.tsx
@@ -58,10 +58,10 @@ export class Filter extends LitElement {
 
   //#region Public Properties
 
-  /** When `true`, interaction is prevented and the component is displayed with lower opacity. */
+  /** When `true`, prevents interaction and decreases the component's opacity. */
   @property({ reflect: true }) disabled = false;
 
-  /** Specifies the properties to match against when filtering. This will only apply when `value` is an object. If not set, all properties will be matched. */
+  /** When `value` is an object, specifies the properties to match against when filtering. If not set, all properties will be matched. */
   @property() filterProps?: string[];
 
   /**
@@ -72,7 +72,7 @@ export class Filter extends LitElement {
   @property() filteredItems: object[] = [];
 
   /**
-   * Defines the items to filter. The component uses the values as the starting point, and returns items
+   * Specifies the items to filter. The component uses the values as the starting point, and returns items
    *
    * that contain the string entered in the input, using a partial match and recursive search.
    *
@@ -88,7 +88,7 @@ export class Filter extends LitElement {
   /** Overrides individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
-  /** Specifies placeholder text for the input element. */
+  /** Specifies the component's input placeholder text. */
   @property() placeholder?: string;
 
   /** Specifies the size of the component. */

--- a/packages/components/src/components/flow-item/flow-item.scss
+++ b/packages/components/src/components/flow-item/flow-item.scss
@@ -7,14 +7,14 @@
  * @prop --calcite-flow-item-header-border-block-end: [Deprecated] Use `--calcite-flow-border-color` instead. Specifies the component header's block end border.
  * @prop --calcite-flow-corner-radius: Specifies the component's corner radius.
  * @prop --calcite-flow-heading-text-color: Specifies the text color of the component's `heading`.
- * @prop --calcite-flow-icon-color: Specifies the color of the component's icon.
+ * @prop --calcite-flow-icon-color: Specifies the color of the component's `icon`.
  * @prop --calcite-flow-description-text-color: Specifies the text color of the component's `description`.
  * @prop --calcite-flow-border-color: Specifies the component's border color.
  * @prop --calcite-flow-background-color: Specifies the component's background color.
  * @prop --calcite-flow-header-background-color: Specifies the background color of the component's header.
  * @prop --calcite-flow-footer-background-color: Specifies the background color of the component's footer.
- * @prop --calcite-flow-space: Specifies the padding of the component's `"unnamed (default)"` slot.
- * @prop --calcite-flow-header-content-space: Specifies the padding of the `"header-content"` slot.
+ * @prop --calcite-flow-space: Specifies the padding of the component's `unnamed (default)` slot.
+ * @prop --calcite-flow-header-content-space: Specifies the padding of the `header-content` slot.
  * @prop --calcite-flow-footer-space: Specifies the padding of the component's footer.
  * @prop --calcite-action-background-color: Specifies the background color of the component's `closable`, `collapsible`, and `back` `calcite-action`s. Applies to any slotted `calcite-action`s.
  * @prop --calcite-action-background-color-hover: Specifies the background color of the component's `closable`, `collapsible`, and `back` `calcite-action`s when hovered. Applies to any slotted `calcite-action`s.
@@ -22,12 +22,12 @@
  * @prop --calcite-action-text-color-hover: Specifies the text and icon color of the component's `closable`, `collapsible`, and `back` `calcite-action`s when hovered. Applies to any slotted `calcite-action`s.
  * @prop --calcite-action-text-color-pressed: Specifies the text and icon color of the component's `closable`, `collapsible`, and `back` `calcite-action`s when pressed. Applies to any slotted `calcite-action`s.
  * @prop --calcite-popover-border-color: Specifies the border color of the component's internally rendered `calcite-popover`, which is rendered within a `calcite-action` menu when slotted `calcite-action`s are present in the `header-actions-end` slot. Applies to any slotted `calcite-popover`s.
- * @prop --calcite-flow-header-action-background-color-hover: Specifies the background color of the component's `calcite-action` items  in the flow item header when hovered.
- * @prop --calcite-flow-header-action-background-color-press: Specifies the background color of the component's `calcite-action` items  in the flow item header when pressed.
- * @prop --calcite-flow-header-action-background-color: Specifies the background color of the component's `calcite-action` items  in the flow item header.
- * @prop --calcite-flow-header-action-indicator-color: Specifies the color of the component's `calcite-action` items' indicator in the flow item header.
- * @prop --calcite-flow-header-action-text-color-press: Specifies the text color of the component's `calcite-action` items in the flow item header when pressed.
- * @prop --calcite-flow-header-action-text-color: Specifies the text color of the component's `calcite-action` items in the flow item header.
+ * @prop --calcite-flow-header-action-background-color-hover: Specifies the background color of any `calcite-action`s in the component's header when hovered.
+ * @prop --calcite-flow-header-action-background-color-press: Specifies the background color of any `calcite-action`s in the component's header when pressed.
+ * @prop --calcite-flow-header-action-background-color: Specifies the background color of any `calcite-action`s in the component's header.
+ * @prop --calcite-flow-header-action-indicator-color: Specifies the color of any `calcite-action`s indicator in the component's header.
+ * @prop --calcite-flow-header-action-text-color-press: Specifies the text color of any `calcite-action`s in the component's header when pressed.
+ * @prop --calcite-flow-header-action-text-color: Specifies the text color of any `calcite-action`s in the component's header.
  */
 
 @use "../../styles/includes";

--- a/packages/components/src/components/flow-item/flow-item.tsx
+++ b/packages/components/src/components/flow-item/flow-item.tsx
@@ -34,9 +34,9 @@ declare global {
  * @slot header-content - A slot for adding custom content to the component's header.
  * @slot header-menu-actions - A slot for adding an overflow menu with `calcite-action`s inside a `calcite-dropdown`.
  * @slot fab - A slot for adding a `calcite-fab` (floating action button) to perform an action.
- * @slot footer - A slot for adding custom content to the component's footer. Should not be used with the `"footer-start"` or `"footer-end"` slots.
- * @slot footer-end - A slot for adding a trailing footer custom content. Should not be used with the `"footer"` slot.
- * @slot footer-start - A slot for adding a leading footer custom content. Should not be used with the `"footer"` slot.
+ * @slot footer - A slot for adding custom content to the component's footer. Should not be used with the `footer-start` or `footer-end` slots.
+ * @slot footer-end - A slot for adding a trailing footer custom content. Should not be used with the `footer` slot.
+ * @slot footer-start - A slot for adding a leading footer custom content. Should not be used with the `footer` slot.
  */
 export class FlowItem extends LitElement {
   //#region Static Members
@@ -66,10 +66,10 @@ export class FlowItem extends LitElement {
 
   //#region Public Properties
 
-  /** When provided, the method will be called before it is removed from its parent `calcite-flow`. */
+  /** Specifies a function to run before the component is removed from its parent `calcite-flow`. */
   @property() beforeBack?: () => Promise<void>;
 
-  /** Passes a function to run before the component closes. */
+  /** Specifies a function to run before the component closes. */
   @property() beforeClose: () => Promise<void>;
 
   /** When `true`, displays a close button in the trailing side of the component's header. */
@@ -91,10 +91,10 @@ export class FlowItem extends LitElement {
   /** When `true`, the component is collapsible. */
   @property({ reflect: true }) collapsible = false;
 
-  /** Specifies a description for the component. */
+  /** Specifies a the component's description. */
   @property() description: string;
 
-  /** When `true`, interaction is prevented and the component is displayed with lower opacity. */
+  /** When `true`, prevents interaction and decreases the component's opacity. */
   @property({ reflect: true }) disabled = false;
 
   /** Specifies the component's heading text. */
@@ -106,7 +106,7 @@ export class FlowItem extends LitElement {
   /** Specifies an icon to display. */
   @property({ reflect: true, type: String }) icon: IconName;
 
-  /** When `true`, the icon will be flipped when the element direction is right-to-left (`"rtl"`). */
+  /** When `true` and the element direction is right-to-left (`"rtl"`), flips the component`s `icon`. */
   @property({ reflect: true }) iconFlipRtl = false;
 
   /** When `true`, a busy indicator is displayed. */
@@ -130,7 +130,7 @@ export class FlowItem extends LitElement {
   /** Specifies the size of the component. */
   @property({ reflect: true }) scale: Scale = "m";
 
-  /** When `true`, the component is displayed within a parent flow. */
+  /** When `true`, the component is displayed within a parent `calcite-flow`. */
   @property({ reflect: true }) selected = false;
 
   /**
@@ -187,10 +187,10 @@ export class FlowItem extends LitElement {
 
   //#region Events
 
-  /** Fires when the back button is clicked. */
+  /** Fires when the component's back button is clicked. */
   calciteFlowItemBack = createEvent();
 
-  /** Fires when the close button is clicked. */
+  /** Fires when the component's close button is clicked. */
   calciteFlowItemClose = createEvent({ cancelable: false });
 
   /** Fires when the component's content area is collapsed. */
@@ -199,10 +199,10 @@ export class FlowItem extends LitElement {
   /** Fires when the component's content area is expanded. */
   calciteFlowItemExpand = createEvent({ cancelable: false });
 
-  /** Fires when the content is scrolled. */
+  /** Fires when the component's content is scrolled. */
   calciteFlowItemScroll = createEvent({ cancelable: false });
 
-  /** Fires when the collapse button is clicked. */
+  /** Fires when the component's collapse button is clicked. */
   calciteFlowItemToggle = createEvent({ cancelable: false });
 
   /** @private */

--- a/packages/components/src/components/flow/flow.tsx
+++ b/packages/components/src/components/flow/flow.tsx
@@ -16,7 +16,7 @@ declare global {
   }
 }
 
-/** @slot - A slot for adding `calcite-flow-item` elements to the component. */
+/** @slot - A slot for adding `calcite-flow-item`s to the component. */
 export class Flow extends LitElement {
   // #region Static Members
 
@@ -60,7 +60,7 @@ export class Flow extends LitElement {
   // #region Public Methods
 
   /**
-   * Removes the currently active `calcite-flow-item`.
+   * Removes selection of the currently active `calcite-flow-item`.
    *
    * @returns Promise<HTMLCalciteFlowItemElement | FlowItemLikeElement>
    */

--- a/packages/components/src/components/popover/popover.tsx
+++ b/packages/components/src/components/popover/popover.tsx
@@ -162,11 +162,11 @@ export class Popover extends LitElement implements FloatingUIComponent {
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /**
-   * Offsets the position of the popover away from the `referenceElement`.
+   * Specifies the distance to position the component away from the `referenceElement`.
    */
   @property({ type: Number, reflect: true }) offsetDistance = defaultOffsetDistance;
 
-  /** Offsets the position of the component along the `referenceElement`. */
+  /** Specifies the distance to position the component along the `referenceElement`. */
   @property({ reflect: true }) offsetSkidding = 0;
 
   /** When `true`, displays and positions the component. */

--- a/packages/components/src/components/tooltip/tooltip.tsx
+++ b/packages/components/src/components/tooltip/tooltip.tsx
@@ -89,11 +89,11 @@ export class Tooltip extends LitElement implements FloatingUIComponent {
   @property() label: string;
 
   /**
-   * Offset the position of the component away from the `referenceElement`.
+   * Specifies the distance to position the component away from the `referenceElement`.
    */
   @property({ type: Number, reflect: true }) offsetDistance = defaultOffsetDistance;
 
-  /** Offset the position of the component along the `referenceElement`. */
+  /** Specifies the distance to position the component along the `referenceElement`. */
   @property({ reflect: true }) offsetSkidding = 0;
 
   /** When `true`, the component is open. */


### PR DESCRIPTION
**Related Issue:** #12833

## Summary
Aligns the API descriptions with our style guide for the following components:
- `date-picker`
- `dialog`
- `dropdown-group`
- `dropdown-item`
- `dropdown`
- `fab`
- `filter`
- `flow-item`
- `flow`
- `popover`
- `tooltip`