### PR TITLE
ci: fix branch name references

### DIFF
--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - ${{ vars.RELEASE_BRANCH }}
+      - 2026.R1
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - '26.R*'
+      - "releases/**"
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -18,7 +18,7 @@ jobs:
         id: release
         with:
           token: ${{ secrets.ADMIN_TOKEN }}
-          target-branch: ${{ vars.RELEASE_BRANCH }}
+          target-branch: ${{ github.ref_name }}
       - name: Checkout Repository
         if: steps.release.outputs.releases_created == 'true'
         uses: actions/checkout@v6

--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - 2026.R1
+      - '26.R*'
 permissions:
   contents: write
   pull-requests: write


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

https://github.com/Esri/calcite-design-system/pull/13839 used invalid syntax for the `branches` argument. This uses a release branch filter instead of using GitHub variables.