### PR TITLE
ci(chromatic): update workflow to use accurate baselines

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
       - uses: actions/setup-node@v6
         with:
           node-version-file: package.json
@@ -39,7 +40,10 @@ jobs:
           storybookBuildDir: docs
         env:
           STORYBOOK_SCREENSHOT_TEST_BUILD: true
+          CHROMATIC_BRANCH: ${{ github.event.pull_request.head.ref || github.ref_name }}
           CHROMATIC_DIFF_THRESHOLD: ${{ secrets.CHROMATIC_DIFF_THRESHOLD }}
+          CHROMATIC_SHA: ${{ github.event.pull_request.head.sha || github.ref }}
+          CHROMATIC_SLUG: ${{ github.repository }}
   skip:
     if: >
       github.event_name == 'pull_request' &&


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Updates Chromatic workflow to align with their [guidance on `pull_request` trigger events](https://www.chromatic.com/docs/github-actions/#recommended-configuration-for-build-events).

https://github.com/Esri/calcite-design-system/pull/13606/ removed builds when pushing to `dev` and `rc`, which may affect the baselines used for screenshot tests:

> While the `pull_request` event also works, it can cause Chromatic’s baselines to be lost in certain scenarios or cause Chromatic to use an unexpected baseline from the main branch.