### PR TITLE
fix(dialog): honor `--calcite-dialog-offset-y` regardless of fullscreen behavior

### DIFF
--- a/packages/components/src/components/dialog/dialog.scss
+++ b/packages/components/src/components/dialog/dialog.scss
@@ -228,7 +228,7 @@ calcite-panel {
   visibility: hidden;
 
   transition:
-    inset-block var(--calcite-internal-animation-timing-slow) animation.$easing-function,
+    inset-block var(--calcite-internal-animation-timing-slow) animation.$easing-function allow-discrete,
     opacity var(--calcite-internal-animation-timing-slow) animation.$easing-function;
 
   border-radius: var(--calcite-dialog-corner-radius, var(--calcite-corner-radius-sm));
@@ -245,12 +245,6 @@ calcite-panel {
 
   inset-inline-start: var(--calcite-dialog-offset-x, 0);
   inset-block-start: var(--calcite-internal-dialog-hidden-position);
-
-  &--opening {
-    &-active {
-      inset-block-start: var(--calcite-internal-dialog-shown-position);
-    }
-  }
 }
 
 :host([top-layer-disabled]) .dialog,
@@ -290,7 +284,7 @@ calcite-panel {
       visible
       opacity-100;
     transition:
-      inset-block var(--calcite-internal-animation-timing-slow) animation.$easing-function,
+      inset-block var(--calcite-internal-animation-timing-slow) animation.$easing-function allow-discrete,
       opacity var(--calcite-internal-animation-timing-slow) animation.$easing-function;
     transition-delay: 0ms;
   }
@@ -314,13 +308,6 @@ calcite-panel {
             max-w-full;
         inset-inline-start: 0;
         inset-block-start: var(--calcite-internal-dialog-animation-offset);
-      }
-    }
-    .width-#{$size}.dialog {
-      &--opening {
-        &-active {
-          inset-block-start: 0;
-        }
       }
     }
   }
@@ -380,6 +367,16 @@ calcite-panel {
 
 :host([kind="warning"]) .dialog {
   border-color: var(--calcite-dialog-accent-color, var(--calcite-color-status-warning));
+}
+
+:host([open]) {
+  .dialog {
+    inset-block-start: var(--calcite-internal-dialog-shown-position);
+
+    @starting-style {
+      inset-block-start: var(--calcite-internal-dialog-hidden-position);
+    }
+  }
 }
 
 :host([kind="brand"][open]),

--- a/packages/components/src/components/dialog/dialog.scss
+++ b/packages/components/src/components/dialog/dialog.scss
@@ -228,7 +228,7 @@ calcite-panel {
   visibility: hidden;
 
   transition:
-    inset-block var(--calcite-internal-animation-timing-slow) animation.$easing-function allow-discrete,
+    inset-block-start var(--calcite-internal-animation-timing-slow) animation.$easing-function allow-discrete,
     opacity var(--calcite-internal-animation-timing-slow) animation.$easing-function;
 
   border-radius: var(--calcite-dialog-corner-radius, var(--calcite-corner-radius-sm));
@@ -284,7 +284,7 @@ calcite-panel {
       visible
       opacity-100;
     transition:
-      inset-block var(--calcite-internal-animation-timing-slow) animation.$easing-function allow-discrete,
+      inset-block-start var(--calcite-internal-animation-timing-slow) animation.$easing-function allow-discrete,
       opacity var(--calcite-internal-animation-timing-slow) animation.$easing-function;
     transition-delay: 0ms;
   }

--- a/packages/components/src/components/dialog/dialog.tsx
+++ b/packages/components/src/components/dialog/dialog.tsx
@@ -459,12 +459,6 @@ export class Dialog extends LitElement implements OpenCloseComponentWithEl {
   }
 
   private handleOpenedChange(): void {
-    const { transitionEl } = this;
-
-    if (!transitionEl) {
-      return;
-    }
-
     toggleOpenClose(this);
   }
 

--- a/packages/components/src/components/dialog/dialog.tsx
+++ b/packages/components/src/components/dialog/dialog.tsx
@@ -390,7 +390,7 @@ export class Dialog extends LitElement implements OpenCloseComponentWithEl {
     }
 
     if (changes.has("opened") && (this.hasUpdated || this.opened !== false)) {
-      this.handleOpenedChange(this.opened);
+      this.handleOpenedChange();
     }
   }
 
@@ -458,14 +458,13 @@ export class Dialog extends LitElement implements OpenCloseComponentWithEl {
     this.opened = value;
   }
 
-  private handleOpenedChange(value: boolean): void {
+  private handleOpenedChange(): void {
     const { transitionEl } = this;
 
     if (!transitionEl) {
       return;
     }
 
-    transitionEl.classList.toggle(CSS.openingActive, value);
     toggleOpenClose(this);
   }
 

--- a/packages/components/src/components/dialog/resources.ts
+++ b/packages/components/src/components/dialog/resources.ts
@@ -9,7 +9,6 @@ export const CSS = {
   containerOpen: "container--open",
   containerEmbedded: "container--embedded",
   assistiveText: "assistive-text",
-  openingActive: "dialog--opening-active",
 };
 
 export const SLOTS = {


### PR DESCRIPTION
**Related Issue:** #13902 

## Summary

This refactors the open/close animation handling in the `calcite-dialog` component to use uses [`@starting-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/@starting-style) and [`transition-behavior`](https://developer.mozilla.org/en-US/docs/Web/CSS/transition-behavior) instead of manually managing idle, start, end classes (like modal did).