### PR TITLE
ci(release-please): skip if deploy-latest workflow is not on release branch

### DIFF
--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -13,6 +13,12 @@ jobs:
     permissions:
       id-token: write
     steps:
+      - name: Check if on release branch
+        run: |
+          if [[ ! "${GITHUB_REF_NAME}" =~ ^releases/ ]]; then
+            echo "::warning::Not on a release branch (releases/**). Skipping deployment."
+            exit 0
+          fi
       - uses: googleapis/release-please-action@v4
         id: release
         with:


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

The [`Deploy Latest` workflow](https://github.com/Esri/calcite-design-system/blob/dev/.github/workflows/deploy-latest.yml) should only run on a release branch, so this is adding a check to prevent accidental runs.