### PR TITLE
ci(release-please): drop `group-pull-request-title-pattern` to test effect on workflow

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
   "tag-separator": "@",
-  "group-pull-request-title-pattern": "chore: release main",
   "draft-pull-request": true,
   "include-v-in-tag": false,
   "commit-search-depth": 1000,


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Recent `deploy latest` runs are not creating a release, so this will test if the option is impacting `release-please`'s logic.
