### PR TITLE
fix(action-pad): avoid collapsing unrelated actions

### DIFF
--- a/packages/components/src/components/action-bar/action-bar.browser.e2e.tsx
+++ b/packages/components/src/components/action-bar/action-bar.browser.e2e.tsx
@@ -1,7 +1,7 @@
 import { h } from "@arcgis/lumina";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { userEvent } from "vitest/browser";
-import { describe, it, expect } from "vitest";
+import { page, userEvent } from "vitest/browser";
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
 import {
   cancelable,
   defaults,
@@ -14,7 +14,9 @@ import {
   delegatesToFloatingUiOwningComponent,
 } from "../../tests/commonTests/browser";
 import { mockConsole } from "../../tests/utils/logging";
+import { DEBOUNCE } from "../../utils/resources";
 import { SLOTS } from "./resources";
+import { ActionBar } from "./action-bar";
 
 describe("calcite-action-bar", () => {
   mockConsole();
@@ -204,6 +206,78 @@ describe("calcite-action-bar", () => {
       await userEvent.click(action4);
       expect(action3.active).toBe(true);
       expect(action4.active).toBe(false);
+    });
+  });
+
+  describe("overflowing actions", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("only collapses and expand direct actions and trigger actions for direct action-menus", async () => {
+      const { el } = await mount<ActionBar>(
+        <calcite-action-bar expand-disabled expanded layout="horizontal">
+          <calcite-action-menu>
+            <calcite-action active icon="toggle" text-enabled />
+            <calcite-action icon="toggle" />
+            <calcite-action icon="toggle" />
+            <calcite-dropdown>
+              <calcite-action icon="pushpin" slot="trigger" />
+              <calcite-dropdown-item>1</calcite-dropdown-item>
+              <calcite-dropdown-item>2</calcite-dropdown-item>
+              <calcite-dropdown-item>3</calcite-dropdown-item>
+            </calcite-dropdown>
+          </calcite-action-menu>
+          <calcite-action-group>
+            <calcite-action icon="toggle" />
+            <calcite-action icon="toggle" />
+            <calcite-action icon="toggle" />
+            <calcite-dropdown>
+              <calcite-action icon="pushpin" slot="trigger" />
+              <calcite-dropdown-item>1</calcite-dropdown-item>
+              <calcite-dropdown-item>2</calcite-dropdown-item>
+              <calcite-dropdown-item>3</calcite-dropdown-item>
+            </calcite-dropdown>
+          </calcite-action-group>
+          <calcite-action-group>
+            <calcite-action icon="toggle" />
+            <calcite-action icon="toggle" />
+            <calcite-action icon="toggle" />
+            <calcite-dropdown>
+              <calcite-action icon="pushpin" slot="trigger" />
+              <calcite-dropdown-item>1</calcite-dropdown-item>
+              <calcite-dropdown-item>2</calcite-dropdown-item>
+              <calcite-dropdown-item>3</calcite-dropdown-item>
+            </calcite-dropdown>
+          </calcite-action-group>
+        </calcite-action-bar>,
+      );
+      const triggerActions = page.getBySelector("calcite-action[slot='trigger']");
+
+      el.style.width = "100%";
+      vi.advanceTimersByTime(DEBOUNCE.resize);
+
+      await expect.element(triggerActions.nth(0)).not.toBeInViewport(); // collapsed in action-menu
+      await expect.element(triggerActions.nth(1)).toBeInViewport();
+      await expect.element(triggerActions.nth(2)).toBeInViewport();
+
+      el.style.width = "100px";
+      vi.advanceTimersByTime(DEBOUNCE.resize);
+
+      await expect.element(triggerActions.nth(0)).not.toBeInViewport(); // collapsed in action-menu
+      await expect.element(triggerActions.nth(1)).toBeInViewport();
+      await expect.element(triggerActions.nth(2)).toBeInViewport();
+
+      el.style.width = "100%";
+      vi.advanceTimersByTime(DEBOUNCE.resize);
+
+      await expect.element(triggerActions.nth(0)).not.toBeInViewport(); // collapsed in action-menu
+      await expect.element(triggerActions.nth(1)).toBeInViewport();
+      await expect.element(triggerActions.nth(2)).toBeInViewport();
     });
   });
 });

--- a/packages/components/src/components/action-bar/utils.ts
+++ b/packages/components/src/components/action-bar/utils.ts
@@ -22,7 +22,9 @@ export const overflowActions = ({
   actionGroups.reverse().forEach((group) => {
     let slottedWithinGroupCount = 0;
 
-    const groupActions = queryActions(group).reverse();
+    const groupActions = queryActions(group)
+      .filter((action) => action.parentElement?.tagName === "CALCITE-ACTION-GROUP")
+      .reverse();
 
     groupActions.forEach((groupAction) => {
       if (groupAction.slot === ACTION_GROUP_SLOTS.menuActions) {

--- a/packages/components/src/components/action-bar/utils.ts
+++ b/packages/components/src/components/action-bar/utils.ts
@@ -9,6 +9,10 @@ export const queryActions = (el: HTMLElement): Action["el"][] => {
   );
 };
 
+/**
+ * Manages action overflow by slotting actions into action menus as needed.
+ * Note: this only handles direct actions and action-groups.
+ */
 export const overflowActions = ({
   actionGroups,
   expanded,

--- a/packages/components/src/components/action-bar/utils.ts
+++ b/packages/components/src/components/action-bar/utils.ts
@@ -1,4 +1,4 @@
-import { SLOTS as ACTION_GROUP_SLOTS } from "../action-group/resources";
+import { SLOTS as ACTION_GROUP_SLOTS, isActionGroup } from "../action-group/resources";
 import { SLOTS as ACTION_MENU_SLOTS } from "../action-menu/resources";
 import type { ActionGroup } from "../action-group/action-group";
 import type { Action } from "../action/action";
@@ -26,11 +26,11 @@ export const overflowActions = ({
   actionGroups.reverse().forEach((group) => {
     let slottedWithinGroupCount = 0;
 
-    const groupActions = queryActions(group)
-      .filter((action) => action.parentElement?.tagName === "CALCITE-ACTION-GROUP")
+    const directGroupActions = queryActions(group)
+      .filter((action) => isActionGroup(action.parentElement))
       .reverse();
 
-    groupActions.forEach((groupAction) => {
+    directGroupActions.forEach((groupAction) => {
       if (groupAction.slot === ACTION_GROUP_SLOTS.menuActions) {
         groupAction.removeAttribute("slot");
         groupAction.textEnabled = expanded;
@@ -38,10 +38,14 @@ export const overflowActions = ({
     });
 
     if (needToSlotCount > 0) {
-      groupActions.some((groupAction) => {
-        const unslottedActions = groupActions.filter((action) => !action.slot);
+      directGroupActions.some((groupAction) => {
+        const unslottedActions = directGroupActions.filter((action) => !action.slot);
 
-        if (unslottedActions.length > 1 && groupActions.length > 2 && !groupAction.closest("calcite-action-menu")) {
+        if (
+          unslottedActions.length > 1 &&
+          directGroupActions.length > 2 &&
+          !groupAction.closest("calcite-action-menu")
+        ) {
           groupAction.textEnabled = true;
           groupAction.setAttribute("slot", ACTION_GROUP_SLOTS.menuActions);
           slottedWithinGroupCount++;

--- a/packages/components/src/components/action-group/resources.ts
+++ b/packages/components/src/components/action-group/resources.ts
@@ -12,3 +12,7 @@ export const ICONS: Record<string, IconName> = {
 export const CSS = {
   container: "container",
 };
+
+export function isActionGroup(el: Element | null): el is ActionGroup["el"] {
+  return el?.tagName === "CALCITE-ACTION-GROUP";
+}

--- a/packages/components/src/components/action-group/resources.ts
+++ b/packages/components/src/components/action-group/resources.ts
@@ -1,4 +1,5 @@
 import { IconName } from "../icon/interfaces";
+import { ActionGroup } from "./action-group";
 
 export const SLOTS = {
   menuActions: "menu-actions",


### PR DESCRIPTION
**Related Issue:** #12098 

## Summary

Fixes an issue where `action-bar`'s overflowing logic was managing all `action` children regardless of them being direct children of `action-group` or not.