### PR TITLE
ci(release-please): update config for v5 release

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,7 @@
   "release-type": "node",
   "tag-separator": "@",
   "last-release-sha": "e98cb96296377b93efbcb2078fe7ba4764d5e4f2",
+  "group-pull-request-title-pattern": "chore: release main",
   "draft-pull-request": true,
   "include-v-in-tag": false,
   "commit-search-depth": 1000,

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -21,7 +21,6 @@
   ],
   "packages": {
     "packages/components": {
-      "release-as": "5.0.0",
       "component": "@esri/calcite-components",
       "extra-files": [
         "README.md",
@@ -64,7 +63,6 @@
     },
     "packages/components-react": {
       "component": "@esri/calcite-components-react",
-      "release-as": "5.0.0",
       "extra-files": [
         {
           "type": "json",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
   "tag-separator": "@",
+  "last-release-sha": "e98cb96296377b93efbcb2078fe7ba4764d5e4f2",
   "draft-pull-request": true,
   "include-v-in-tag": false,
   "commit-search-depth": 1000,


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

* drops inert `release-as` option (for 5.0.0)
* keeps default group PR title as `chore: release main`
* sets `last-release-sha` to 3.3.0 to ensure accurate changelog generation

