### PR TITLE
ci(release-please): restore `release-as` for packages starting at v5 for alignment

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -23,6 +23,7 @@
   ],
   "packages": {
     "packages/components": {
+      "release-as": "5.0.0",
       "component": "@esri/calcite-components",
       "extra-files": [
         "README.md",
@@ -65,6 +66,7 @@
     },
     "packages/components-react": {
       "component": "@esri/calcite-components-react",
+      "release-as": "5.0.0",
       "extra-files": [
         {
           "type": "json",


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Restoring this option until v5 is released. Removal causes the `package.json` version to be ignored (see https://github.com/Esri/calcite-design-system/pull/13845).