### PR TITLE
ci: avoid extra prerelease changelog removal trigger

### DIFF
--- a/.github/workflows/remove-prerelease-changelog-entries.yml
+++ b/.github/workflows/remove-prerelease-changelog-entries.yml
@@ -7,6 +7,7 @@ permissions:
   pull-requests: write
 name: clean-changelog
 jobs:
+  if: github.actor != 'github-actions[bot]'
   clean-changelog:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

This avoids an extra trigger of the [`remove-prereleas-changelog-entries.yml`](https://github.com/Esri/calcite-design-system/blob/8ef486ca86a21c9f6baf2f6c75d18818ae25c273/.github/workflows/remove-prerelease-changelog-entries.yml) action since it is configured to [run on pushes to the target branch](https://github.com/Esri/calcite-design-system/blob/8ef486ca86a21c9f6baf2f6c75d18818ae25c273/.github/workflows/remove-prerelease-changelog-entries.yml#L2-L4), which it [does after any changelog updates](https://github.com/Esri/calcite-design-system/blob/8ef486ca86a21c9f6baf2f6c75d18818ae25c273/.github/workflows/remove-prerelease-changelog-entries.yml#L33).