### PR TITLE
fix(tab-title): switch order of preferred and deprecated icon color variables

### DIFF
--- a/packages/components/src/components/tab-title/tab-title.scss
+++ b/packages/components/src/components/tab-title/tab-title.scss
@@ -185,11 +185,11 @@
   color: var(--calcite-tab-text-color, var(--calcite-color-text-3));
 
   .icon-start {
-    color: var(--calcite-tab-icon-color-start, var(--calcite-ui-icon-color, var(--calcite-icon-color)));
+    color: var(--calcite-tab-icon-color-start, var(--calcite-icon-color, var(--calcite-ui-icon-color)));
   }
 
   .icon-end {
-    color: var(--calcite-tab-icon-color-end, var(--calcite-ui-icon-color, var(--calcite-icon-color)));
+    color: var(--calcite-tab-icon-color-end, var(--calcite-icon-color, var(--calcite-ui-icon-color)));
   }
 
   &:hover,
@@ -198,11 +198,11 @@
     color: var(--calcite-tab-text-color-press, var(--calcite-color-text-1));
 
     .icon-start {
-      color: var(--calcite-tab-icon-color-start-press, var(--calcite-ui-icon-color, var(--calcite-icon-color)));
+      color: var(--calcite-tab-icon-color-start-press, var(--calcite-icon-color, var(--calcite-ui-icon-color)));
     }
 
     .icon-end {
-      color: var(--calcite-tab-icon-color-end-press, var(--calcite-ui-icon-color, var(--calcite-icon-color)));
+      color: var(--calcite-tab-icon-color-end-press, var(--calcite-icon-color, var(--calcite-ui-icon-color)));
     }
   }
 }


### PR DESCRIPTION
**Related Issue:** #13899

## Summary

This PR updates the CSS variable fallback approach in the Tab Title so that the preferred icon color variable overrides the deprecated variable. This fixes the [initial approach](https://github.com/Esri/calcite-design-system/pull/13681) of adding support for the `--calcite-ui-icon-color` variable.