### PR TITLE
fix(input-time-picker): emit change event when clearing meridiem

### DIFF
--- a/packages/components/src/components/input-time-picker/input-time-picker.e2e.ts
+++ b/packages/components/src/components/input-time-picker/input-time-picker.e2e.ts
@@ -1995,6 +1995,57 @@ describe("calcite-input-time-picker", () => {
           expect(input.textContent).toBe("--");
           expect(pickerInput.textContent).toBe("--");
         });
+
+        describe("clearing", () => {
+          it("emits change event when cleared after a valid value has been entered", async () => {
+            const component = await page.find("calcite-input-time-picker");
+            const changeEvent = await page.spyOnEvent("calciteInputTimePickerChange");
+
+            await component.callMethod("setFocus");
+            await page.keyboard.press("ArrowUp");
+            await page.keyboard.press("Tab");
+            await page.keyboard.press("ArrowUp");
+            await page.keyboard.press("Tab");
+            await page.keyboard.press("ArrowUp");
+            await page.keyboard.press("Tab");
+            await page.keyboard.press("ArrowUp");
+            await page.keyboard.press("Tab");
+            await page.waitForChanges();
+
+            expect(changeEvent).toHaveReceivedEventTimes(0);
+            expect(await component.getProperty("value")).toBeTruthy();
+
+            await page.keyboard.press("Enter");
+            await page.waitForChanges();
+
+            expect(changeEvent).toHaveReceivedEventTimes(1);
+
+            await input.click();
+            await page.keyboard.press(deleteKey);
+            await page.keyboard.press("Enter");
+            await page.waitForChanges();
+
+            expect(changeEvent).toHaveReceivedEventTimes(2);
+          });
+
+          it("emits change event when cleared right after value is directly set (#12889)", async () => {
+            const component = await page.find("calcite-input-time-picker");
+            const changeEvent = await page.spyOnEvent("calciteInputTimePickerChange");
+
+            component.setProperty("value", "15:00:00");
+            await page.waitForChanges();
+
+            expect(changeEvent).toHaveReceivedEventTimes(0);
+            expect(await component.getProperty("value")).toBe("15:00:00.000");
+
+            await input.click();
+            await page.keyboard.press(deleteKey);
+            await page.keyboard.press("Enter");
+            await page.waitForChanges();
+
+            expect(changeEvent).toHaveReceivedEventTimes(1);
+          });
+        });
       });
     });
 

--- a/packages/components/src/controllers/useTime.ts
+++ b/packages/components/src/controllers/useTime.ts
@@ -625,6 +625,7 @@ class TimeController extends GenericController<TimeProperties, TimeComponent> {
             }
             break;
           default:
+            this.userChangedValue = true;
             this.component.value = "";
             break;
         }


### PR DESCRIPTION
**Related Issue:** #12889

## Summary

This PR fixes an issue when clearing the meridiem field (which subsequently clears the whole value), a change event failed to fire.
