### PR TITLE
docs: remove copyright preamble for consistent copyright headers across cc + sdk

### DIFF
--- a/packages/components/vite.config.ts
+++ b/packages/components/vite.config.ts
@@ -32,7 +32,6 @@ const lumina = useLumina({
         proxiesFile: "../components-react/src/components.ts",
       },
     ],
-    preamble: `All material copyright ESRI, All Rights Reserved, unless otherwise specified.\nSee https://github.com/Esri/calcite-design-system/blob/dev/LICENSE.md for details.\nv${version}`,
   },
   css: {
     globalStylesPath: "src/styles/global/index.scss",


### PR DESCRIPTION
**Related Issue:** #13708

## Summary
Removes the `preamble` variable in the vite.config.ts file to ensure all files built as `dist/*.js` contain consistent copyright headers.