### PR TITLE
docs: update action background hover token descriptions to match functionality

### DIFF
--- a/packages/components/src/components/action/action.scss
+++ b/packages/components/src/components/action/action.scss
@@ -3,7 +3,7 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-action-background-color-hover: Specifies the component's background color when hovered or focused.
+ * @prop --calcite-action-background-color-hover: Specifies the component's background color when hovered.
  * @prop --calcite-action-background-color-press: Specifies the component's background color when active.
  * @prop --calcite-action-background-color-pressed: [Deprecated] Use --calcite-action-background-color-press. Specifies the component's background color when active.
  * @prop --calcite-action-background-color: Specifies the component's background color.

--- a/packages/components/src/components/input-time-picker/input-time-picker.scss
+++ b/packages/components/src/components/input-time-picker/input-time-picker.scss
@@ -21,7 +21,7 @@
  * @prop --calcite-input-time-picker-digit-border-color-press: Specifies the component's digit border color when pressed.
  * @prop --calcite-input-time-picker-digit-border-color-hover: Specifies the component's digit border color when hovered.
 
- * @prop --calcite-input-time-picker-action-background-color-hover: Specifies the background color of the component's actions when hovered or focused.
+ * @prop --calcite-input-time-picker-action-background-color-hover: Specifies the background color of the component's actions when hovered.
  * @prop --calcite-input-time-picker-action-background-color-press: Specifies the background color of the component's actions when active.
  */
 


### PR DESCRIPTION
**Related Issue:** #

## Summary

Updates the description of 2 component tokens to accurately represent their functionality. This also makes all nested `...-action-background-color-hover` token descriptions consistent. For others, see this [GitHub search](https://github.com/search?q=repo%3AEsri%2Fcalcite-design-system+path%3A%2F%5Epackages%5C%2Fcomponents%5C%2Fsrc%5C%2Fcomponents%5C%2F%2F+%22action-background-color-hover%3A+Specifies%22&type=code) (<- search results are better in vscode or some place that isn't GitHub, but it works)

`--calcite-action-background-color-hover`:
- before: `Specifies the component's background color when hovered or focused.`
- after: `Specifies the component's background color when hovered.`

`--calcite-input-time-picker-action-background-color-hover`:
- before: `Specifies the background color of the component's actions when hovered or focused.`
- after: `Specifies the background color of the component's actions when hovered.`

cc @DintaMel 