### PR TITLE
docs(angular sample): Add css import step to the readme

### DIFF
--- a/examples/components/angular/README.md
+++ b/examples/components/angular/README.md
@@ -79,6 +79,6 @@ cp -r node_modules/@esri/calcite-components/dist/cdn/assets/ ./public
 
 Angular does not automatically load `.css` assets from external libraries. To ensure all component styles load correctly, explicitly import Calcite’s CSS in the project's root stylesheet (`src/styles.css`):
 
-```javascript
-import "@esri/calcite-components/main.css";
+```css
+@import "@esri/calcite-components/main.css";
 ```

--- a/examples/components/angular/README.md
+++ b/examples/components/angular/README.md
@@ -75,7 +75,7 @@ Calcite components' assets need to be copied to the `./public` directory when [u
 cp -r node_modules/@esri/calcite-components/dist/cdn/assets/ ./public
 ```
 
-### Import the styles
+### Import CSS styles
 
 Angular does not automatically load `.css` assets from external libraries. To ensure all component styles load correctly, explicitly import Calcite’s CSS in the project's root stylesheet (`src/styles.css`):
 

--- a/examples/components/angular/README.md
+++ b/examples/components/angular/README.md
@@ -74,3 +74,11 @@ Calcite components' assets need to be copied to the `./public` directory when [u
 ```sh
 cp -r node_modules/@esri/calcite-components/dist/cdn/assets/ ./public
 ```
+
+### Import the styles
+
+Angular does not automatically load `.css` assets from external libraries. To ensure all component styles load correctly, import Calcite’s CSS in your Angular app’s global stylesheet (`src/styles.css`):
+
+```javascript
+import "@esri/calcite-components/main.css";
+```

--- a/examples/components/angular/README.md
+++ b/examples/components/angular/README.md
@@ -77,7 +77,7 @@ cp -r node_modules/@esri/calcite-components/dist/cdn/assets/ ./public
 
 ### Import the styles
 
-Angular does not automatically load `.css` assets from external libraries. To ensure all component styles load correctly, import Calcite’s CSS in your Angular app’s global stylesheet (`src/styles.css`):
+Angular does not automatically load `.css` assets from external libraries. To ensure all component styles load correctly, explicitly import Calcite’s CSS in the project's root stylesheet (`src/styles.css`):
 
 ```javascript
 import "@esri/calcite-components/main.css";

--- a/examples/components/angular/src/styles.css
+++ b/examples/components/angular/src/styles.css
@@ -1,3 +1,5 @@
+@import "@esri/calcite-components/main.css";
+
 html,
 body {
   height: 100%;


### PR DESCRIPTION
**Related Issue:** [Devtopia issue](https://devtopia.esri.com/ArcGISDevelopers/calcite-documentation/issues/1478#event-31883421)

## Summary
Update the Angular readme to include instruction for importing Calcite's style sheet and update the sample to include an import statement in the main styles.css file.

Maps SDK docs on this: https://developers.arcgis.com/javascript/latest/get-started/#angular