### PR TITLE
ci(release-please): run on workflow dispatch and release-branch push

### DIFF
--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -9,7 +9,6 @@ permissions:
   pull-requests: write
 jobs:
   release-please:
-    if: github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       id-token: write


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

The previous workflow would sync `dev` and `main` branches and wait for a successful build and test run before triggering `release-please`. https://github.com/Esri/calcite-design-system/pull/13839/ removed the first part, but didn't update the `release-please` step to run on both release-branch push and manual triggers via the workflow dispatch event.