### PR TITLE
refactor: rename timing test utils

### DIFF
--- a/packages/components/src/controllers/useFocusTrap.browser.e2e.tsx
+++ b/packages/components/src/controllers/useFocusTrap.browser.e2e.tsx
@@ -5,7 +5,7 @@ import { PropertyValues } from "lit";
 import * as focusTrap from "focus-trap";
 import { Locator, page } from "vitest/browser";
 import { html } from "../../support/formatting";
-import { waitForNextTick } from "../tests/utils/timing";
+import { afterNextTask } from "../tests/utils/timing";
 import { GlobalTestProps } from "../tests/utils/interfaces";
 import { CalciteConfig, clearConfig } from "../utils/config";
 import { FocusTrap, useFocusTrap } from "./useFocusTrap";
@@ -40,7 +40,7 @@ describe("useFocusTrap", () => {
   async function waitForFocusShift(): Promise<void> {
     // focus-trap delays focus changes until the next execution frame - see https://github.com/focus-trap/focus-trap/#delayinitialfocus
     // wait for one timeout
-    await waitForNextTick();
+    await afterNextTask();
   }
 
   it("focusTrapComponent lifecycle", async () => {

--- a/packages/components/src/controllers/useTopLayer.browser.spec.tsx
+++ b/packages/components/src/controllers/useTopLayer.browser.spec.tsx
@@ -3,7 +3,7 @@ import { mount } from "@arcgis/lumina-compiler/testing";
 import { h, JsxNode, LitElement, property } from "@arcgis/lumina";
 import { createRef } from "lit/directives/ref.js";
 import { isInTopLayer } from "../tests/utils/dom";
-import { waitForAnimationFrame } from "../tests/utils/timing";
+import { afterNextFrame } from "../tests/utils/timing";
 import { useTopLayer } from "./useTopLayer";
 
 describe("useTopLayer", () => {
@@ -285,7 +285,7 @@ describe("useTopLayer", () => {
     expect(isInTopLayer(component.overlayRef.value)).toBe(false);
 
     container.append(el);
-    await waitForAnimationFrame();
+    await afterNextFrame();
 
     expect(isInTopLayer(component.overlayRef.value)).toBe(true);
   });

--- a/packages/components/src/tests/commonTests/browser/disabled.ts
+++ b/packages/components/src/tests/commonTests/browser/disabled.ts
@@ -2,7 +2,7 @@ import { SetFieldType } from "type-fest";
 import { expect, it, vi } from "vitest";
 import { page, userEvent } from "vitest/browser";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { waitForAnimationFrame, waitForNextTick } from "../../utils/timing";
+import { afterNextFrame, afterNextTask } from "../../utils/timing";
 import { IntrinsicElementsWithProp } from "../../utils/interfaces";
 
 /** This interface is used to specify focus targets for different interactions. */
@@ -210,7 +210,7 @@ export function disabled(setup: () => ReturnType<typeof mount>, options?: Disabl
     });
 
     // wait to ensure focus has been applied and browser has flushed layout
-    await waitForAnimationFrame();
+    await afterNextFrame();
 
     expectToBeFocused(effectiveFocusTarget.click.pointer, "click");
 
@@ -234,7 +234,7 @@ export function disabled(setup: () => ReturnType<typeof mount>, options?: Disabl
     await reRender();
 
     // ensure focus has been applied and browser has flushed layout
-    await waitForAnimationFrame();
+    await afterNextFrame();
 
     expect(target.getAttribute("aria-disabled")).toBe("true");
 
@@ -271,7 +271,7 @@ export function disabled(setup: () => ReturnType<typeof mount>, options?: Disabl
 
     target.disabled = true;
     await reRender();
-    await waitForNextTick();
+    await afterNextTask();
 
     expect(target.getAttribute("aria-disabled")).toBe("true");
 
@@ -284,7 +284,7 @@ export function disabled(setup: () => ReturnType<typeof mount>, options?: Disabl
     // this ensures disabling and events fire immediately after being set
     target.disabled = false;
     await reRender();
-    await waitForNextTick();
+    await afterNextTask();
 
     const [clientX, clientY] = getShadowFocusableCenterCoordinates(target.tagName);
 
@@ -302,7 +302,7 @@ export function disabled(setup: () => ReturnType<typeof mount>, options?: Disabl
 
     target.disabled = true;
     await reRender();
-    await waitForNextTick();
+    await afterNextTask();
     allExpectedEvents.forEach((event) =>
       target.dispatchEvent(
         new MouseEvent(event, {

--- a/packages/components/src/tests/commonTests/browser/floating-ui.ts
+++ b/packages/components/src/tests/commonTests/browser/floating-ui.ts
@@ -4,7 +4,7 @@ import { page } from "vitest/browser";
 import { css } from "../../../../support/formatting";
 import { IntrinsicElementsWithProp } from "../../utils/interfaces";
 import { FlipPlacement } from "../../../utils/floating-ui";
-import { waitForAnimationFrame } from "../../utils/timing";
+import { afterNextFrame } from "../../utils/timing";
 
 /**
  * This helper will test if a floating-ui-owning component has configured the floating-ui correctly.
@@ -67,7 +67,7 @@ export function floatingUIOwner(
 
     try {
       el[togglePropName] = false;
-      await waitForAnimationFrame();
+      await afterNextFrame();
 
       const initialClosedTransform = getTransform();
 
@@ -75,33 +75,33 @@ export function floatingUIOwner(
 
       scrollTo(scrollablePageSizeInPx, scrollablePageSizeInPx);
       await waitForScrollEvent();
-      await waitForAnimationFrame();
+      await afterNextFrame();
 
       expect(getTransform()).toBe(initialClosedTransform);
       await expect.element(floatingUIEl).not.toBeVisible();
 
       scrollTo(0, 0);
       await waitForScrollEvent();
-      await waitForAnimationFrame();
+      await afterNextFrame();
 
       expect(getTransform()).toBe(initialClosedTransform);
       await expect.element(floatingUIEl).not.toBeVisible();
 
       el[togglePropName] = true;
-      await waitForAnimationFrame();
+      await afterNextFrame();
 
       const initialOpenTransform = getTransform();
 
       scrollTo(scrollablePageSizeInPx, scrollablePageSizeInPx);
       await waitForScrollEvent();
-      await waitForAnimationFrame();
+      await afterNextFrame();
 
       expect(getTransform()).not.toBe(initialOpenTransform);
       await expect.element(floatingUIEl).not.toBeVisible();
 
       scrollTo(0, 0);
       await waitForScrollEvent();
-      await waitForAnimationFrame();
+      await afterNextFrame();
 
       expect(getTransform()).toBe(initialOpenTransform);
       await expect.element(floatingUIEl).toBeVisible();

--- a/packages/components/src/tests/commonTests/browser/slots.ts
+++ b/packages/components/src/tests/commonTests/browser/slots.ts
@@ -1,6 +1,6 @@
 import { expect, it } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { waitForAnimationFrame } from "../../utils/timing";
+import { afterNextFrame } from "../../utils/timing";
 
 /**
  * Helper for asserting slots.
@@ -30,7 +30,7 @@ export function slots(
       }
 
       el.append(elToSlot);
-      await waitForAnimationFrame();
+      await afterNextFrame();
     }
 
     const namedSlotTestClass = "slotted-into-named-slot";

--- a/packages/components/src/tests/commonTests/browser/top-layer.ts
+++ b/packages/components/src/tests/commonTests/browser/top-layer.ts
@@ -1,7 +1,7 @@
 import { expect, it } from "vitest";
 import { Locator, page } from "vitest/browser";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { waitForNextTick } from "../../utils/timing";
+import { afterNextTask } from "../../utils/timing";
 import { isInTopLayer } from "../../utils/dom";
 import { getEventPrefix, waitForEvent } from "./utils";
 
@@ -43,14 +43,14 @@ export async function topLayer(setup: () => ReturnType<typeof mount>, options?: 
     const componentOpen = waitForEvent(el, `${getEventPrefix(el)}Open`);
     el[openProp] = true;
     await componentOpen;
-    await waitForNextTick();
+    await afterNextTask();
 
     expect(isInTopLayer(topLayerEl)).toBe(true);
 
     const componentClose = waitForEvent(el, `${getEventPrefix(el)}Close`);
     el[openProp] = false;
     await componentClose;
-    await waitForNextTick();
+    await afterNextTask();
 
     expect(isInTopLayer(topLayerEl)).toBe(false);
 
@@ -59,7 +59,7 @@ export async function topLayer(setup: () => ReturnType<typeof mount>, options?: 
       el.topLayerDisabled = true;
       el[openProp] = true;
       await componentOpen;
-      await waitForNextTick();
+      await afterNextTask();
 
       expect(isInTopLayer(topLayerEl)).toBe(false);
     }

--- a/packages/components/src/tests/utils/puppeteer.ts
+++ b/packages/components/src/tests/utils/puppeteer.ts
@@ -4,7 +4,7 @@ import { LitElement, ToElement } from "@arcgis/lumina";
 import { E2EElement, E2EPage, newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { expect } from "vitest";
 import { ComponentTag } from "../commonTests/interfaces";
-import { waitForAnimationFrame as waitForRaf } from "./timing";
+import { afterNextFrame as waitForRaf } from "./timing";
 import { GlobalTestProps } from "./interfaces";
 
 type DragAndDropSelector = string | SelectorOptions;

--- a/packages/components/src/tests/utils/timing.ts
+++ b/packages/components/src/tests/utils/timing.ts
@@ -1,15 +1,29 @@
 /**
+ * Timing helpers for browser based tests.
+ *
+ * These utilities expose observable timing milestones instead of raw event loop primitives.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Execution_model
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/HTML_DOM_API/Microtask_guide
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/HTML_DOM_API/Microtask_guide/In_depth
+ */
+
+/**
  * Helper function to wait for the next animation frame.
  *
  * If you need to run this within a Puppeteer browser context, please see the `waitForAnimationFrame` function in the `puppeteer` module.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/HTML_DOM_API/Microtask_guide/In_depth#event_loops
  */
-export async function waitForAnimationFrame(): Promise<void> {
+export async function afterNextFrame(): Promise<void> {
   return new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
 }
 
 /**
- * Helper function to wait for the next tick of the event loop.
+ * Helper function to wait for the next task turn of the event loop.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/HTML_DOM_API/Microtask_guide#tasks
  */
-export async function waitForNextTick(): Promise<void> {
+export async function afterNextTask(): Promise<void> {
   return new Promise<void>((resolve) => setTimeout(() => resolve(), 0));
 }

--- a/packages/components/src/utils/dom.browser.spec.ts
+++ b/packages/components/src/utils/dom.browser.spec.ts
@@ -2,7 +2,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { ModeName } from "../components/interfaces";
 import { html } from "../../support/formatting";
-import { waitForAnimationFrame } from "../tests/utils/timing";
+import { afterNextFrame } from "../tests/utils/timing";
 import { createControlledPromise } from "../tests/utils/promises";
 import { IconName } from "../components/icon/interfaces";
 import { guidPattern } from "./guid.browser.spec";
@@ -306,13 +306,13 @@ describe("dom", () => {
         const slottedEls = [createEl("div"), createEl("div")];
 
         appendChildren(testEl, slottedEls);
-        await waitForAnimationFrame();
+        await afterNextFrame();
 
         expect(assigned).toEqual(slottedEls);
 
         assigned = null;
         slottedEls.forEach((el) => el.remove());
-        await waitForAnimationFrame();
+        await afterNextFrame();
 
         expect(assigned).toEqual([]);
       });
@@ -349,7 +349,7 @@ describe("dom", () => {
         ];
 
         appendChildren(testEl, nodes);
-        await waitForAnimationFrame();
+        await afterNextFrame();
 
         expect(slotToAssigned).toEqual({
           "": [nodes[1]],
@@ -360,7 +360,7 @@ describe("dom", () => {
 
         Object.keys(slotToAssigned).forEach((key) => delete slotToAssigned[key]);
         nodes.forEach((el) => el.remove());
-        await waitForAnimationFrame();
+        await afterNextFrame();
 
         expect(slotToAssigned).toEqual({
           "": [],
@@ -409,13 +409,13 @@ describe("dom", () => {
         const nodes = [document.createTextNode("hello"), createEl("div"), document.createTextNode("world")];
 
         appendChildren(testEl, nodes);
-        await waitForAnimationFrame();
+        await afterNextFrame();
 
         expect(assigned).toEqual(nodes);
 
         assigned = null;
         nodes.forEach((el) => el.remove());
-        await waitForAnimationFrame();
+        await afterNextFrame();
 
         expect(assigned).toEqual([]);
       });
@@ -452,7 +452,7 @@ describe("dom", () => {
         ];
 
         appendChildren(testEl, nodes);
-        await waitForAnimationFrame();
+        await afterNextFrame();
 
         expect(slotToAssigned).toEqual({
           "": [nodes[0], nodes[1]],
@@ -463,7 +463,7 @@ describe("dom", () => {
 
         Object.keys(slotToAssigned).forEach((key) => delete slotToAssigned[key]);
         nodes.forEach((node) => node.remove());
-        await waitForAnimationFrame();
+        await afterNextFrame();
 
         expect(slotToAssigned).toEqual({
           "": [],
@@ -981,7 +981,7 @@ describe("dom", () => {
 
           expect(await promiseState(promise)).toHaveProperty("status", "pending");
 
-          await waitForAnimationFrame();
+          await afterNextFrame();
 
           expect(await promiseState(promise)).toHaveProperty("status", "pending");
 
@@ -999,7 +999,7 @@ describe("dom", () => {
           const promise = helper(element, testTransitionOrAnimationName);
           expect(await promiseState(promise)).toHaveProperty("status", "pending");
 
-          await waitForAnimationFrame();
+          await afterNextFrame();
 
           expect(await promiseState(promise)).toHaveProperty("status", "fulfilled");
         });

--- a/packages/components/src/utils/floating-ui.browser.spec.ts
+++ b/packages/components/src/utils/floating-ui.browser.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeEach, vi } from "vitest";
-import { waitForAnimationFrame } from "../tests/utils/timing";
+import { afterNextFrame } from "../tests/utils/timing";
 import { mockConsole } from "../tests/utils/logging";
 import { DEBOUNCE } from "./resources";
 import * as floatingUI from "./floating-ui";
@@ -134,7 +134,7 @@ describe("repositioning", () => {
 
     assertPreOpenPositioning(floatingEl);
 
-    await waitForAnimationFrame();
+    await afterNextFrame();
     assertOpenPositioning(floatingEl);
   });
 

--- a/packages/components/src/utils/openCloseComponent.browser.spec.tsx
+++ b/packages/components/src/utils/openCloseComponent.browser.spec.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { JsxNode, LitElement } from "@arcgis/lumina";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { waitForAnimationFrame } from "../tests/utils/timing";
+import { afterNextFrame } from "../tests/utils/timing";
 import { createControlledPromise } from "../tests/utils/promises";
 import { toggleOpenClose } from "./openCloseComponent";
 
@@ -64,11 +64,11 @@ describe("openCloseComponent", () => {
 
       component.open = true;
       toggleOpenClose(component);
-      await waitForAnimationFrame();
+      await afterNextFrame();
       expect(emittedEvents).toEqual(["beforeOpen"]);
 
       openingControlledPromise.resolve();
-      await waitForAnimationFrame();
+      await afterNextFrame();
       expect(emittedEvents).toEqual(["beforeOpen", "open"]);
 
       const closingControlledPromise = createControlledPromise<void>();
@@ -81,12 +81,12 @@ describe("openCloseComponent", () => {
 
       component.open = false;
       toggleOpenClose(component);
-      await waitForAnimationFrame();
+      await afterNextFrame();
 
       expect(emittedEvents).toEqual(["beforeOpen", "open", "beforeClose"]);
 
       closingControlledPromise.resolve();
-      await waitForAnimationFrame();
+      await afterNextFrame();
 
       expect(emittedEvents).toEqual(["beforeOpen", "open", "beforeClose", "close"]);
     });


### PR DESCRIPTION
**monday.com sync:** #12135635232

**Related Issue:** N/A

## Summary

This updates timing helpers across the codebase to improve clarity and consistency in browser-based tests. The main change is renaming utils with new, more descriptive names, reflecting event loop semantics.
