### PR TITLE
ci: update deployment process to use release branches

### DIFF
--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -2,38 +2,12 @@ name: Deploy Latest
 on:
   workflow_dispatch:
   push:
-    branches: [main]
+    branches:
+      - ${{ vars.RELEASE_BRANCH }}
 permissions:
   contents: write
   pull-requests: write
 jobs:
-  sync-dev-to-main:
-    if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-22.04
-    permissions:
-      id-token: write
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v6
-        with:
-          ref: main
-          fetch-depth: 0
-          token: ${{ secrets.ADMIN_TOKEN }}
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: package.json
-      - name: Sync dev to main
-        run: |
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git config --global user.name "github-actions[bot]"
-          git rebase --autostash origin/dev
-          git pull --rebase origin main
-          npm install
-          npm run build
-          npm test
-          git push origin main
-
   release-please:
     if: github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
@@ -44,7 +18,7 @@ jobs:
         id: release
         with:
           token: ${{ secrets.ADMIN_TOKEN }}
-          target-branch: main
+          target-branch: ${{ vars.RELEASE_BRANCH }}
       - name: Checkout Repository
         if: steps.release.outputs.releases_created == 'true'
         uses: actions/checkout@v6


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Our current deployment process relies heavily between keeping `main` and `dev` (source of truth) in sync, which is error prone, and time consuming.

This PR updates the process to use release branches, which is defined as a `RELEASE_BRANCH` repository variable and will no longer depend on having a `main` branch. Patching will still be applied to `dev` and cherry-picked onto the respective release branch. Once a release is deployed, we'll have to merge the release commit back to `dev` to keep package versions in sync.
