### PR TITLE
docs(carousel, meter): fix design tokens doc formatting

### DIFF
--- a/packages/components/src/components/carousel/carousel.scss
+++ b/packages/components/src/components/carousel/carousel.scss
@@ -3,17 +3,17 @@
   *
   * These properties can be overridden using the component's tag as selector.
   *
-  * --calcite-carousel-pagination-background-color: Specifies the background color of the component's pagination items, navigation arrows, and autoplay controls.
-  * --calcite-carousel-pagination-background-color-hover: Specifies the background color of the component's pagination items, navigation arrows, and autoplay controls when hovered.
-  * --calcite-carousel-pagination-background-color-press: Specifies the background color of the component's pagination items, navigation arrows, and autoplay controls when pressed.
-  * --calcite-carousel-pagination-background-color-selected: Specifies the background color of the component's pagination items, navigation arrows, and autoplay controls when selected.
-  * --calcite-carousel-pagination-icon-color: Specifies the icon color of the component's pagination items and autoplay controls.
-  * --calcite-carousel-pagination-icon-color-hover: Specifies the icon color of the component's pagination items when hovered or pressed.
-  * --calcite-carousel-pagination-icon-color-selected: Specifies the icon color of the component's pagination items when selected.
-  * --calcite-carousel-control-icon-color: Specifies the icon color of the component's navigation arrow controls.
-  * --calcite-carousel-control-icon-color-hover: Specifies the icon color of the component's navigation arrow controls when hovered or pressed.
-  * --calcite-carousel-autoplay-progress-background-color: Specifies the background color of the component's autoplay progress when `autoplay` is specified.
-  * --calcite-carousel-autoplay-progress-fill-color: Specifies the fill color of the component's autoplay progress when `autoplay` is specified.
+  * @prop --calcite-carousel-pagination-background-color: Specifies the background color of the component's pagination items, navigation arrows, and autoplay controls.
+  * @prop --calcite-carousel-pagination-background-color-hover: Specifies the background color of the component's pagination items, navigation arrows, and autoplay controls when hovered.
+  * @prop --calcite-carousel-pagination-background-color-press: Specifies the background color of the component's pagination items, navigation arrows, and autoplay controls when pressed.
+  * @prop --calcite-carousel-pagination-background-color-selected: Specifies the background color of the component's pagination items, navigation arrows, and autoplay controls when selected.
+  * @prop --calcite-carousel-pagination-icon-color: Specifies the icon color of the component's pagination items and autoplay controls.
+  * @prop --calcite-carousel-pagination-icon-color-hover: Specifies the icon color of the component's pagination items when hovered or pressed.
+  * @prop --calcite-carousel-pagination-icon-color-selected: Specifies the icon color of the component's pagination items when selected.
+  * @prop --calcite-carousel-control-icon-color: Specifies the icon color of the component's navigation arrow controls.
+  * @prop --calcite-carousel-control-icon-color-hover: Specifies the icon color of the component's navigation arrow controls when hovered or pressed.
+  * @prop --calcite-carousel-autoplay-progress-background-color: Specifies the background color of the component's autoplay progress when `autoplay` is specified.
+  * @prop --calcite-carousel-autoplay-progress-fill-color: Specifies the fill color of the component's autoplay progress when `autoplay` is specified.
   *
 */
 

--- a/packages/components/src/components/meter/meter.scss
+++ b/packages/components/src/components/meter/meter.scss
@@ -13,23 +13,6 @@
  *
  */
 
-/**
-  * Local props
-  * These properties are intended for internal component use only. It is not recommended that these properties be overwritten.
-  *
-  * --calcite-internal-meter-fill-color
-  * --calcite-internal-meter-background-color
-  * --calcite-internal-meter-space
-  * --calcite-internal-meter-height
-  * --calcite-internal-meter-font-size
-  * --calcite-internal-meter-border-color
-  * --calcite-internal-meter-shadow
-  * --calcite-internal-meter-corner-radius
-  * --calcite-internal-meter-value-text-color
-  * --calcite-internal-meter-range-text-color
-  *
-*/
-
 // AUTO-GENERATED — do not modify. Changes will be overwritten.
 //
 // Internal CSS custom properties for component use only. Overwriting is not recommended.


### PR DESCRIPTION
**Related Issue:** #13864

## Summary
- Carousel: adds the correct `@prop` prefix to the public tokens, including them in the build output.
- Meter: clean up manually entered internal tokens comment.
