### PR TITLE
ci(remove-prerelease-changelog-entries): move if condition under job

### DIFF
--- a/.github/workflows/remove-prerelease-changelog-entries.yml
+++ b/.github/workflows/remove-prerelease-changelog-entries.yml
@@ -7,8 +7,8 @@ permissions:
   pull-requests: write
 name: clean-changelog
 jobs:
-  if: github.actor != 'github-actions[bot]'
   clean-changelog:
+    if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

https://github.com/Esri/calcite-design-system/pull/13884 incorrectly had an `if` under `jobs` instead of the target job. 

Tested with https://rhysd.github.io/actionlint/, which [shows no errors now](https://rhysd.github.io/actionlint/#eJyNUk1vEzEQvedXDCukSpW85cRhJaQi6AEhAircEKq8zmTXjddj7HFK1fS/M/uRbdqUj5Plmef3nt8M+WoBEHJq+xOgjtqbFtN4A1BQRHSoE6owHmoPUWrqpLPT02IRMHY2JUt+eGzIM3pOFdxEyziIOCdPfmZMD2WvO6zACI9XptW+QUfN4prqkeRxfTRl1xU0lttcl9owRXjxBk7GgpJCb+B7TfzjZEDH7JMiX0Gus+esnGbRH1qJMRx8dLTyrkWzocxwiYGSFf7bCQGQ5a8VTBpnZkKeb1/PiBuxUc03AKYNivbLuztIaCJyKt++//RhefXt88eLJdzfH2DXyKZVKwxCAa+e2PqKnAMsaYV/cJN6gPIC+Jufvq+2GPsxqbV1why02egGy+tE/onoJXa0RVjiL5ZcpiHAhedoMc2sknAFuwMRmcUw7EPd0IH1ifVRVV5DZuuqOIipEHG/cPPcFT6S3Nv7Ils7+fqHG1nGtW1AqcZRrV0fXSyx09ZB8czmnPf9VHqKGNxtOS2boa74H97e3LO0x6+7Tg6lOyhWZGSYYwbwkAHMGcCUQQG7HXDMeBS4hEHRNtYP6zaZjri+GgzJqv0G5mI2Kg==).