### PR TITLE
chore: fix API extractor errors

### DIFF
--- a/packages/components/src/controllers/useFocusTrap.ts
+++ b/packages/components/src/controllers/useFocusTrap.ts
@@ -74,6 +74,7 @@ interface FocusTrapComponent extends LitElement {
   focusTrapOptions?: Partial<FocusTrapOptions>;
 }
 
+/** @public */
 export type FocusTrapOptions =
   /**
    * @see https://github.com/focus-trap/focus-trap#createoptions

--- a/packages/components/src/controllers/useTime.ts
+++ b/packages/components/src/controllers/useTime.ts
@@ -687,4 +687,5 @@ class TimeController extends GenericController<TimeProperties, TimeComponent> {
   //#endregion
 }
 
+/** @public */
 export const useTime = toFunction(TimeController);


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Fixes the following errors:

```sh
■  Vite src/components/dialog/dialog.tsx:1:1 - error TS@arcgis/api-extractor: The
│  FocusTrapOptions imported from controllers/useFocusTrap is not @public but used
│  in the type of a @public declaration. Add /** @public */ JSDoc, refactor out the
│  usage, or ensure FocusTrapOptions is not a re-export.

│
■  Vite src/components/popover/popover.tsx:1:1 - error TS@arcgis/api-extractor: The
│  FocusTrapOptions imported from controllers/useFocusTrap is not @public but used
│  in the type of a @public declaration. Add /** @public */ JSDoc, refactor out the
│  usage, or ensure FocusTrapOptions is not a re-export.

│
■  Vite src/components/sheet/sheet.tsx:1:1 - error TS@arcgis/api-extractor: The
│  FocusTrapOptions imported from controllers/useFocusTrap is not @public but used
│  in the type of a @public declaration. Add /** @public */ JSDoc, refactor out the
│  usage, or ensure FocusTrapOptions is not a re-export.

│
■  Vite src/components/time-picker/time-picker.tsx:1:1 - error
│  TS@arcgis/api-extractor: The useTime imported from controllers/useTime is not
│  @public but used in the type of a @public declaration. Add /** @public */ JSDoc,
│  refactor out the usage, or ensure useTime is not a re-export.

│
■  Vite [@arcgis/api-extractor] Found 4 errors
```