### PR TITLE
docs(tokens): change deprecations to tokens package versions

### DIFF
--- a/packages/design-tokens/src/tokens/core/color.json
+++ b/packages/design-tokens/src/tokens/core/color.json
@@ -1288,7 +1288,7 @@
           "l-vv-1000": {
             "value": "#13111a",
             "type": "color",
-            "description": "Deprecated in v3.3.0, removal target v6.0.0 - Use `--calcite-color-low-saturation-violet-l-vv-100` instead.",
+            "description": "Deprecated in Calcite Components v3.3.0, removal target v6.0.0 - Use `--calcite-color-low-saturation-violet-l-vv-100` instead.",
             "attributes": {
               "category": "color",
               "group": "low-saturation",

--- a/packages/design-tokens/src/tokens/core/color.json
+++ b/packages/design-tokens/src/tokens/core/color.json
@@ -1288,7 +1288,7 @@
           "l-vv-1000": {
             "value": "#13111a",
             "type": "color",
-            "description": "Deprecated in Calcite Components v3.3.0, removal target v6.0.0 - Use `--calcite-color-low-saturation-violet-l-vv-100` instead.",
+            "description": "Deprecated in v3.3.0, removal target v5.0.0 - Use `--calcite-color-low-saturation-violet-l-vv-100` instead.",
             "attributes": {
               "category": "color",
               "group": "low-saturation",

--- a/packages/design-tokens/src/tokens/core/color.json
+++ b/packages/design-tokens/src/tokens/core/color.json
@@ -1288,7 +1288,7 @@
           "l-vv-1000": {
             "value": "#13111a",
             "type": "color",
-            "description": "Deprecated in v3.3.0, removal target v5.0.0 - Use `--calcite-color-low-saturation-violet-l-vv-100` instead.",
+            "description": "Deprecated in v3.2.0, removal target v5.0.0 - Use `--calcite-color-low-saturation-violet-l-vv-100` instead.",
             "attributes": {
               "category": "color",
               "group": "low-saturation",

--- a/packages/design-tokens/src/tokens/core/font.json
+++ b/packages/design-tokens/src/tokens/core/font.json
@@ -185,7 +185,7 @@
         "none": {
           "value": "none",
           "type": "textDecoration",
-          "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+          "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - No longer needed.",
           "attributes": {
             "category": "font",
             "docs": "deprecated"
@@ -194,7 +194,7 @@
         "underline": {
           "value": "underline",
           "type": "textDecoration",
-          "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+          "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - No longer needed.",
           "attributes": {
             "category": "font",
             "docs": "deprecated"
@@ -205,7 +205,7 @@
         "none": {
           "value": "none",
           "type": "textCase",
-          "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+          "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - No longer needed.",
           "attributes": {
             "category": "font",
             "docs": "deprecated"
@@ -214,7 +214,7 @@
         "uppercase": {
           "value": "uppercase",
           "type": "textCase",
-          "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+          "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - No longer needed.",
           "attributes": {
             "category": "font",
             "docs": "deprecated"
@@ -223,7 +223,7 @@
         "lowercase": {
           "value": "lowercase",
           "type": "textCase",
-          "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+          "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - No longer needed.",
           "attributes": {
             "category": "font",
             "docs": "deprecated"
@@ -232,7 +232,7 @@
         "capitalize": {
           "value": "capitalize",
           "type": "textCase",
-          "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+          "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - No longer needed.",
           "attributes": {
             "category": "font",
             "docs": "deprecated"

--- a/packages/design-tokens/src/tokens/core/font.json
+++ b/packages/design-tokens/src/tokens/core/font.json
@@ -185,7 +185,7 @@
         "none": {
           "value": "none",
           "type": "textDecoration",
-          "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - No longer needed.",
+          "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
           "attributes": {
             "category": "font",
             "docs": "deprecated"
@@ -194,7 +194,7 @@
         "underline": {
           "value": "underline",
           "type": "textDecoration",
-          "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - No longer needed.",
+          "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
           "attributes": {
             "category": "font",
             "docs": "deprecated"
@@ -205,7 +205,7 @@
         "none": {
           "value": "none",
           "type": "textCase",
-          "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - No longer needed.",
+          "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
           "attributes": {
             "category": "font",
             "docs": "deprecated"
@@ -214,7 +214,7 @@
         "uppercase": {
           "value": "uppercase",
           "type": "textCase",
-          "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - No longer needed.",
+          "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
           "attributes": {
             "category": "font",
             "docs": "deprecated"
@@ -223,7 +223,7 @@
         "lowercase": {
           "value": "lowercase",
           "type": "textCase",
-          "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - No longer needed.",
+          "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
           "attributes": {
             "category": "font",
             "docs": "deprecated"
@@ -232,7 +232,7 @@
         "capitalize": {
           "value": "capitalize",
           "type": "textCase",
-          "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - No longer needed.",
+          "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
           "attributes": {
             "category": "font",
             "docs": "deprecated"

--- a/packages/design-tokens/src/tokens/semantic/color/dark.json
+++ b/packages/design-tokens/src/tokens/semantic/color/dark.json
@@ -103,7 +103,7 @@
           "group": "foreground",
           "docs": "deprecated"
         },
-        "description": "Deprecated in v3.3.0, removal target v5.0.0 - Use `--calcite-color-surface-highlight` instead."
+        "description": "Deprecated in v3.2.0, removal target v5.0.0 - Use `--calcite-color-surface-highlight` instead."
       }
     },
     "text": {

--- a/packages/design-tokens/src/tokens/semantic/color/dark.json
+++ b/packages/design-tokens/src/tokens/semantic/color/dark.json
@@ -51,7 +51,7 @@
           "group": "background",
           "docs": "deprecated"
         },
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use `--calcite-color-surface-1` instead."
+        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-color-surface-1` instead."
       },
       "none": {
         "value": "rgba({core.color.neutral.blk-000}, {core.opacity.0})",
@@ -61,7 +61,7 @@
           "group": "background",
           "docs": "unlisted"
         },
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - No longer needed."
+        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - No longer needed."
       }
     },
     "foreground": {
@@ -73,7 +73,7 @@
           "group": "foreground",
           "docs": "deprecated"
         },
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use `--calcite-color-surface-2` instead."
+        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-color-surface-2` instead."
       },
       "2": {
         "value": "{core.color.neutral.blk-190}",
@@ -83,7 +83,7 @@
           "group": "foreground",
           "docs": "deprecated"
         },
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use `--calcite-color-surface-3` instead."
+        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-color-surface-3` instead."
       },
       "3": {
         "value": "{core.color.neutral.blk-180}",
@@ -93,7 +93,7 @@
           "group": "foreground",
           "docs": "deprecated"
         },
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use `--calcite-color-surface-4` instead."
+        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-color-surface-4` instead."
       },
       "current": {
         "value": "{core.color.medium-saturation.blue.m-bb-090}",
@@ -103,7 +103,7 @@
           "group": "foreground",
           "docs": "deprecated"
         },
-        "description": "Deprecated in v3.3.0, removal target v6.0.0 - Use `--calcite-color-surface-highlight` instead."
+        "description": "Deprecated in Calcite Components v3.3.0, removal target v6.0.0 - Use `--calcite-color-surface-highlight` instead."
       }
     },
     "text": {
@@ -197,7 +197,7 @@
           "group": "border",
           "docs": "unlisted"
         },
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - No longer needed."
+        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - No longer needed."
       },
       "white": {
         "value": "{core.color.neutral.blk-005}",
@@ -207,7 +207,7 @@
           "group": "border",
           "docs": "unlisted"
         },
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - No longer needed."
+        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - No longer needed."
       }
     },
     "brand": {

--- a/packages/design-tokens/src/tokens/semantic/color/dark.json
+++ b/packages/design-tokens/src/tokens/semantic/color/dark.json
@@ -51,7 +51,7 @@
           "group": "background",
           "docs": "deprecated"
         },
-        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-color-surface-1` instead."
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use `--calcite-color-surface-1` instead."
       },
       "none": {
         "value": "rgba({core.color.neutral.blk-000}, {core.opacity.0})",
@@ -61,7 +61,7 @@
           "group": "background",
           "docs": "unlisted"
         },
-        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - No longer needed."
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - No longer needed."
       }
     },
     "foreground": {
@@ -73,7 +73,7 @@
           "group": "foreground",
           "docs": "deprecated"
         },
-        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-color-surface-2` instead."
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use `--calcite-color-surface-2` instead."
       },
       "2": {
         "value": "{core.color.neutral.blk-190}",
@@ -83,7 +83,7 @@
           "group": "foreground",
           "docs": "deprecated"
         },
-        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-color-surface-3` instead."
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use `--calcite-color-surface-3` instead."
       },
       "3": {
         "value": "{core.color.neutral.blk-180}",
@@ -93,7 +93,7 @@
           "group": "foreground",
           "docs": "deprecated"
         },
-        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-color-surface-4` instead."
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use `--calcite-color-surface-4` instead."
       },
       "current": {
         "value": "{core.color.medium-saturation.blue.m-bb-090}",
@@ -103,7 +103,7 @@
           "group": "foreground",
           "docs": "deprecated"
         },
-        "description": "Deprecated in Calcite Components v3.3.0, removal target v6.0.0 - Use `--calcite-color-surface-highlight` instead."
+        "description": "Deprecated in v3.3.0, removal target v5.0.0 - Use `--calcite-color-surface-highlight` instead."
       }
     },
     "text": {
@@ -197,7 +197,7 @@
           "group": "border",
           "docs": "unlisted"
         },
-        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - No longer needed."
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - No longer needed."
       },
       "white": {
         "value": "{core.color.neutral.blk-005}",
@@ -207,7 +207,7 @@
           "group": "border",
           "docs": "unlisted"
         },
-        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - No longer needed."
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - No longer needed."
       }
     },
     "brand": {

--- a/packages/design-tokens/src/tokens/semantic/color/light.json
+++ b/packages/design-tokens/src/tokens/semantic/color/light.json
@@ -103,7 +103,7 @@
           "group": "foreground",
           "docs": "deprecated"
         },
-        "description": "Deprecated in v3.3.0, removal target v5.0.0 - Use `--calcite-color-surface-highlight` instead."
+        "description": "Deprecated in v3.2.0, removal target v5.0.0 - Use `--calcite-color-surface-highlight` instead."
       }
     },
     "text": {

--- a/packages/design-tokens/src/tokens/semantic/color/light.json
+++ b/packages/design-tokens/src/tokens/semantic/color/light.json
@@ -51,7 +51,7 @@
           "group": "background",
           "docs": "deprecated"
         },
-        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-color-surface-1` instead."
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use `--calcite-color-surface-1` instead."
       },
       "none": {
         "value": "rgba({core.color.neutral.blk-000}, {core.opacity.0})",
@@ -61,7 +61,7 @@
           "group": "background",
           "docs": "unlisted"
         },
-        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - No longer needed."
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - No longer needed."
       }
     },
     "foreground": {
@@ -73,7 +73,7 @@
           "group": "foreground",
           "docs": "deprecated"
         },
-        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-color-surface-2` instead."
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use `--calcite-color-surface-2` instead."
       },
       "2": {
         "value": "{core.color.neutral.blk-010}",
@@ -83,7 +83,7 @@
           "group": "foreground",
           "docs": "deprecated"
         },
-        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-color-surface-3` instead."
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use `--calcite-color-surface-3` instead."
       },
       "3": {
         "value": "{core.color.neutral.blk-020}",
@@ -93,7 +93,7 @@
           "group": "foreground",
           "docs": "deprecated"
         },
-        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-color-surface-4` instead."
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use `--calcite-color-surface-4` instead."
       },
       "current": {
         "value": "{core.color.high-saturation.blue.h-bb-010}",
@@ -103,7 +103,7 @@
           "group": "foreground",
           "docs": "deprecated"
         },
-        "description": "Deprecated in Calcite Components v3.3.0, removal target v6.0.0 - Use `--calcite-color-surface-highlight` instead."
+        "description": "Deprecated in v3.3.0, removal target v5.0.0 - Use `--calcite-color-surface-highlight` instead."
       }
     },
     "text": {
@@ -197,7 +197,7 @@
           "group": "border",
           "docs": "unlisted"
         },
-        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - No longer needed."
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - No longer needed."
       },
       "white": {
         "value": "{core.color.neutral.blk-000}",
@@ -207,7 +207,7 @@
           "group": "border",
           "docs": "unlisted"
         },
-        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - No longer needed."
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - No longer needed."
       }
     },
     "brand": {

--- a/packages/design-tokens/src/tokens/semantic/color/light.json
+++ b/packages/design-tokens/src/tokens/semantic/color/light.json
@@ -51,7 +51,7 @@
           "group": "background",
           "docs": "deprecated"
         },
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use `--calcite-color-surface-1` instead."
+        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-color-surface-1` instead."
       },
       "none": {
         "value": "rgba({core.color.neutral.blk-000}, {core.opacity.0})",
@@ -61,7 +61,7 @@
           "group": "background",
           "docs": "unlisted"
         },
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - No longer needed."
+        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - No longer needed."
       }
     },
     "foreground": {
@@ -73,7 +73,7 @@
           "group": "foreground",
           "docs": "deprecated"
         },
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use `--calcite-color-surface-2` instead."
+        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-color-surface-2` instead."
       },
       "2": {
         "value": "{core.color.neutral.blk-010}",
@@ -83,7 +83,7 @@
           "group": "foreground",
           "docs": "deprecated"
         },
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use `--calcite-color-surface-3` instead."
+        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-color-surface-3` instead."
       },
       "3": {
         "value": "{core.color.neutral.blk-020}",
@@ -93,7 +93,7 @@
           "group": "foreground",
           "docs": "deprecated"
         },
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use `--calcite-color-surface-4` instead."
+        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-color-surface-4` instead."
       },
       "current": {
         "value": "{core.color.high-saturation.blue.h-bb-010}",
@@ -103,7 +103,7 @@
           "group": "foreground",
           "docs": "deprecated"
         },
-        "description": "Deprecated in v3.3.0, removal target v6.0.0 - Use `--calcite-color-surface-highlight` instead."
+        "description": "Deprecated in Calcite Components v3.3.0, removal target v6.0.0 - Use `--calcite-color-surface-highlight` instead."
       }
     },
     "text": {
@@ -197,7 +197,7 @@
           "group": "border",
           "docs": "unlisted"
         },
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - No longer needed."
+        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - No longer needed."
       },
       "white": {
         "value": "{core.color.neutral.blk-000}",
@@ -207,7 +207,7 @@
           "group": "border",
           "docs": "unlisted"
         },
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - No longer needed."
+        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - No longer needed."
       }
     },
     "brand": {

--- a/packages/design-tokens/src/tokens/semantic/container-size.json
+++ b/packages/design-tokens/src/tokens/semantic/container-size.json
@@ -7,7 +7,7 @@
           "max": "{core.container-size.154}"
         },
         "type": "dimension",
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use `--calcite-container-size-height-2xs-min|max` instead.",
+        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-container-size-height-2xs-min|max` instead.",
         "attributes": {
           "category": "breakpoint",
           "docs": "deprecated"
@@ -86,7 +86,7 @@
           "max": "{core.container-size.320}"
         },
         "type": "dimension",
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use `--calcite-container-size-width-2xs-min|max` instead.",
+        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-container-size-width-2xs-min|max` instead.",
         "attributes": {
           "category": "breakpoint",
           "docs": "deprecated"

--- a/packages/design-tokens/src/tokens/semantic/container-size.json
+++ b/packages/design-tokens/src/tokens/semantic/container-size.json
@@ -7,7 +7,7 @@
           "max": "{core.container-size.154}"
         },
         "type": "dimension",
-        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-container-size-height-2xs-min|max` instead.",
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use `--calcite-container-size-height-2xs-min|max` instead.",
         "attributes": {
           "category": "breakpoint",
           "docs": "deprecated"
@@ -86,7 +86,7 @@
           "max": "{core.container-size.320}"
         },
         "type": "dimension",
-        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-container-size-width-2xs-min|max` instead.",
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use `--calcite-container-size-width-2xs-min|max` instead.",
         "attributes": {
           "category": "breakpoint",
           "docs": "deprecated"

--- a/packages/design-tokens/src/tokens/semantic/corner-radius.json
+++ b/packages/design-tokens/src/tokens/semantic/corner-radius.json
@@ -14,7 +14,7 @@
         "category": "corner-radius",
         "docs": "deprecated"
       },
-      "description": "Deprecated in Calcite Components v3.2.0, removal target v6.0.0 - Use `--calcite-corner-radius-none` instead."
+      "description": "Deprecated in v3.1.0, removal target v5.0.0 - Use `--calcite-corner-radius-none` instead."
     },
     "none": {
       "value": "{core.size.default.none}",
@@ -44,7 +44,7 @@
         "category": "corner-radius",
         "docs": "deprecated"
       },
-      "description": "Deprecated in Calcite Components v3.2.0, removal target v6.0.0 - Use `--calcite-corner-radius-sm` instead."
+      "description": "Deprecated in v3.1.0, removal target v5.0.0 - Use `--calcite-corner-radius-sm` instead."
     },
     "pill": {
       "value": "{core.size.default.9999}",

--- a/packages/design-tokens/src/tokens/semantic/corner-radius.json
+++ b/packages/design-tokens/src/tokens/semantic/corner-radius.json
@@ -14,7 +14,7 @@
         "category": "corner-radius",
         "docs": "deprecated"
       },
-      "description": "Deprecated in v3.2.0, removal target v6.0.0 - Use `--calcite-corner-radius-none` instead."
+      "description": "Deprecated in Calcite Components v3.2.0, removal target v6.0.0 - Use `--calcite-corner-radius-none` instead."
     },
     "none": {
       "value": "{core.size.default.none}",
@@ -44,7 +44,7 @@
         "category": "corner-radius",
         "docs": "deprecated"
       },
-      "description": "Deprecated in v3.2.0, removal target v6.0.0 - Use `--calcite-corner-radius-sm` instead."
+      "description": "Deprecated in Calcite Components v3.2.0, removal target v6.0.0 - Use `--calcite-corner-radius-sm` instead."
     },
     "pill": {
       "value": "{core.size.default.9999}",

--- a/packages/design-tokens/src/tokens/semantic/font.json
+++ b/packages/design-tokens/src/tokens/semantic/font.json
@@ -41,7 +41,7 @@
           "group": "weight",
           "docs": "deprecated"
         },
-        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - Use `--calcite-font-weight-regular` instead."
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use `--calcite-font-weight-regular` instead."
       },
       "regular": {
         "value": "{core.font.weight.regular}",
@@ -133,7 +133,7 @@
           "group": "size",
           "docs": "deprecated"
         },
-        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-font-size-2xl` instead."
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use `--calcite-font-size-2xl` instead."
       },
       "2xl": {
         "value": "{core.size.default.24}",
@@ -522,7 +522,7 @@
       "tight": {
         "value": "{core.size.default.none} - .4 ",
         "type": "letterSpacing",
-        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "attributes": {
           "category": "font",
           "group": "letter-spacing",
@@ -532,7 +532,7 @@
       "normal": {
         "value": "{core.size.default.none}",
         "type": "letterSpacing",
-        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "attributes": {
           "category": "font",
           "group": "letter-spacing",
@@ -542,7 +542,7 @@
       "wide": {
         "value": "{core.size.default.none} + .4 ",
         "type": "letterSpacing",
-        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "attributes": {
           "category": "font",
           "group": "letter-spacing",
@@ -554,7 +554,7 @@
       "normal": {
         "value": "{core.size.default.4}",
         "type": "paragraphSpacing",
-        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "attributes": {
           "category": "font",
           "group": "paragraph-spacing"
@@ -565,7 +565,7 @@
       "none": {
         "value": "{core.font.text-decoration.none}",
         "type": "textDecoration",
-        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "attributes": {
           "category": "font",
           "group": "text-decoration",
@@ -575,7 +575,7 @@
       "underline": {
         "value": "{core.font.text-decoration.underline}",
         "type": "textDecoration",
-        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "attributes": {
           "category": "font",
           "group": "text-decoration",
@@ -587,7 +587,7 @@
       "none": {
         "value": "{core.font.text-case.none}",
         "type": "textCase",
-        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "attributes": {
           "category": "font",
           "group": "text-case",
@@ -597,7 +597,7 @@
       "uppercase": {
         "value": "{core.font.text-case.uppercase}",
         "type": "textCase",
-        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "attributes": {
           "category": "font",
           "group": "text-case",
@@ -607,7 +607,7 @@
       "lowercase": {
         "value": "{core.font.text-case.lowercase}",
         "type": "textCase",
-        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "attributes": {
           "category": "font",
           "group": "text-case",
@@ -617,7 +617,7 @@
       "capitalize": {
         "value": "{core.font.text-case.capitalize}",
         "type": "textCase",
-        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "attributes": {
           "category": "font",
           "group": "text-case",

--- a/packages/design-tokens/src/tokens/semantic/font.json
+++ b/packages/design-tokens/src/tokens/semantic/font.json
@@ -41,7 +41,7 @@
           "group": "weight",
           "docs": "deprecated"
         },
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use `--calcite-font-weight-regular` instead."
+        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - Use `--calcite-font-weight-regular` instead."
       },
       "regular": {
         "value": "{core.font.weight.regular}",
@@ -133,7 +133,7 @@
           "group": "size",
           "docs": "deprecated"
         },
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use `--calcite-font-size-2xl` instead."
+        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-font-size-2xl` instead."
       },
       "2xl": {
         "value": "{core.size.default.24}",
@@ -522,7 +522,7 @@
       "tight": {
         "value": "{core.size.default.none} - .4 ",
         "type": "letterSpacing",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - No longer needed.",
         "attributes": {
           "category": "font",
           "group": "letter-spacing",
@@ -532,7 +532,7 @@
       "normal": {
         "value": "{core.size.default.none}",
         "type": "letterSpacing",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - No longer needed.",
         "attributes": {
           "category": "font",
           "group": "letter-spacing",
@@ -542,7 +542,7 @@
       "wide": {
         "value": "{core.size.default.none} + .4 ",
         "type": "letterSpacing",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - No longer needed.",
         "attributes": {
           "category": "font",
           "group": "letter-spacing",
@@ -554,7 +554,7 @@
       "normal": {
         "value": "{core.size.default.4}",
         "type": "paragraphSpacing",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - No longer needed.",
         "attributes": {
           "category": "font",
           "group": "paragraph-spacing"
@@ -565,7 +565,7 @@
       "none": {
         "value": "{core.font.text-decoration.none}",
         "type": "textDecoration",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - No longer needed.",
         "attributes": {
           "category": "font",
           "group": "text-decoration",
@@ -575,7 +575,7 @@
       "underline": {
         "value": "{core.font.text-decoration.underline}",
         "type": "textDecoration",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - No longer needed.",
         "attributes": {
           "category": "font",
           "group": "text-decoration",
@@ -587,7 +587,7 @@
       "none": {
         "value": "{core.font.text-case.none}",
         "type": "textCase",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - No longer needed.",
         "attributes": {
           "category": "font",
           "group": "text-case",
@@ -597,7 +597,7 @@
       "uppercase": {
         "value": "{core.font.text-case.uppercase}",
         "type": "textCase",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - No longer needed.",
         "attributes": {
           "category": "font",
           "group": "text-case",
@@ -607,7 +607,7 @@
       "lowercase": {
         "value": "{core.font.text-case.lowercase}",
         "type": "textCase",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - No longer needed.",
         "attributes": {
           "category": "font",
           "group": "text-case",
@@ -617,7 +617,7 @@
       "capitalize": {
         "value": "{core.font.text-case.capitalize}",
         "type": "textCase",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - No longer needed.",
         "attributes": {
           "category": "font",
           "group": "text-case",

--- a/packages/design-tokens/src/tokens/semantic/size.json
+++ b/packages/design-tokens/src/tokens/semantic/size.json
@@ -8,7 +8,7 @@
           "category": "size",
           "docs": "deprecated"
         },
-        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - No longer needed."
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed."
       },
       "xxs": {
         "value": "{core.size.default.4}",
@@ -17,7 +17,7 @@
           "category": "size",
           "docs": "deprecated"
         },
-        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - No longer needed."
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed."
       },
       "xs": {
         "value": "{core.size.default.6}",
@@ -26,7 +26,7 @@
           "category": "size",
           "docs": "deprecated"
         },
-        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - No longer needed."
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed."
       },
       "sm": {
         "value": "{core.size.default.8}",
@@ -35,7 +35,7 @@
           "category": "size",
           "docs": "deprecated"
         },
-        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - No longer needed."
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed."
       },
       "sm+": {
         "value": "{core.size.default.10}",
@@ -44,7 +44,7 @@
           "category": "size",
           "docs": "deprecated"
         },
-        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - Use `--calcite-size-4xs` instead."
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use `--calcite-size-4xs` instead."
       },
       "md": {
         "value": "{core.size.default.12}",
@@ -53,7 +53,7 @@
           "category": "size",
           "docs": "deprecated"
         },
-        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - Use `--calcite-size-3xs` instead."
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use `--calcite-size-3xs` instead."
       },
       "md+": {
         "value": "{core.size.default.14}",
@@ -62,7 +62,7 @@
           "category": "size",
           "docs": "deprecated"
         },
-        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - Use `--calcite-size-2xs` instead."
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use `--calcite-size-2xs` instead."
       },
       "lg": {
         "value": "{core.size.default.16}",
@@ -71,7 +71,7 @@
           "category": "size",
           "docs": "deprecated"
         },
-        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - Use `--calcite-size-xs` instead."
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use `--calcite-size-xs` instead."
       },
       "xl": {
         "value": "{core.size.default.20}",
@@ -80,7 +80,7 @@
           "category": "size",
           "docs": "deprecated"
         },
-        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - No longer needed."
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed."
       },
       "xxl": {
         "value": "{core.size.default.24}",
@@ -89,7 +89,7 @@
           "category": "size",
           "docs": "deprecated"
         },
-        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - Use `--calcite-size-sm` instead."
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use `--calcite-size-sm` instead."
       },
       "xxxl": {
         "value": "{core.size.default.32}",
@@ -98,7 +98,7 @@
           "category": "size",
           "docs": "deprecated"
         },
-        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - Use `--calcite-size-md` instead."
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use `--calcite-size-md` instead."
       }
     },
     "px": {
@@ -122,7 +122,7 @@
         "category": "size",
         "docs": "deprecated"
       },
-      "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-size-3xs` instead."
+      "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use `--calcite-size-3xs` instead."
     },
     "3xs": {
       "value": "{core.size.default.12}",
@@ -138,7 +138,7 @@
         "category": "size",
         "docs": "deprecated"
       },
-      "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-size-2xs` instead."
+      "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use `--calcite-size-2xs` instead."
     },
     "2xs": {
       "value": "{core.size.default.14}",
@@ -189,7 +189,7 @@
         "category": "size",
         "docs": "deprecated"
       },
-      "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-size-2xl` instead."
+      "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use `--calcite-size-2xl` instead."
     },
     "2xl": {
       "value": "{core.size.default.64}",
@@ -205,7 +205,7 @@
         "category": "size",
         "docs": "deprecated"
       },
-      "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-size-3xl` instead."
+      "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use `--calcite-size-3xl` instead."
     },
     "3xl": {
       "value": "{core.size.default.96}",

--- a/packages/design-tokens/src/tokens/semantic/size.json
+++ b/packages/design-tokens/src/tokens/semantic/size.json
@@ -8,7 +8,7 @@
           "category": "size",
           "docs": "deprecated"
         },
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed."
+        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - No longer needed."
       },
       "xxs": {
         "value": "{core.size.default.4}",
@@ -17,7 +17,7 @@
           "category": "size",
           "docs": "deprecated"
         },
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed."
+        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - No longer needed."
       },
       "xs": {
         "value": "{core.size.default.6}",
@@ -26,7 +26,7 @@
           "category": "size",
           "docs": "deprecated"
         },
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed."
+        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - No longer needed."
       },
       "sm": {
         "value": "{core.size.default.8}",
@@ -35,7 +35,7 @@
           "category": "size",
           "docs": "deprecated"
         },
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed."
+        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - No longer needed."
       },
       "sm+": {
         "value": "{core.size.default.10}",
@@ -44,7 +44,7 @@
           "category": "size",
           "docs": "deprecated"
         },
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use `--calcite-size-4xs` instead."
+        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - Use `--calcite-size-4xs` instead."
       },
       "md": {
         "value": "{core.size.default.12}",
@@ -53,7 +53,7 @@
           "category": "size",
           "docs": "deprecated"
         },
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use `--calcite-size-3xs` instead."
+        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - Use `--calcite-size-3xs` instead."
       },
       "md+": {
         "value": "{core.size.default.14}",
@@ -62,7 +62,7 @@
           "category": "size",
           "docs": "deprecated"
         },
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use `--calcite-size-2xs` instead."
+        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - Use `--calcite-size-2xs` instead."
       },
       "lg": {
         "value": "{core.size.default.16}",
@@ -71,7 +71,7 @@
           "category": "size",
           "docs": "deprecated"
         },
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use `--calcite-size-xs` instead."
+        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - Use `--calcite-size-xs` instead."
       },
       "xl": {
         "value": "{core.size.default.20}",
@@ -80,7 +80,7 @@
           "category": "size",
           "docs": "deprecated"
         },
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed."
+        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - No longer needed."
       },
       "xxl": {
         "value": "{core.size.default.24}",
@@ -89,7 +89,7 @@
           "category": "size",
           "docs": "deprecated"
         },
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use `--calcite-size-sm` instead."
+        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - Use `--calcite-size-sm` instead."
       },
       "xxxl": {
         "value": "{core.size.default.32}",
@@ -98,7 +98,7 @@
           "category": "size",
           "docs": "deprecated"
         },
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use `--calcite-size-md` instead."
+        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - Use `--calcite-size-md` instead."
       }
     },
     "px": {
@@ -122,7 +122,7 @@
         "category": "size",
         "docs": "deprecated"
       },
-      "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use `--calcite-size-3xs` instead."
+      "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-size-3xs` instead."
     },
     "3xs": {
       "value": "{core.size.default.12}",
@@ -138,7 +138,7 @@
         "category": "size",
         "docs": "deprecated"
       },
-      "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use `--calcite-size-2xs` instead."
+      "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-size-2xs` instead."
     },
     "2xs": {
       "value": "{core.size.default.14}",
@@ -189,7 +189,7 @@
         "category": "size",
         "docs": "deprecated"
       },
-      "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use `--calcite-size-2xl` instead."
+      "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-size-2xl` instead."
     },
     "2xl": {
       "value": "{core.size.default.64}",
@@ -205,7 +205,7 @@
         "category": "size",
         "docs": "deprecated"
       },
-      "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use `--calcite-size-3xl` instead."
+      "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-size-3xl` instead."
     },
     "3xl": {
       "value": "{core.size.default.96}",

--- a/packages/design-tokens/src/tokens/semantic/space.json
+++ b/packages/design-tokens/src/tokens/semantic/space.json
@@ -8,7 +8,7 @@
           "category": "spacing",
           "docs": "unlisted"
         },
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use `--calcite-space-2xs` instead."
+        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - Use `--calcite-space-2xs` instead."
       },
       "xs": {
         "value": "{core.size.default.6}",
@@ -17,7 +17,7 @@
           "category": "spacing",
           "docs": "unlisted"
         },
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use `--calcite-space-xs` instead."
+        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - Use `--calcite-space-xs` instead."
       },
       "sm": {
         "value": "{core.size.default.8}",
@@ -26,7 +26,7 @@
           "category": "spacing",
           "docs": "unlisted"
         },
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use `--calcite-space-sm` instead."
+        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - Use `--calcite-space-sm` instead."
       },
       "md": {
         "value": "{core.size.default.12}",
@@ -35,7 +35,7 @@
           "category": "spacing",
           "docs": "unlisted"
         },
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use `--calcite-space-md` instead."
+        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - Use `--calcite-space-md` instead."
       },
       "lg": {
         "value": "{core.size.default.14}",
@@ -44,7 +44,7 @@
           "category": "spacing",
           "docs": "unlisted"
         },
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use `--calcite-space-md-plus` instead."
+        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - Use `--calcite-space-md-plus` instead."
       },
       "xl": {
         "value": "{core.size.default.16}",
@@ -53,7 +53,7 @@
           "category": "spacing",
           "docs": "unlisted"
         },
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use `--calcite-space-lg` instead."
+        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - Use `--calcite-space-lg` instead."
       },
       "xxl": {
         "value": "{core.size.default.20}",
@@ -62,7 +62,7 @@
           "category": "spacing",
           "docs": "unlisted"
         },
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use `--calcite-space-xl` instead."
+        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - Use `--calcite-space-xl` instead."
       },
       "xxxl": {
         "value": "{core.size.default.32}",
@@ -71,7 +71,7 @@
           "category": "spacing",
           "docs": "unlisted"
         },
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use `--calcite-space-3xl` instead."
+        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - Use `--calcite-space-3xl` instead."
       }
     },
     "default": {
@@ -82,7 +82,7 @@
           "category": "spacing",
           "docs": "deprecated"
         },
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use `--calcite-space-none` instead."
+        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-space-none` instead."
       },
       "px": {
         "value": "{core.size.default.1}",
@@ -91,7 +91,7 @@
           "category": "spacing",
           "docs": "deprecated"
         },
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use `--calcite-space-px` instead."
+        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-space-px` instead."
       },
       "base": {
         "value": "{core.size.default.2}",
@@ -100,7 +100,7 @@
           "category": "spacing",
           "docs": "deprecated"
         },
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use `--calcite-space-base` instead."
+        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-space-base` instead."
       },
       "xxs": {
         "value": "{core.size.default.4}",
@@ -109,7 +109,7 @@
           "category": "spacing",
           "docs": "deprecated"
         },
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use `--calcite-space-2xs` instead."
+        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-space-2xs` instead."
       },
       "xs": {
         "value": "{core.size.default.6}",
@@ -118,7 +118,7 @@
           "category": "spacing",
           "docs": "deprecated"
         },
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use `--calcite-space-xs` instead."
+        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-space-xs` instead."
       },
       "sm": {
         "value": "{core.size.default.8}",
@@ -127,7 +127,7 @@
           "category": "spacing",
           "docs": "deprecated"
         },
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use `--calcite-space-sm` instead."
+        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-space-sm` instead."
       },
       "sm+": {
         "value": "{core.size.default.10}",
@@ -136,7 +136,7 @@
           "category": "spacing",
           "docs": "deprecated"
         },
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use `--calcite-space-sm-plus` instead."
+        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-space-sm-plus` instead."
       },
       "md": {
         "value": "{core.size.default.12}",
@@ -145,7 +145,7 @@
           "category": "spacing",
           "docs": "deprecated"
         },
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use `--calcite-space-md` instead."
+        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-space-md` instead."
       },
       "md+": {
         "value": "{core.size.default.14}",
@@ -154,7 +154,7 @@
           "category": "spacing",
           "docs": "deprecated"
         },
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use `--calcite-space-md-plus` instead."
+        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-space-md-plus` instead."
       },
       "lg": {
         "value": "{core.size.default.16}",
@@ -163,7 +163,7 @@
           "category": "spacing",
           "docs": "deprecated"
         },
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use `--calcite-space-lg` instead."
+        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-space-lg` instead."
       },
       "xl": {
         "value": "{core.size.default.20}",
@@ -172,7 +172,7 @@
           "category": "spacing",
           "docs": "deprecated"
         },
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use `--calcite-space-xl` instead."
+        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-space-xl` instead."
       },
       "xxl": {
         "value": "{core.size.default.24}",
@@ -181,7 +181,7 @@
           "category": "spacing",
           "docs": "deprecated"
         },
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use `--calcite-space-2xl` instead."
+        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-space-2xl` instead."
       },
       "xxxl": {
         "value": "{core.size.default.32}",
@@ -190,7 +190,7 @@
           "category": "spacing",
           "docs": "deprecated"
         },
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use `--calcite-space-3xl` instead."
+        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-space-3xl` instead."
       }
     }
   },

--- a/packages/design-tokens/src/tokens/semantic/space.json
+++ b/packages/design-tokens/src/tokens/semantic/space.json
@@ -8,7 +8,7 @@
           "category": "spacing",
           "docs": "unlisted"
         },
-        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - Use `--calcite-space-2xs` instead."
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use `--calcite-space-2xs` instead."
       },
       "xs": {
         "value": "{core.size.default.6}",
@@ -17,7 +17,7 @@
           "category": "spacing",
           "docs": "unlisted"
         },
-        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - Use `--calcite-space-xs` instead."
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use `--calcite-space-xs` instead."
       },
       "sm": {
         "value": "{core.size.default.8}",
@@ -26,7 +26,7 @@
           "category": "spacing",
           "docs": "unlisted"
         },
-        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - Use `--calcite-space-sm` instead."
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use `--calcite-space-sm` instead."
       },
       "md": {
         "value": "{core.size.default.12}",
@@ -35,7 +35,7 @@
           "category": "spacing",
           "docs": "unlisted"
         },
-        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - Use `--calcite-space-md` instead."
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use `--calcite-space-md` instead."
       },
       "lg": {
         "value": "{core.size.default.14}",
@@ -44,7 +44,7 @@
           "category": "spacing",
           "docs": "unlisted"
         },
-        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - Use `--calcite-space-md-plus` instead."
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use `--calcite-space-md-plus` instead."
       },
       "xl": {
         "value": "{core.size.default.16}",
@@ -53,7 +53,7 @@
           "category": "spacing",
           "docs": "unlisted"
         },
-        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - Use `--calcite-space-lg` instead."
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use `--calcite-space-lg` instead."
       },
       "xxl": {
         "value": "{core.size.default.20}",
@@ -62,7 +62,7 @@
           "category": "spacing",
           "docs": "unlisted"
         },
-        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - Use `--calcite-space-xl` instead."
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use `--calcite-space-xl` instead."
       },
       "xxxl": {
         "value": "{core.size.default.32}",
@@ -71,7 +71,7 @@
           "category": "spacing",
           "docs": "unlisted"
         },
-        "description": "Deprecated in Calcite Components v3.0.0, removal target v6.0.0 - Use `--calcite-space-3xl` instead."
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use `--calcite-space-3xl` instead."
       }
     },
     "default": {
@@ -82,7 +82,7 @@
           "category": "spacing",
           "docs": "deprecated"
         },
-        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-space-none` instead."
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use `--calcite-space-none` instead."
       },
       "px": {
         "value": "{core.size.default.1}",
@@ -91,7 +91,7 @@
           "category": "spacing",
           "docs": "deprecated"
         },
-        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-space-px` instead."
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use `--calcite-space-px` instead."
       },
       "base": {
         "value": "{core.size.default.2}",
@@ -100,7 +100,7 @@
           "category": "spacing",
           "docs": "deprecated"
         },
-        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-space-base` instead."
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use `--calcite-space-base` instead."
       },
       "xxs": {
         "value": "{core.size.default.4}",
@@ -109,7 +109,7 @@
           "category": "spacing",
           "docs": "deprecated"
         },
-        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-space-2xs` instead."
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use `--calcite-space-2xs` instead."
       },
       "xs": {
         "value": "{core.size.default.6}",
@@ -118,7 +118,7 @@
           "category": "spacing",
           "docs": "deprecated"
         },
-        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-space-xs` instead."
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use `--calcite-space-xs` instead."
       },
       "sm": {
         "value": "{core.size.default.8}",
@@ -127,7 +127,7 @@
           "category": "spacing",
           "docs": "deprecated"
         },
-        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-space-sm` instead."
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use `--calcite-space-sm` instead."
       },
       "sm+": {
         "value": "{core.size.default.10}",
@@ -136,7 +136,7 @@
           "category": "spacing",
           "docs": "deprecated"
         },
-        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-space-sm-plus` instead."
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use `--calcite-space-sm-plus` instead."
       },
       "md": {
         "value": "{core.size.default.12}",
@@ -145,7 +145,7 @@
           "category": "spacing",
           "docs": "deprecated"
         },
-        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-space-md` instead."
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use `--calcite-space-md` instead."
       },
       "md+": {
         "value": "{core.size.default.14}",
@@ -154,7 +154,7 @@
           "category": "spacing",
           "docs": "deprecated"
         },
-        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-space-md-plus` instead."
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use `--calcite-space-md-plus` instead."
       },
       "lg": {
         "value": "{core.size.default.16}",
@@ -163,7 +163,7 @@
           "category": "spacing",
           "docs": "deprecated"
         },
-        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-space-lg` instead."
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use `--calcite-space-lg` instead."
       },
       "xl": {
         "value": "{core.size.default.20}",
@@ -172,7 +172,7 @@
           "category": "spacing",
           "docs": "deprecated"
         },
-        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-space-xl` instead."
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use `--calcite-space-xl` instead."
       },
       "xxl": {
         "value": "{core.size.default.24}",
@@ -181,7 +181,7 @@
           "category": "spacing",
           "docs": "deprecated"
         },
-        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-space-2xl` instead."
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use `--calcite-space-2xl` instead."
       },
       "xxxl": {
         "value": "{core.size.default.32}",
@@ -190,7 +190,7 @@
           "category": "spacing",
           "docs": "deprecated"
         },
-        "description": "Deprecated in Calcite Components v5.0.0, removal target v6.0.0 - Use `--calcite-space-3xl` instead."
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use `--calcite-space-3xl` instead."
       }
     }
   },

--- a/packages/design-tokens/tests/spec/__snapshots__/index.spec.ts.snap
+++ b/packages/design-tokens/tests/spec/__snapshots__/index.spec.ts.snap
@@ -7,11 +7,11 @@ exports[`generated tokens > CSS > breakpoints should match 1`] = `
  */
 
 :root {
-  --calcite-container-size-height-xxs-min: 0; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-container-size-height-2xs-min|max\` instead. */
+  --calcite-container-size-height-xxs-min: 0; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-container-size-height-2xs-min|max\` instead. */
   --calcite-container-size-height-2xs-min: 0; /** Small handheld devices and mini-windows */
-  --calcite-container-size-width-xxs-min: 0; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-container-size-width-2xs-min|max\` instead. */
+  --calcite-container-size-width-xxs-min: 0; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-container-size-width-2xs-min|max\` instead. */
   --calcite-container-size-width-2xs-min: 0; /** Small handheld devices and mini-windows */
-  --calcite-container-size-height-xxs-max: 154px; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-container-size-height-2xs-min|max\` instead. */
+  --calcite-container-size-height-xxs-max: 154px; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-container-size-height-2xs-min|max\` instead. */
   --calcite-container-size-height-2xs-max: 154px; /** Small handheld devices and mini-windows */
   --calcite-container-size-height-xs-min: 155px; /** Handheld devices */
   --calcite-container-size-height-xs-max: 328px; /** Handheld devices */
@@ -22,7 +22,7 @@ exports[`generated tokens > CSS > breakpoints should match 1`] = `
   --calcite-container-size-height-lg-min: 679px; /** Large laptops and desktop computers */
   --calcite-container-size-height-lg-max: 854px; /** Large laptops and desktop computers */
   --calcite-container-size-height-xl-min: 855px; /** Projectors and televisions */
-  --calcite-container-size-width-xxs-max: 320px; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-container-size-width-2xs-min|max\` instead. */
+  --calcite-container-size-width-xxs-max: 320px; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-container-size-width-2xs-min|max\` instead. */
   --calcite-container-size-width-2xs-max: 320px; /** Small handheld devices and mini-windows */
   --calcite-container-size-width-xs-min: 321px; /** Handheld devices */
   --calcite-container-size-width-xs-max: 476px; /** Handheld devices */
@@ -477,7 +477,7 @@ exports[`generated tokens > CSS > core should match 1`] = `
   --calcite-color-low-saturation-violet-l-vv-080: #504b60;
   --calcite-color-low-saturation-violet-l-vv-090: #322e3d;
   --calcite-color-low-saturation-violet-l-vv-100: #13111a;
-  --calcite-color-low-saturation-violet-l-vv-1000: #13111a; /** Deprecated in v3.3.0, removal target v6.0.0 - Use \`--calcite-color-low-saturation-violet-l-vv-100\` instead. */
+  --calcite-color-low-saturation-violet-l-vv-1000: #13111a; /** Deprecated in v3.2.0, removal target v5.0.0 - Use \`--calcite-color-low-saturation-violet-l-vv-100\` instead. */
   --calcite-color-medium-saturation-blue-m-bb-010: #dfeffa;
   --calcite-color-medium-saturation-blue-m-bb-020: #c8e3f5;
   --calcite-color-medium-saturation-blue-m-bb-030: #b1d8f1;
@@ -818,12 +818,12 @@ exports[`generated tokens > CSS > core should match 1`] = `
   --calcite-font-weight-extrabold: 800; /** only for Avenir Next World (secondary font family) */
   --calcite-font-weight-black: 900; /** only for Avenir Next World (secondary font family) */
   --calcite-font-weight-heavy: 900;
-  --calcite-font-text-decoration-none: none; /** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
-  --calcite-font-text-decoration-underline: underline; /** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
-  --calcite-font-text-case-none: none; /** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
-  --calcite-font-text-case-uppercase: uppercase; /** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
-  --calcite-font-text-case-lowercase: lowercase; /** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
-  --calcite-font-text-case-capitalize: capitalize; /** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
+  --calcite-font-text-decoration-none: none; /** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
+  --calcite-font-text-decoration-underline: underline; /** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
+  --calcite-font-text-case-none: none; /** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
+  --calcite-font-text-case-uppercase: uppercase; /** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
+  --calcite-font-text-case-lowercase: lowercase; /** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
+  --calcite-font-text-case-capitalize: capitalize; /** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
   --calcite-opacity-0: 0;
   --calcite-opacity-4: 0.04;
   --calcite-opacity-8: 0.08;
@@ -927,12 +927,12 @@ exports[`generated tokens > CSS > dark should match 1`] = `
   --calcite-color-surface-3: #363636;
   --calcite-color-surface-4: #404040;
   --calcite-color-surface-highlight: #2b465f;
-  --calcite-color-background: #212121; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-1\` instead. */
-  --calcite-color-background-none: rgba(255, 255, 255, 0); /** Deprecated in v5.0.0, removal target v6.0.0 - No longer needed. */
-  --calcite-color-foreground-1: #2b2b2b; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-2\` instead. */
-  --calcite-color-foreground-2: #363636; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-3\` instead. */
-  --calcite-color-foreground-3: #404040; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-4\` instead. */
-  --calcite-color-foreground-current: #2b465f; /** Deprecated in v3.3.0, removal target v6.0.0 - Use \`--calcite-color-surface-highlight\` instead. */
+  --calcite-color-background: #212121; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-1\` instead. */
+  --calcite-color-background-none: rgba(255, 255, 255, 0); /** Deprecated in v4.0.0, removal target v5.0.0 - No longer needed. */
+  --calcite-color-foreground-1: #2b2b2b; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-2\` instead. */
+  --calcite-color-foreground-2: #363636; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-3\` instead. */
+  --calcite-color-foreground-3: #404040; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-4\` instead. */
+  --calcite-color-foreground-current: #2b465f; /** Deprecated in v3.2.0, removal target v5.0.0 - Use \`--calcite-color-surface-highlight\` instead. */
   --calcite-color-text-1: #ffffff;
   --calcite-color-text-2: #bfbfbf;
   --calcite-color-text-3: #9e9e9e;
@@ -943,8 +943,8 @@ exports[`generated tokens > CSS > dark should match 1`] = `
   --calcite-color-border-2: #4a4a4a;
   --calcite-color-border-3: #404040;
   --calcite-color-border-input: #757575;
-  --calcite-color-border-ghost: rgba(117, 117, 117, 0.3); /** Deprecated in v5.0.0, removal target v6.0.0 - No longer needed. */
-  --calcite-color-border-white: #f7f7f7; /** Deprecated in v5.0.0, removal target v6.0.0 - No longer needed. */
+  --calcite-color-border-ghost: rgba(117, 117, 117, 0.3); /** Deprecated in v4.0.0, removal target v5.0.0 - No longer needed. */
+  --calcite-color-border-white: #f7f7f7; /** Deprecated in v4.0.0, removal target v5.0.0 - No longer needed. */
   --calcite-color-brand: #009af2;
   --calcite-color-brand-hover: #007ac2;
   --calcite-color-brand-press: #00619b;
@@ -984,7 +984,7 @@ exports[`generated tokens > CSS > global should match 1`] = `
  */
 
 :root {
-  --calcite-color-background-none: rgba(255, 255, 255, 0); /** Deprecated in v5.0.0, removal target v6.0.0 - No longer needed. */
+  --calcite-color-background-none: rgba(255, 255, 255, 0); /** Deprecated in v4.0.0, removal target v5.0.0 - No longer needed. */
   --calcite-border-width-none: 0;
   --calcite-border-width-sm: 1px;
   --calcite-border-width-md: 2px;
@@ -993,17 +993,17 @@ exports[`generated tokens > CSS > global should match 1`] = `
   --calcite-container-size-gutter: 16px;
   --calcite-container-size-content-fluid: 100%; /** for fluid grid widths */
   --calcite-container-size-content-fixed: 1440px; /** only for lg breakpoint fixed grid width */
-  --calcite-corner-radius-sharp: 0; /** Deprecated in v3.2.0, removal target v6.0.0 - Use \`--calcite-corner-radius-none\` instead. */
+  --calcite-corner-radius-sharp: 0; /** Deprecated in v3.1.0, removal target v5.0.0 - Use \`--calcite-corner-radius-none\` instead. */
   --calcite-corner-radius-none: 0;
   --calcite-corner-radius-xs: 2px;
   --calcite-corner-radius-sm: 4px;
-  --calcite-corner-radius-round: 4px; /** Deprecated in v3.2.0, removal target v6.0.0 - Use \`--calcite-corner-radius-sm\` instead. */
+  --calcite-corner-radius-round: 4px; /** Deprecated in v3.1.0, removal target v5.0.0 - Use \`--calcite-corner-radius-sm\` instead. */
   --calcite-corner-radius-pill: 9999px;
   --calcite-font-family: 'Avenir Next', Avenir, 'Helvetica Neue', sans-serif; /** Primary font with fallbacks */
   --calcite-font-family-code: Monaco, Consolas, 'Andale Mono', 'Lucida Console', monospace; /** Font family for code with fallbacks */
   --calcite-font-weight-light: 300; /** For Avenir Next World (secondary font family) */
   --calcite-font-weight-regular: 400;
-  --calcite-font-weight-normal: 400; /** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-font-weight-regular\` instead. */
+  --calcite-font-weight-normal: 400; /** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-font-weight-regular\` instead. */
   --calcite-font-weight-medium: 500;
   --calcite-font-weight-semibold: 600;
   --calcite-font-weight-bold: 600;
@@ -1013,7 +1013,7 @@ exports[`generated tokens > CSS > global should match 1`] = `
   --calcite-font-size-md: 16px;
   --calcite-font-size-lg: 18px;
   --calcite-font-size-xl: 20px;
-  --calcite-font-size-xxl: 24px; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-font-size-2xl\` instead. */
+  --calcite-font-size-xxl: 24px; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-font-size-2xl\` instead. */
   --calcite-font-size-2xl: 24px;
   --calcite-font-size-relative-xs: 0.625rem;
   --calcite-font-size-relative-sm: 0.75rem;
@@ -1056,68 +1056,68 @@ exports[`generated tokens > CSS > global should match 1`] = `
   --calcite-font-line-height-5xl: 4rem;
   --calcite-font-line-height-6xl: 4rem;
   --calcite-font-line-height-7xl: 5rem;
-  --calcite-font-letter-spacing-tight: -0.4px; /** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
-  --calcite-font-letter-spacing-normal: 0; /** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
-  --calcite-font-letter-spacing-wide: 0.4px; /** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
-  --calcite-font-paragraph-spacing-normal: 4px; /** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
-  --calcite-font-text-decoration-none: none; /** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
-  --calcite-font-text-decoration-underline: underline; /** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
-  --calcite-font-text-case-none: none; /** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
-  --calcite-font-text-case-uppercase: uppercase; /** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
-  --calcite-font-text-case-lowercase: lowercase; /** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
-  --calcite-font-text-case-capitalize: capitalize; /** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
+  --calcite-font-letter-spacing-tight: -0.4px; /** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
+  --calcite-font-letter-spacing-normal: 0; /** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
+  --calcite-font-letter-spacing-wide: 0.4px; /** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
+  --calcite-font-paragraph-spacing-normal: 4px; /** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
+  --calcite-font-text-decoration-none: none; /** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
+  --calcite-font-text-decoration-underline: underline; /** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
+  --calcite-font-text-case-none: none; /** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
+  --calcite-font-text-case-uppercase: uppercase; /** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
+  --calcite-font-text-case-lowercase: lowercase; /** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
+  --calcite-font-text-case-capitalize: capitalize; /** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
   --calcite-opacity-disabled: 0.5;
   --calcite-opacity-light: 0.4;
   --calcite-opacity-half: 0.5;
   --calcite-opacity-dark: 0.85;
   --calcite-opacity-full: 1;
-  --calcite-size-fixed-xxxs: 2px; /** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
-  --calcite-size-fixed-xxs: 4px; /** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
-  --calcite-size-fixed-xs: 6px; /** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
-  --calcite-size-fixed-sm: 8px; /** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
-  --calcite-size-fixed-sm-plus: 10px; /** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-4xs\` instead. */
-  --calcite-size-fixed-md: 12px; /** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-3xs\` instead. */
-  --calcite-size-fixed-md-plus: 14px; /** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-2xs\` instead. */
-  --calcite-size-fixed-lg: 16px; /** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-xs\` instead. */
-  --calcite-size-fixed-xl: 20px; /** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
-  --calcite-size-fixed-xxl: 24px; /** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-sm\` instead. */
-  --calcite-size-fixed-xxxl: 32px; /** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-md\` instead. */
+  --calcite-size-fixed-xxxs: 2px; /** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
+  --calcite-size-fixed-xxs: 4px; /** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
+  --calcite-size-fixed-xs: 6px; /** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
+  --calcite-size-fixed-sm: 8px; /** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
+  --calcite-size-fixed-sm-plus: 10px; /** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-4xs\` instead. */
+  --calcite-size-fixed-md: 12px; /** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-3xs\` instead. */
+  --calcite-size-fixed-md-plus: 14px; /** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-2xs\` instead. */
+  --calcite-size-fixed-lg: 16px; /** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-xs\` instead. */
+  --calcite-size-fixed-xl: 20px; /** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
+  --calcite-size-fixed-xxl: 24px; /** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-sm\` instead. */
+  --calcite-size-fixed-xxxl: 32px; /** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-md\` instead. */
   --calcite-size-px: 1px;
   --calcite-size-4xs: 0.625rem;
-  --calcite-size-xxxs: 0.75rem; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-3xs\` instead. */
+  --calcite-size-xxxs: 0.75rem; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-3xs\` instead. */
   --calcite-size-3xs: 0.75rem;
-  --calcite-size-xxs: 0.875rem; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-2xs\` instead. */
+  --calcite-size-xxs: 0.875rem; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-2xs\` instead. */
   --calcite-size-2xs: 0.875rem;
   --calcite-size-xs: 1rem;
   --calcite-size-sm: 1.5rem;
   --calcite-size-md: 2rem;
   --calcite-size-lg: 2.75rem;
   --calcite-size-xl: 3rem;
-  --calcite-size-xxl: 4rem; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-2xl\` instead. */
+  --calcite-size-xxl: 4rem; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-2xl\` instead. */
   --calcite-size-2xl: 4rem;
-  --calcite-size-xxxl: 6rem; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-3xl\` instead. */
+  --calcite-size-xxxl: 6rem; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-3xl\` instead. */
   --calcite-size-3xl: 6rem;
-  --calcite-spacing-fixed-xxs: 4px; /** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-2xs\` instead. */
-  --calcite-spacing-fixed-xs: 6px; /** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-xs\` instead. */
-  --calcite-spacing-fixed-sm: 8px; /** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-sm\` instead. */
-  --calcite-spacing-fixed-md: 12px; /** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-md\` instead. */
-  --calcite-spacing-fixed-lg: 14px; /** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-md-plus\` instead. */
-  --calcite-spacing-fixed-xl: 16px; /** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-lg\` instead. */
-  --calcite-spacing-fixed-xxl: 20px; /** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-xl\` instead. */
-  --calcite-spacing-fixed-xxxl: 32px; /** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-3xl\` instead. */
-  --calcite-spacing-none: 0; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-none\` instead. */
-  --calcite-spacing-px: 1px; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-px\` instead. */
-  --calcite-spacing-base: 2px; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-base\` instead. */
-  --calcite-spacing-xxs: 0.25rem; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-2xs\` instead. */
-  --calcite-spacing-xs: 0.375rem; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-xs\` instead. */
-  --calcite-spacing-sm: 0.5rem; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-sm\` instead. */
-  --calcite-spacing-sm-plus: 0.625rem; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-sm-plus\` instead. */
-  --calcite-spacing-md: 0.75rem; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-md\` instead. */
-  --calcite-spacing-md-plus: 0.875rem; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-md-plus\` instead. */
-  --calcite-spacing-lg: 1rem; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-lg\` instead. */
-  --calcite-spacing-xl: 1.25rem; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-xl\` instead. */
-  --calcite-spacing-xxl: 1.5rem; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-2xl\` instead. */
-  --calcite-spacing-xxxl: 2rem; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-3xl\` instead. */
+  --calcite-spacing-fixed-xxs: 4px; /** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-2xs\` instead. */
+  --calcite-spacing-fixed-xs: 6px; /** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-xs\` instead. */
+  --calcite-spacing-fixed-sm: 8px; /** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-sm\` instead. */
+  --calcite-spacing-fixed-md: 12px; /** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-md\` instead. */
+  --calcite-spacing-fixed-lg: 14px; /** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-md-plus\` instead. */
+  --calcite-spacing-fixed-xl: 16px; /** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-lg\` instead. */
+  --calcite-spacing-fixed-xxl: 20px; /** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-xl\` instead. */
+  --calcite-spacing-fixed-xxxl: 32px; /** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-3xl\` instead. */
+  --calcite-spacing-none: 0; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-none\` instead. */
+  --calcite-spacing-px: 1px; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-px\` instead. */
+  --calcite-spacing-base: 2px; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-base\` instead. */
+  --calcite-spacing-xxs: 0.25rem; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-2xs\` instead. */
+  --calcite-spacing-xs: 0.375rem; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-xs\` instead. */
+  --calcite-spacing-sm: 0.5rem; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-sm\` instead. */
+  --calcite-spacing-sm-plus: 0.625rem; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-sm-plus\` instead. */
+  --calcite-spacing-md: 0.75rem; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-md\` instead. */
+  --calcite-spacing-md-plus: 0.875rem; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-md-plus\` instead. */
+  --calcite-spacing-lg: 1rem; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-lg\` instead. */
+  --calcite-spacing-xl: 1.25rem; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-xl\` instead. */
+  --calcite-spacing-xxl: 1.5rem; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-2xl\` instead. */
+  --calcite-spacing-xxxl: 2rem; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-3xl\` instead. */
   --calcite-space-none: 0;
   --calcite-space-px: 1px;
   --calcite-space-base: 2px;
@@ -1185,13 +1185,13 @@ exports[`generated tokens > CSS > index should match 1`] = `
   --calcite-color-brand-press: #004874;
   --calcite-color-brand-hover: #00619b;
   --calcite-color-brand: #007ac2;
-  --calcite-color-border-white: #ffffff; /** Deprecated in v5.0.0, removal target v6.0.0 - No longer needed. */
+  --calcite-color-border-white: #ffffff; /** Deprecated in v4.0.0, removal target v5.0.0 - No longer needed. */
   --calcite-color-border-ghost: rgba(
     0,
     0,
     0,
     0.3
-  ); /** Deprecated in v5.0.0, removal target v6.0.0 - No longer needed. */
+  ); /** Deprecated in v4.0.0, removal target v5.0.0 - No longer needed. */
   --calcite-color-border-input: #949494;
   --calcite-color-border-3: #ebebeb;
   --calcite-color-border-2: #dedede;
@@ -1202,17 +1202,17 @@ exports[`generated tokens > CSS > index should match 1`] = `
   --calcite-color-text-3: #6b6b6b;
   --calcite-color-text-2: #4a4a4a;
   --calcite-color-text-1: #141414;
-  --calcite-color-foreground-current: #d6efff; /** Deprecated in v3.3.0, removal target v6.0.0 - Use \`--calcite-color-surface-highlight\` instead. */
-  --calcite-color-foreground-3: #ebebeb; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-4\` instead. */
-  --calcite-color-foreground-2: #f2f2f2; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-3\` instead. */
-  --calcite-color-foreground-1: #ffffff; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-2\` instead. */
+  --calcite-color-foreground-current: #d6efff; /** Deprecated in v3.2.0, removal target v5.0.0 - Use \`--calcite-color-surface-highlight\` instead. */
+  --calcite-color-foreground-3: #ebebeb; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-4\` instead. */
+  --calcite-color-foreground-2: #f2f2f2; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-3\` instead. */
+  --calcite-color-foreground-1: #ffffff; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-2\` instead. */
   --calcite-color-background-none: rgba(
     255,
     255,
     255,
     0
-  ); /** Deprecated in v5.0.0, removal target v6.0.0 - No longer needed. */
-  --calcite-color-background: #f7f7f7; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-1\` instead. */
+  ); /** Deprecated in v4.0.0, removal target v5.0.0 - No longer needed. */
+  --calcite-color-background: #f7f7f7; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-1\` instead. */
   --calcite-color-surface-highlight: #d6efff;
   --calcite-color-surface-4: #ebebeb;
   --calcite-color-surface-3: #f2f2f2;
@@ -1248,13 +1248,13 @@ exports[`generated tokens > CSS > index should match 1`] = `
     --calcite-color-brand-press: #004874;
     --calcite-color-brand-hover: #00619b;
     --calcite-color-brand: #007ac2;
-    --calcite-color-border-white: #ffffff; /** Deprecated in v5.0.0, removal target v6.0.0 - No longer needed. */
+    --calcite-color-border-white: #ffffff; /** Deprecated in v4.0.0, removal target v5.0.0 - No longer needed. */
     --calcite-color-border-ghost: rgba(
       0,
       0,
       0,
       0.3
-    ); /** Deprecated in v5.0.0, removal target v6.0.0 - No longer needed. */
+    ); /** Deprecated in v4.0.0, removal target v5.0.0 - No longer needed. */
     --calcite-color-border-input: #949494;
     --calcite-color-border-3: #ebebeb;
     --calcite-color-border-2: #dedede;
@@ -1265,17 +1265,17 @@ exports[`generated tokens > CSS > index should match 1`] = `
     --calcite-color-text-3: #6b6b6b;
     --calcite-color-text-2: #4a4a4a;
     --calcite-color-text-1: #141414;
-    --calcite-color-foreground-current: #d6efff; /** Deprecated in v3.3.0, removal target v6.0.0 - Use \`--calcite-color-surface-highlight\` instead. */
-    --calcite-color-foreground-3: #ebebeb; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-4\` instead. */
-    --calcite-color-foreground-2: #f2f2f2; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-3\` instead. */
-    --calcite-color-foreground-1: #ffffff; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-2\` instead. */
+    --calcite-color-foreground-current: #d6efff; /** Deprecated in v3.2.0, removal target v5.0.0 - Use \`--calcite-color-surface-highlight\` instead. */
+    --calcite-color-foreground-3: #ebebeb; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-4\` instead. */
+    --calcite-color-foreground-2: #f2f2f2; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-3\` instead. */
+    --calcite-color-foreground-1: #ffffff; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-2\` instead. */
     --calcite-color-background-none: rgba(
       255,
       255,
       255,
       0
-    ); /** Deprecated in v5.0.0, removal target v6.0.0 - No longer needed. */
-    --calcite-color-background: #f7f7f7; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-1\` instead. */
+    ); /** Deprecated in v4.0.0, removal target v5.0.0 - No longer needed. */
+    --calcite-color-background: #f7f7f7; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-1\` instead. */
     --calcite-color-surface-highlight: #d6efff;
     --calcite-color-surface-4: #ebebeb;
     --calcite-color-surface-3: #f2f2f2;
@@ -1312,13 +1312,13 @@ exports[`generated tokens > CSS > index should match 1`] = `
     --calcite-color-brand-press: #00619b;
     --calcite-color-brand-hover: #007ac2;
     --calcite-color-brand: #009af2;
-    --calcite-color-border-white: #f7f7f7; /** Deprecated in v5.0.0, removal target v6.0.0 - No longer needed. */
+    --calcite-color-border-white: #f7f7f7; /** Deprecated in v4.0.0, removal target v5.0.0 - No longer needed. */
     --calcite-color-border-ghost: rgba(
       117,
       117,
       117,
       0.3
-    ); /** Deprecated in v5.0.0, removal target v6.0.0 - No longer needed. */
+    ); /** Deprecated in v4.0.0, removal target v5.0.0 - No longer needed. */
     --calcite-color-border-input: #757575;
     --calcite-color-border-3: #404040;
     --calcite-color-border-2: #4a4a4a;
@@ -1329,17 +1329,17 @@ exports[`generated tokens > CSS > index should match 1`] = `
     --calcite-color-text-3: #9e9e9e;
     --calcite-color-text-2: #bfbfbf;
     --calcite-color-text-1: #ffffff;
-    --calcite-color-foreground-current: #2b465f; /** Deprecated in v3.3.0, removal target v6.0.0 - Use \`--calcite-color-surface-highlight\` instead. */
-    --calcite-color-foreground-3: #404040; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-4\` instead. */
-    --calcite-color-foreground-2: #363636; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-3\` instead. */
-    --calcite-color-foreground-1: #2b2b2b; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-2\` instead. */
+    --calcite-color-foreground-current: #2b465f; /** Deprecated in v3.2.0, removal target v5.0.0 - Use \`--calcite-color-surface-highlight\` instead. */
+    --calcite-color-foreground-3: #404040; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-4\` instead. */
+    --calcite-color-foreground-2: #363636; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-3\` instead. */
+    --calcite-color-foreground-1: #2b2b2b; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-2\` instead. */
     --calcite-color-background-none: rgba(
       255,
       255,
       255,
       0
-    ); /** Deprecated in v5.0.0, removal target v6.0.0 - No longer needed. */
-    --calcite-color-background: #212121; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-1\` instead. */
+    ); /** Deprecated in v4.0.0, removal target v5.0.0 - No longer needed. */
+    --calcite-color-background: #212121; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-1\` instead. */
     --calcite-color-surface-highlight: #2b465f;
     --calcite-color-surface-4: #404040;
     --calcite-color-surface-3: #363636;
@@ -1375,13 +1375,13 @@ exports[`generated tokens > CSS > index should match 1`] = `
   --calcite-color-brand-press: #004874;
   --calcite-color-brand-hover: #00619b;
   --calcite-color-brand: #007ac2;
-  --calcite-color-border-white: #ffffff; /** Deprecated in v5.0.0, removal target v6.0.0 - No longer needed. */
+  --calcite-color-border-white: #ffffff; /** Deprecated in v4.0.0, removal target v5.0.0 - No longer needed. */
   --calcite-color-border-ghost: rgba(
     0,
     0,
     0,
     0.3
-  ); /** Deprecated in v5.0.0, removal target v6.0.0 - No longer needed. */
+  ); /** Deprecated in v4.0.0, removal target v5.0.0 - No longer needed. */
   --calcite-color-border-input: #949494;
   --calcite-color-border-3: #ebebeb;
   --calcite-color-border-2: #dedede;
@@ -1392,17 +1392,17 @@ exports[`generated tokens > CSS > index should match 1`] = `
   --calcite-color-text-3: #6b6b6b;
   --calcite-color-text-2: #4a4a4a;
   --calcite-color-text-1: #141414;
-  --calcite-color-foreground-current: #d6efff; /** Deprecated in v3.3.0, removal target v6.0.0 - Use \`--calcite-color-surface-highlight\` instead. */
-  --calcite-color-foreground-3: #ebebeb; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-4\` instead. */
-  --calcite-color-foreground-2: #f2f2f2; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-3\` instead. */
-  --calcite-color-foreground-1: #ffffff; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-2\` instead. */
+  --calcite-color-foreground-current: #d6efff; /** Deprecated in v3.2.0, removal target v5.0.0 - Use \`--calcite-color-surface-highlight\` instead. */
+  --calcite-color-foreground-3: #ebebeb; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-4\` instead. */
+  --calcite-color-foreground-2: #f2f2f2; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-3\` instead. */
+  --calcite-color-foreground-1: #ffffff; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-2\` instead. */
   --calcite-color-background-none: rgba(
     255,
     255,
     255,
     0
-  ); /** Deprecated in v5.0.0, removal target v6.0.0 - No longer needed. */
-  --calcite-color-background: #f7f7f7; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-1\` instead. */
+  ); /** Deprecated in v4.0.0, removal target v5.0.0 - No longer needed. */
+  --calcite-color-background: #f7f7f7; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-1\` instead. */
   --calcite-color-surface-highlight: #d6efff;
   --calcite-color-surface-4: #ebebeb;
   --calcite-color-surface-3: #f2f2f2;
@@ -1437,13 +1437,13 @@ exports[`generated tokens > CSS > index should match 1`] = `
   --calcite-color-brand-press: #00619b;
   --calcite-color-brand-hover: #007ac2;
   --calcite-color-brand: #009af2;
-  --calcite-color-border-white: #f7f7f7; /** Deprecated in v5.0.0, removal target v6.0.0 - No longer needed. */
+  --calcite-color-border-white: #f7f7f7; /** Deprecated in v4.0.0, removal target v5.0.0 - No longer needed. */
   --calcite-color-border-ghost: rgba(
     117,
     117,
     117,
     0.3
-  ); /** Deprecated in v5.0.0, removal target v6.0.0 - No longer needed. */
+  ); /** Deprecated in v4.0.0, removal target v5.0.0 - No longer needed. */
   --calcite-color-border-input: #757575;
   --calcite-color-border-3: #404040;
   --calcite-color-border-2: #4a4a4a;
@@ -1454,17 +1454,17 @@ exports[`generated tokens > CSS > index should match 1`] = `
   --calcite-color-text-3: #9e9e9e;
   --calcite-color-text-2: #bfbfbf;
   --calcite-color-text-1: #ffffff;
-  --calcite-color-foreground-current: #2b465f; /** Deprecated in v3.3.0, removal target v6.0.0 - Use \`--calcite-color-surface-highlight\` instead. */
-  --calcite-color-foreground-3: #404040; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-4\` instead. */
-  --calcite-color-foreground-2: #363636; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-3\` instead. */
-  --calcite-color-foreground-1: #2b2b2b; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-2\` instead. */
+  --calcite-color-foreground-current: #2b465f; /** Deprecated in v3.2.0, removal target v5.0.0 - Use \`--calcite-color-surface-highlight\` instead. */
+  --calcite-color-foreground-3: #404040; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-4\` instead. */
+  --calcite-color-foreground-2: #363636; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-3\` instead. */
+  --calcite-color-foreground-1: #2b2b2b; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-2\` instead. */
   --calcite-color-background-none: rgba(
     255,
     255,
     255,
     0
-  ); /** Deprecated in v5.0.0, removal target v6.0.0 - No longer needed. */
-  --calcite-color-background: #212121; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-1\` instead. */
+  ); /** Deprecated in v4.0.0, removal target v5.0.0 - No longer needed. */
+  --calcite-color-background: #212121; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-1\` instead. */
   --calcite-color-surface-highlight: #2b465f;
   --calcite-color-surface-4: #404040;
   --calcite-color-surface-3: #363636;
@@ -1487,12 +1487,12 @@ exports[`generated tokens > CSS > light should match 1`] = `
   --calcite-color-surface-3: #f2f2f2;
   --calcite-color-surface-4: #ebebeb;
   --calcite-color-surface-highlight: #d6efff;
-  --calcite-color-background: #f7f7f7; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-1\` instead. */
-  --calcite-color-background-none: rgba(255, 255, 255, 0); /** Deprecated in v5.0.0, removal target v6.0.0 - No longer needed. */
-  --calcite-color-foreground-1: #ffffff; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-2\` instead. */
-  --calcite-color-foreground-2: #f2f2f2; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-3\` instead. */
-  --calcite-color-foreground-3: #ebebeb; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-4\` instead. */
-  --calcite-color-foreground-current: #d6efff; /** Deprecated in v3.3.0, removal target v6.0.0 - Use \`--calcite-color-surface-highlight\` instead. */
+  --calcite-color-background: #f7f7f7; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-1\` instead. */
+  --calcite-color-background-none: rgba(255, 255, 255, 0); /** Deprecated in v4.0.0, removal target v5.0.0 - No longer needed. */
+  --calcite-color-foreground-1: #ffffff; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-2\` instead. */
+  --calcite-color-foreground-2: #f2f2f2; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-3\` instead. */
+  --calcite-color-foreground-3: #ebebeb; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-4\` instead. */
+  --calcite-color-foreground-current: #d6efff; /** Deprecated in v3.2.0, removal target v5.0.0 - Use \`--calcite-color-surface-highlight\` instead. */
   --calcite-color-text-1: #141414;
   --calcite-color-text-2: #4a4a4a;
   --calcite-color-text-3: #6b6b6b;
@@ -1503,8 +1503,8 @@ exports[`generated tokens > CSS > light should match 1`] = `
   --calcite-color-border-2: #dedede;
   --calcite-color-border-3: #ebebeb;
   --calcite-color-border-input: #949494;
-  --calcite-color-border-ghost: rgba(0, 0, 0, 0.3); /** Deprecated in v5.0.0, removal target v6.0.0 - No longer needed. */
-  --calcite-color-border-white: #ffffff; /** Deprecated in v5.0.0, removal target v6.0.0 - No longer needed. */
+  --calcite-color-border-ghost: rgba(0, 0, 0, 0.3); /** Deprecated in v4.0.0, removal target v5.0.0 - No longer needed. */
+  --calcite-color-border-white: #ffffff; /** Deprecated in v4.0.0, removal target v5.0.0 - No longer needed. */
   --calcite-color-brand: #007ac2;
   --calcite-color-brand-hover: #00619b;
   --calcite-color-brand-press: #004874;
@@ -1551,17 +1551,17 @@ exports[`generated tokens > CSS > semantic should match 1`] = `
   --calcite-container-size-gutter: 16px;
   --calcite-container-size-content-fluid: 100%; /** for fluid grid widths */
   --calcite-container-size-content-fixed: 1440px; /** only for lg breakpoint fixed grid width */
-  --calcite-corner-radius-sharp: 0; /** Deprecated in v3.2.0, removal target v6.0.0 - Use \`--calcite-corner-radius-none\` instead. */
+  --calcite-corner-radius-sharp: 0; /** Deprecated in v3.1.0, removal target v5.0.0 - Use \`--calcite-corner-radius-none\` instead. */
   --calcite-corner-radius-none: 0;
   --calcite-corner-radius-xs: 2px;
   --calcite-corner-radius-sm: 4px;
-  --calcite-corner-radius-round: 4px; /** Deprecated in v3.2.0, removal target v6.0.0 - Use \`--calcite-corner-radius-sm\` instead. */
+  --calcite-corner-radius-round: 4px; /** Deprecated in v3.1.0, removal target v5.0.0 - Use \`--calcite-corner-radius-sm\` instead. */
   --calcite-corner-radius-pill: 9999px;
   --calcite-font-family: 'Avenir Next', Avenir, 'Helvetica Neue', sans-serif; /** Primary font with fallbacks */
   --calcite-font-family-code: Monaco, Consolas, 'Andale Mono', 'Lucida Console', monospace; /** Font family for code with fallbacks */
   --calcite-font-weight-light: 300; /** For Avenir Next World (secondary font family) */
   --calcite-font-weight-regular: 400;
-  --calcite-font-weight-normal: 400; /** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-font-weight-regular\` instead. */
+  --calcite-font-weight-normal: 400; /** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-font-weight-regular\` instead. */
   --calcite-font-weight-medium: 500;
   --calcite-font-weight-semibold: 600;
   --calcite-font-weight-bold: 600;
@@ -1571,7 +1571,7 @@ exports[`generated tokens > CSS > semantic should match 1`] = `
   --calcite-font-size-md: 16px;
   --calcite-font-size-lg: 18px;
   --calcite-font-size-xl: 20px;
-  --calcite-font-size-xxl: 24px; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-font-size-2xl\` instead. */
+  --calcite-font-size-xxl: 24px; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-font-size-2xl\` instead. */
   --calcite-font-size-2xl: 24px;
   --calcite-font-size-relative-xs: 0.625rem;
   --calcite-font-size-relative-sm: 0.75rem;
@@ -1614,68 +1614,68 @@ exports[`generated tokens > CSS > semantic should match 1`] = `
   --calcite-font-line-height-5xl: 4rem;
   --calcite-font-line-height-6xl: 4rem;
   --calcite-font-line-height-7xl: 5rem;
-  --calcite-font-letter-spacing-tight: -0.4px; /** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
-  --calcite-font-letter-spacing-normal: 0; /** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
-  --calcite-font-letter-spacing-wide: 0.4px; /** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
-  --calcite-font-paragraph-spacing-normal: 4px; /** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
-  --calcite-font-text-decoration-none: none; /** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
-  --calcite-font-text-decoration-underline: underline; /** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
-  --calcite-font-text-case-none: none; /** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
-  --calcite-font-text-case-uppercase: uppercase; /** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
-  --calcite-font-text-case-lowercase: lowercase; /** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
-  --calcite-font-text-case-capitalize: capitalize; /** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
+  --calcite-font-letter-spacing-tight: -0.4px; /** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
+  --calcite-font-letter-spacing-normal: 0; /** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
+  --calcite-font-letter-spacing-wide: 0.4px; /** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
+  --calcite-font-paragraph-spacing-normal: 4px; /** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
+  --calcite-font-text-decoration-none: none; /** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
+  --calcite-font-text-decoration-underline: underline; /** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
+  --calcite-font-text-case-none: none; /** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
+  --calcite-font-text-case-uppercase: uppercase; /** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
+  --calcite-font-text-case-lowercase: lowercase; /** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
+  --calcite-font-text-case-capitalize: capitalize; /** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
   --calcite-opacity-disabled: 0.5;
   --calcite-opacity-light: 0.4;
   --calcite-opacity-half: 0.5;
   --calcite-opacity-dark: 0.85;
   --calcite-opacity-full: 1;
-  --calcite-size-fixed-xxxs: 2px; /** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
-  --calcite-size-fixed-xxs: 4px; /** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
-  --calcite-size-fixed-xs: 6px; /** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
-  --calcite-size-fixed-sm: 8px; /** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
-  --calcite-size-fixed-sm-plus: 10px; /** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-4xs\` instead. */
-  --calcite-size-fixed-md: 12px; /** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-3xs\` instead. */
-  --calcite-size-fixed-md-plus: 14px; /** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-2xs\` instead. */
-  --calcite-size-fixed-lg: 16px; /** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-xs\` instead. */
-  --calcite-size-fixed-xl: 20px; /** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
-  --calcite-size-fixed-xxl: 24px; /** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-sm\` instead. */
-  --calcite-size-fixed-xxxl: 32px; /** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-md\` instead. */
+  --calcite-size-fixed-xxxs: 2px; /** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
+  --calcite-size-fixed-xxs: 4px; /** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
+  --calcite-size-fixed-xs: 6px; /** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
+  --calcite-size-fixed-sm: 8px; /** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
+  --calcite-size-fixed-sm-plus: 10px; /** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-4xs\` instead. */
+  --calcite-size-fixed-md: 12px; /** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-3xs\` instead. */
+  --calcite-size-fixed-md-plus: 14px; /** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-2xs\` instead. */
+  --calcite-size-fixed-lg: 16px; /** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-xs\` instead. */
+  --calcite-size-fixed-xl: 20px; /** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
+  --calcite-size-fixed-xxl: 24px; /** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-sm\` instead. */
+  --calcite-size-fixed-xxxl: 32px; /** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-md\` instead. */
   --calcite-size-px: 1px;
   --calcite-size-4xs: 0.625rem;
-  --calcite-size-xxxs: 0.75rem; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-3xs\` instead. */
+  --calcite-size-xxxs: 0.75rem; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-3xs\` instead. */
   --calcite-size-3xs: 0.75rem;
-  --calcite-size-xxs: 0.875rem; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-2xs\` instead. */
+  --calcite-size-xxs: 0.875rem; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-2xs\` instead. */
   --calcite-size-2xs: 0.875rem;
   --calcite-size-xs: 1rem;
   --calcite-size-sm: 1.5rem;
   --calcite-size-md: 2rem;
   --calcite-size-lg: 2.75rem;
   --calcite-size-xl: 3rem;
-  --calcite-size-xxl: 4rem; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-2xl\` instead. */
+  --calcite-size-xxl: 4rem; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-2xl\` instead. */
   --calcite-size-2xl: 4rem;
-  --calcite-size-xxxl: 6rem; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-3xl\` instead. */
+  --calcite-size-xxxl: 6rem; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-3xl\` instead. */
   --calcite-size-3xl: 6rem;
-  --calcite-spacing-fixed-xxs: 4px; /** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-2xs\` instead. */
-  --calcite-spacing-fixed-xs: 6px; /** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-xs\` instead. */
-  --calcite-spacing-fixed-sm: 8px; /** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-sm\` instead. */
-  --calcite-spacing-fixed-md: 12px; /** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-md\` instead. */
-  --calcite-spacing-fixed-lg: 14px; /** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-md-plus\` instead. */
-  --calcite-spacing-fixed-xl: 16px; /** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-lg\` instead. */
-  --calcite-spacing-fixed-xxl: 20px; /** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-xl\` instead. */
-  --calcite-spacing-fixed-xxxl: 32px; /** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-3xl\` instead. */
-  --calcite-spacing-none: 0; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-none\` instead. */
-  --calcite-spacing-px: 1px; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-px\` instead. */
-  --calcite-spacing-base: 2px; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-base\` instead. */
-  --calcite-spacing-xxs: 0.25rem; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-2xs\` instead. */
-  --calcite-spacing-xs: 0.375rem; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-xs\` instead. */
-  --calcite-spacing-sm: 0.5rem; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-sm\` instead. */
-  --calcite-spacing-sm-plus: 0.625rem; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-sm-plus\` instead. */
-  --calcite-spacing-md: 0.75rem; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-md\` instead. */
-  --calcite-spacing-md-plus: 0.875rem; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-md-plus\` instead. */
-  --calcite-spacing-lg: 1rem; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-lg\` instead. */
-  --calcite-spacing-xl: 1.25rem; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-xl\` instead. */
-  --calcite-spacing-xxl: 1.5rem; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-2xl\` instead. */
-  --calcite-spacing-xxxl: 2rem; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-3xl\` instead. */
+  --calcite-spacing-fixed-xxs: 4px; /** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-2xs\` instead. */
+  --calcite-spacing-fixed-xs: 6px; /** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-xs\` instead. */
+  --calcite-spacing-fixed-sm: 8px; /** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-sm\` instead. */
+  --calcite-spacing-fixed-md: 12px; /** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-md\` instead. */
+  --calcite-spacing-fixed-lg: 14px; /** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-md-plus\` instead. */
+  --calcite-spacing-fixed-xl: 16px; /** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-lg\` instead. */
+  --calcite-spacing-fixed-xxl: 20px; /** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-xl\` instead. */
+  --calcite-spacing-fixed-xxxl: 32px; /** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-3xl\` instead. */
+  --calcite-spacing-none: 0; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-none\` instead. */
+  --calcite-spacing-px: 1px; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-px\` instead. */
+  --calcite-spacing-base: 2px; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-base\` instead. */
+  --calcite-spacing-xxs: 0.25rem; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-2xs\` instead. */
+  --calcite-spacing-xs: 0.375rem; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-xs\` instead. */
+  --calcite-spacing-sm: 0.5rem; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-sm\` instead. */
+  --calcite-spacing-sm-plus: 0.625rem; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-sm-plus\` instead. */
+  --calcite-spacing-md: 0.75rem; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-md\` instead. */
+  --calcite-spacing-md-plus: 0.875rem; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-md-plus\` instead. */
+  --calcite-spacing-lg: 1rem; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-lg\` instead. */
+  --calcite-spacing-xl: 1.25rem; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-xl\` instead. */
+  --calcite-spacing-xxl: 1.5rem; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-2xl\` instead. */
+  --calcite-spacing-xxxl: 2rem; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-3xl\` instead. */
   --calcite-space-none: 0;
   --calcite-space-px: 1px;
   --calcite-space-base: 2px;
@@ -6085,7 +6085,7 @@ exports[`generated tokens > DOCS (internal) > core should match 1`] = `
       "key": "{core.color.low-saturation.violet.l-vv-1000}",
       "value": "#13111a",
       "type": "color",
-      "description": "Deprecated in v3.3.0, removal target v6.0.0 - Use \`--calcite-color-low-saturation-violet-l-vv-100\` instead.",
+      "description": "Deprecated in v3.2.0, removal target v5.0.0 - Use \`--calcite-color-low-saturation-violet-l-vv-100\` instead.",
       "attributes": {
         "category": "color",
         "group": "low-saturation",
@@ -6095,13 +6095,13 @@ exports[`generated tokens > DOCS (internal) > core should match 1`] = `
         "subitem": "violet",
         "state": "l-vv-1000",
         "value": "#13111a",
-        "description": "Deprecated in v3.3.0, removal target v6.0.0 - Use \`--calcite-color-low-saturation-violet-l-vv-100\` instead.",
+        "description": "Deprecated in v3.2.0, removal target v5.0.0 - Use \`--calcite-color-low-saturation-violet-l-vv-100\` instead.",
         "filePath": "src/tokens/core/color.json",
         "isSource": false,
         "key": "{core.color.low-saturation.violet.l-vv-1000}",
         "name": "calcite-core-color-low-saturation-violet-l-vv-1000",
         "path": ["core", "color", "low-saturation", "violet", "l-vv-1000"],
-        "comment": "Deprecated in v3.3.0, removal target v6.0.0 - Use \`--calcite-color-low-saturation-violet-l-vv-100\` instead.",
+        "comment": "Deprecated in v3.2.0, removal target v5.0.0 - Use \`--calcite-color-low-saturation-violet-l-vv-100\` instead.",
         "names": {
           "scss": "$calcite-color-low-saturation-violet-l-vv-1000",
           "css": "var(--calcite-color-low-saturation-violet-l-vv-1000)",
@@ -6118,7 +6118,7 @@ exports[`generated tokens > DOCS (internal) > core should match 1`] = `
       "isSource": false,
       "name": "Color Low Saturation Violet L Vv 1000",
       "path": ["core", "color", "low-saturation", "violet", "l-vv-1000"],
-      "comment": "Deprecated in v3.3.0, removal target v6.0.0 - Use \`--calcite-color-low-saturation-violet-l-vv-100\` instead."
+      "comment": "Deprecated in v3.2.0, removal target v5.0.0 - Use \`--calcite-color-low-saturation-violet-l-vv-100\` instead."
     },
     {
       "key": "{core.color.medium-saturation.blue.m-bb-010}",
@@ -15755,7 +15755,7 @@ exports[`generated tokens > DOCS (internal) > core should match 1`] = `
       "key": "{core.font.text-decoration.none}",
       "value": "none",
       "type": "textDecoration",
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
       "attributes": {
         "category": "font",
         "docs": "deprecated",
@@ -15763,13 +15763,13 @@ exports[`generated tokens > DOCS (internal) > core should match 1`] = `
         "item": "text-decoration",
         "subitem": "none",
         "value": "none",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "filePath": "src/tokens/core/font.json",
         "isSource": false,
         "key": "{core.font.text-decoration.none}",
         "name": "calcite-core-font-text-decoration-none",
         "path": ["core", "font", "text-decoration", "none"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "names": {
           "scss": "$calcite-font-text-decoration-none",
           "css": "var(--calcite-font-text-decoration-none)",
@@ -15786,13 +15786,13 @@ exports[`generated tokens > DOCS (internal) > core should match 1`] = `
       "isSource": false,
       "name": "Font Text Decoration None",
       "path": ["core", "font", "text-decoration", "none"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed."
     },
     {
       "key": "{core.font.text-decoration.underline}",
       "value": "underline",
       "type": "textDecoration",
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
       "attributes": {
         "category": "font",
         "docs": "deprecated",
@@ -15800,13 +15800,13 @@ exports[`generated tokens > DOCS (internal) > core should match 1`] = `
         "item": "text-decoration",
         "subitem": "underline",
         "value": "underline",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "filePath": "src/tokens/core/font.json",
         "isSource": false,
         "key": "{core.font.text-decoration.underline}",
         "name": "calcite-core-font-text-decoration-underline",
         "path": ["core", "font", "text-decoration", "underline"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "names": {
           "scss": "$calcite-font-text-decoration-underline",
           "css": "var(--calcite-font-text-decoration-underline)",
@@ -15823,13 +15823,13 @@ exports[`generated tokens > DOCS (internal) > core should match 1`] = `
       "isSource": false,
       "name": "Font Text Decoration Underline",
       "path": ["core", "font", "text-decoration", "underline"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed."
     },
     {
       "key": "{core.font.text-case.none}",
       "value": "none",
       "type": "textCase",
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
       "attributes": {
         "category": "font",
         "docs": "deprecated",
@@ -15837,13 +15837,13 @@ exports[`generated tokens > DOCS (internal) > core should match 1`] = `
         "item": "text-case",
         "subitem": "none",
         "value": "none",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "filePath": "src/tokens/core/font.json",
         "isSource": false,
         "key": "{core.font.text-case.none}",
         "name": "calcite-core-font-text-case-none",
         "path": ["core", "font", "text-case", "none"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "names": {
           "scss": "$calcite-font-text-case-none",
           "css": "var(--calcite-font-text-case-none)",
@@ -15860,13 +15860,13 @@ exports[`generated tokens > DOCS (internal) > core should match 1`] = `
       "isSource": false,
       "name": "Font Text Case None",
       "path": ["core", "font", "text-case", "none"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed."
     },
     {
       "key": "{core.font.text-case.uppercase}",
       "value": "uppercase",
       "type": "textCase",
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
       "attributes": {
         "category": "font",
         "docs": "deprecated",
@@ -15874,13 +15874,13 @@ exports[`generated tokens > DOCS (internal) > core should match 1`] = `
         "item": "text-case",
         "subitem": "uppercase",
         "value": "uppercase",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "filePath": "src/tokens/core/font.json",
         "isSource": false,
         "key": "{core.font.text-case.uppercase}",
         "name": "calcite-core-font-text-case-uppercase",
         "path": ["core", "font", "text-case", "uppercase"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "names": {
           "scss": "$calcite-font-text-case-uppercase",
           "css": "var(--calcite-font-text-case-uppercase)",
@@ -15897,13 +15897,13 @@ exports[`generated tokens > DOCS (internal) > core should match 1`] = `
       "isSource": false,
       "name": "Font Text Case Uppercase",
       "path": ["core", "font", "text-case", "uppercase"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed."
     },
     {
       "key": "{core.font.text-case.lowercase}",
       "value": "lowercase",
       "type": "textCase",
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
       "attributes": {
         "category": "font",
         "docs": "deprecated",
@@ -15911,13 +15911,13 @@ exports[`generated tokens > DOCS (internal) > core should match 1`] = `
         "item": "text-case",
         "subitem": "lowercase",
         "value": "lowercase",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "filePath": "src/tokens/core/font.json",
         "isSource": false,
         "key": "{core.font.text-case.lowercase}",
         "name": "calcite-core-font-text-case-lowercase",
         "path": ["core", "font", "text-case", "lowercase"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "names": {
           "scss": "$calcite-font-text-case-lowercase",
           "css": "var(--calcite-font-text-case-lowercase)",
@@ -15934,13 +15934,13 @@ exports[`generated tokens > DOCS (internal) > core should match 1`] = `
       "isSource": false,
       "name": "Font Text Case Lowercase",
       "path": ["core", "font", "text-case", "lowercase"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed."
     },
     {
       "key": "{core.font.text-case.capitalize}",
       "value": "capitalize",
       "type": "textCase",
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
       "attributes": {
         "category": "font",
         "docs": "deprecated",
@@ -15948,13 +15948,13 @@ exports[`generated tokens > DOCS (internal) > core should match 1`] = `
         "item": "text-case",
         "subitem": "capitalize",
         "value": "capitalize",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "filePath": "src/tokens/core/font.json",
         "isSource": false,
         "key": "{core.font.text-case.capitalize}",
         "name": "calcite-core-font-text-case-capitalize",
         "path": ["core", "font", "text-case", "capitalize"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "names": {
           "scss": "$calcite-font-text-case-capitalize",
           "css": "var(--calcite-font-text-case-capitalize)",
@@ -15971,7 +15971,7 @@ exports[`generated tokens > DOCS (internal) > core should match 1`] = `
       "isSource": false,
       "name": "Font Text Case Capitalize",
       "path": ["core", "font", "text-case", "capitalize"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed."
     },
     {
       "key": "{core.opacity.0}",
@@ -18362,13 +18362,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "color",
         "item": "default",
         "value": "#f7f7f7",
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-1\` instead.",
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-1\` instead.",
         "filePath": "src/tokens/semantic/color/light.json",
         "isSource": false,
         "key": "{color.background.default}",
         "name": "calcite-color-background-default",
         "path": ["color", "background", "default"],
-        "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-1\` instead.",
+        "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-1\` instead.",
         "names": {
           "scss": "$calcite-color-background",
           "css": "var(--calcite-color-background)",
@@ -18381,12 +18381,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "color"
         }
       },
-      "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-1\` instead.",
+      "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-1\` instead.",
       "filePath": "src/tokens/semantic/color/light.json",
       "isSource": false,
       "name": "Color Background",
       "path": ["color", "background", "default"],
-      "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-1\` instead."
+      "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-1\` instead."
     },
     {
       "key": "{color.background.none}",
@@ -18399,13 +18399,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "color",
         "item": "none",
         "value": "rgba(#ffffff, 0)",
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - No longer needed.",
         "filePath": "src/tokens/semantic/color/light.json",
         "isSource": false,
         "key": "{color.background.none}",
         "name": "calcite-color-background-none",
         "path": ["color", "background", "none"],
-        "comment": "Deprecated in v5.0.0, removal target v6.0.0 - No longer needed.",
+        "comment": "Deprecated in v4.0.0, removal target v5.0.0 - No longer needed.",
         "names": {
           "scss": "$calcite-color-background-none",
           "css": "var(--calcite-color-background-none)",
@@ -18418,12 +18418,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "color"
         }
       },
-      "description": "Deprecated in v5.0.0, removal target v6.0.0 - No longer needed.",
+      "description": "Deprecated in v4.0.0, removal target v5.0.0 - No longer needed.",
       "filePath": "src/tokens/semantic/color/light.json",
       "isSource": false,
       "name": "Color Background None",
       "path": ["color", "background", "none"],
-      "comment": "Deprecated in v5.0.0, removal target v6.0.0 - No longer needed."
+      "comment": "Deprecated in v4.0.0, removal target v5.0.0 - No longer needed."
     },
     {
       "key": "{color.foreground.1}",
@@ -18436,13 +18436,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "color",
         "item": "1",
         "value": "#ffffff",
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-2\` instead.",
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-2\` instead.",
         "filePath": "src/tokens/semantic/color/light.json",
         "isSource": false,
         "key": "{color.foreground.1}",
         "name": "calcite-color-foreground-1",
         "path": ["color", "foreground", "1"],
-        "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-2\` instead.",
+        "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-2\` instead.",
         "names": {
           "scss": "$calcite-color-foreground-1",
           "css": "var(--calcite-color-foreground-1)",
@@ -18455,12 +18455,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "color"
         }
       },
-      "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-2\` instead.",
+      "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-2\` instead.",
       "filePath": "src/tokens/semantic/color/light.json",
       "isSource": false,
       "name": "Color Foreground 1",
       "path": ["color", "foreground", "1"],
-      "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-2\` instead."
+      "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-2\` instead."
     },
     {
       "key": "{color.foreground.2}",
@@ -18473,13 +18473,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "color",
         "item": "2",
         "value": "#f2f2f2",
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-3\` instead.",
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-3\` instead.",
         "filePath": "src/tokens/semantic/color/light.json",
         "isSource": false,
         "key": "{color.foreground.2}",
         "name": "calcite-color-foreground-2",
         "path": ["color", "foreground", "2"],
-        "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-3\` instead.",
+        "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-3\` instead.",
         "names": {
           "scss": "$calcite-color-foreground-2",
           "css": "var(--calcite-color-foreground-2)",
@@ -18492,12 +18492,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "color"
         }
       },
-      "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-3\` instead.",
+      "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-3\` instead.",
       "filePath": "src/tokens/semantic/color/light.json",
       "isSource": false,
       "name": "Color Foreground 2",
       "path": ["color", "foreground", "2"],
-      "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-3\` instead."
+      "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-3\` instead."
     },
     {
       "key": "{color.foreground.3}",
@@ -18510,13 +18510,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "color",
         "item": "3",
         "value": "#ebebeb",
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-4\` instead.",
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-4\` instead.",
         "filePath": "src/tokens/semantic/color/light.json",
         "isSource": false,
         "key": "{color.foreground.3}",
         "name": "calcite-color-foreground-3",
         "path": ["color", "foreground", "3"],
-        "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-4\` instead.",
+        "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-4\` instead.",
         "names": {
           "scss": "$calcite-color-foreground-3",
           "css": "var(--calcite-color-foreground-3)",
@@ -18529,12 +18529,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "color"
         }
       },
-      "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-4\` instead.",
+      "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-4\` instead.",
       "filePath": "src/tokens/semantic/color/light.json",
       "isSource": false,
       "name": "Color Foreground 3",
       "path": ["color", "foreground", "3"],
-      "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-4\` instead."
+      "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-4\` instead."
     },
     {
       "key": "{color.foreground.current}",
@@ -18547,13 +18547,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "color",
         "item": "current",
         "value": "#d6efff",
-        "description": "Deprecated in v3.3.0, removal target v6.0.0 - Use \`--calcite-color-surface-highlight\` instead.",
+        "description": "Deprecated in v3.2.0, removal target v5.0.0 - Use \`--calcite-color-surface-highlight\` instead.",
         "filePath": "src/tokens/semantic/color/light.json",
         "isSource": false,
         "key": "{color.foreground.current}",
         "name": "calcite-color-foreground-current",
         "path": ["color", "foreground", "current"],
-        "comment": "Deprecated in v3.3.0, removal target v6.0.0 - Use \`--calcite-color-surface-highlight\` instead.",
+        "comment": "Deprecated in v3.2.0, removal target v5.0.0 - Use \`--calcite-color-surface-highlight\` instead.",
         "names": {
           "scss": "$calcite-color-foreground-current",
           "css": "var(--calcite-color-foreground-current)",
@@ -18566,12 +18566,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "color"
         }
       },
-      "description": "Deprecated in v3.3.0, removal target v6.0.0 - Use \`--calcite-color-surface-highlight\` instead.",
+      "description": "Deprecated in v3.2.0, removal target v5.0.0 - Use \`--calcite-color-surface-highlight\` instead.",
       "filePath": "src/tokens/semantic/color/light.json",
       "isSource": false,
       "name": "Color Foreground Current",
       "path": ["color", "foreground", "current"],
-      "comment": "Deprecated in v3.3.0, removal target v6.0.0 - Use \`--calcite-color-surface-highlight\` instead."
+      "comment": "Deprecated in v3.2.0, removal target v5.0.0 - Use \`--calcite-color-surface-highlight\` instead."
     },
     {
       "key": "{color.text.1}",
@@ -18844,13 +18844,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "color",
         "item": "ghost",
         "value": "rgba(#000000, 0.3)",
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - No longer needed.",
         "filePath": "src/tokens/semantic/color/light.json",
         "isSource": false,
         "key": "{color.border.ghost}",
         "name": "calcite-color-border-ghost",
         "path": ["color", "border", "ghost"],
-        "comment": "Deprecated in v5.0.0, removal target v6.0.0 - No longer needed.",
+        "comment": "Deprecated in v4.0.0, removal target v5.0.0 - No longer needed.",
         "names": {
           "scss": "$calcite-color-border-ghost",
           "css": "var(--calcite-color-border-ghost)",
@@ -18863,12 +18863,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "color"
         }
       },
-      "description": "Deprecated in v5.0.0, removal target v6.0.0 - No longer needed.",
+      "description": "Deprecated in v4.0.0, removal target v5.0.0 - No longer needed.",
       "filePath": "src/tokens/semantic/color/light.json",
       "isSource": false,
       "name": "Color Border Ghost",
       "path": ["color", "border", "ghost"],
-      "comment": "Deprecated in v5.0.0, removal target v6.0.0 - No longer needed."
+      "comment": "Deprecated in v4.0.0, removal target v5.0.0 - No longer needed."
     },
     {
       "key": "{color.border.white}",
@@ -18881,13 +18881,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "color",
         "item": "white",
         "value": "#ffffff",
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - No longer needed.",
         "filePath": "src/tokens/semantic/color/light.json",
         "isSource": false,
         "key": "{color.border.white}",
         "name": "calcite-color-border-white",
         "path": ["color", "border", "white"],
-        "comment": "Deprecated in v5.0.0, removal target v6.0.0 - No longer needed.",
+        "comment": "Deprecated in v4.0.0, removal target v5.0.0 - No longer needed.",
         "names": {
           "scss": "$calcite-color-border-white",
           "css": "var(--calcite-color-border-white)",
@@ -18900,12 +18900,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "color"
         }
       },
-      "description": "Deprecated in v5.0.0, removal target v6.0.0 - No longer needed.",
+      "description": "Deprecated in v4.0.0, removal target v5.0.0 - No longer needed.",
       "filePath": "src/tokens/semantic/color/light.json",
       "isSource": false,
       "name": "Color Border White",
       "path": ["color", "border", "white"],
-      "comment": "Deprecated in v5.0.0, removal target v6.0.0 - No longer needed."
+      "comment": "Deprecated in v4.0.0, removal target v5.0.0 - No longer needed."
     },
     {
       "key": "{color.brand.default}",
@@ -19745,7 +19745,7 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "key": "{container-size.height.xxs}",
       "value": "{\\"min\\":\\"0\\",\\"max\\":\\"154px\\"}",
       "type": "dimension",
-      "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-container-size-height-2xs-min|max\` instead.",
+      "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-container-size-height-2xs-min|max\` instead.",
       "attributes": {
         "category": "breakpoint",
         "docs": "deprecated",
@@ -19755,13 +19755,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "min": "0",
           "max": "154px"
         },
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-container-size-height-2xs-min|max\` instead.",
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-container-size-height-2xs-min|max\` instead.",
         "filePath": "src/tokens/semantic/container-size.json",
         "isSource": true,
         "key": "{container-size.height.xxs}",
         "name": "calcite-container-size-height-xxs",
         "path": ["container-size", "height", "xxs"],
-        "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-container-size-height-2xs-min|max\` instead.",
+        "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-container-size-height-2xs-min|max\` instead.",
         "names": {
           "scss": "$calcite-container-size-height-xxs",
           "css": "var(--calcite-container-size-height-xxs)",
@@ -19778,7 +19778,7 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "isSource": true,
       "name": "Container Size Height Xxs",
       "path": ["container-size", "height", "xxs"],
-      "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-container-size-height-2xs-min|max\` instead."
+      "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-container-size-height-2xs-min|max\` instead."
     },
     {
       "key": "{container-size.height.2xs}",
@@ -20011,7 +20011,7 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "key": "{container-size.width.xxs}",
       "value": "{\\"min\\":\\"0\\",\\"max\\":\\"320px\\"}",
       "type": "dimension",
-      "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-container-size-width-2xs-min|max\` instead.",
+      "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-container-size-width-2xs-min|max\` instead.",
       "attributes": {
         "category": "breakpoint",
         "docs": "deprecated",
@@ -20021,13 +20021,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "min": "0",
           "max": "320px"
         },
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-container-size-width-2xs-min|max\` instead.",
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-container-size-width-2xs-min|max\` instead.",
         "filePath": "src/tokens/semantic/container-size.json",
         "isSource": true,
         "key": "{container-size.width.xxs}",
         "name": "calcite-container-size-width-xxs",
         "path": ["container-size", "width", "xxs"],
-        "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-container-size-width-2xs-min|max\` instead.",
+        "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-container-size-width-2xs-min|max\` instead.",
         "names": {
           "scss": "$calcite-container-size-width-xxs",
           "css": "var(--calcite-container-size-width-xxs)",
@@ -20044,7 +20044,7 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "isSource": true,
       "name": "Container Size Width Xxs",
       "path": ["container-size", "width", "xxs"],
-      "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-container-size-width-2xs-min|max\` instead."
+      "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-container-size-width-2xs-min|max\` instead."
     },
     {
       "key": "{container-size.width.2xs}",
@@ -20424,13 +20424,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "docs": "deprecated",
         "type": "dimension",
         "value": "0",
-        "description": "Deprecated in v3.2.0, removal target v6.0.0 - Use \`--calcite-corner-radius-none\` instead.",
+        "description": "Deprecated in v3.1.0, removal target v5.0.0 - Use \`--calcite-corner-radius-none\` instead.",
         "filePath": "src/tokens/semantic/corner-radius.json",
         "isSource": true,
         "key": "{corner-radius.sharp}",
         "name": "calcite-corner-radius-sharp",
         "path": ["corner-radius", "sharp"],
-        "comment": "Deprecated in v3.2.0, removal target v6.0.0 - Use \`--calcite-corner-radius-none\` instead.",
+        "comment": "Deprecated in v3.1.0, removal target v5.0.0 - Use \`--calcite-corner-radius-none\` instead.",
         "names": {
           "scss": "$calcite-corner-radius-sharp",
           "css": "var(--calcite-corner-radius-sharp)",
@@ -20443,12 +20443,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v3.2.0, removal target v6.0.0 - Use \`--calcite-corner-radius-none\` instead.",
+      "description": "Deprecated in v3.1.0, removal target v5.0.0 - Use \`--calcite-corner-radius-none\` instead.",
       "filePath": "src/tokens/semantic/corner-radius.json",
       "isSource": true,
       "name": "Corner Radius Sharp",
       "path": ["corner-radius", "sharp"],
-      "comment": "Deprecated in v3.2.0, removal target v6.0.0 - Use \`--calcite-corner-radius-none\` instead."
+      "comment": "Deprecated in v3.1.0, removal target v5.0.0 - Use \`--calcite-corner-radius-none\` instead."
     },
     {
       "key": "{corner-radius.none}",
@@ -20531,13 +20531,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "docs": "deprecated",
         "type": "dimension",
         "value": "4px",
-        "description": "Deprecated in v3.2.0, removal target v6.0.0 - Use \`--calcite-corner-radius-sm\` instead.",
+        "description": "Deprecated in v3.1.0, removal target v5.0.0 - Use \`--calcite-corner-radius-sm\` instead.",
         "filePath": "src/tokens/semantic/corner-radius.json",
         "isSource": true,
         "key": "{corner-radius.round}",
         "name": "calcite-corner-radius-round",
         "path": ["corner-radius", "round"],
-        "comment": "Deprecated in v3.2.0, removal target v6.0.0 - Use \`--calcite-corner-radius-sm\` instead.",
+        "comment": "Deprecated in v3.1.0, removal target v5.0.0 - Use \`--calcite-corner-radius-sm\` instead.",
         "names": {
           "scss": "$calcite-corner-radius-round",
           "css": "var(--calcite-corner-radius-round)",
@@ -20550,12 +20550,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v3.2.0, removal target v6.0.0 - Use \`--calcite-corner-radius-sm\` instead.",
+      "description": "Deprecated in v3.1.0, removal target v5.0.0 - Use \`--calcite-corner-radius-sm\` instead.",
       "filePath": "src/tokens/semantic/corner-radius.json",
       "isSource": true,
       "name": "Corner Radius Round",
       "path": ["corner-radius", "round"],
-      "comment": "Deprecated in v3.2.0, removal target v6.0.0 - Use \`--calcite-corner-radius-sm\` instead."
+      "comment": "Deprecated in v3.1.0, removal target v5.0.0 - Use \`--calcite-corner-radius-sm\` instead."
     },
     {
       "key": "{corner-radius.pill}",
@@ -20706,13 +20706,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "extensions": {
           "calcite.deprecated": true
         },
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-font-weight-regular\` instead.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-font-weight-regular\` instead.",
         "filePath": "src/tokens/semantic/font.json",
         "isSource": true,
         "key": "{font.weight.normal}",
         "name": "calcite-font-weight-normal",
         "path": ["font", "weight", "normal"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-font-weight-regular\` instead.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-font-weight-regular\` instead.",
         "names": {
           "scss": "$calcite-font-weight-normal",
           "css": "var(--calcite-font-weight-normal)",
@@ -20725,12 +20725,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "fontWeight"
         }
       },
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-font-weight-regular\` instead.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-font-weight-regular\` instead.",
       "filePath": "src/tokens/semantic/font.json",
       "isSource": true,
       "name": "Font Weight Normal",
       "path": ["font", "weight", "normal"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-font-weight-regular\` instead."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-font-weight-regular\` instead."
     },
     {
       "key": "{font.weight.regular}",
@@ -21003,13 +21003,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "fontSize",
         "item": "xxl",
         "value": "24px",
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-font-size-2xl\` instead.",
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-font-size-2xl\` instead.",
         "filePath": "src/tokens/semantic/font.json",
         "isSource": true,
         "key": "{font.size.xxl}",
         "name": "calcite-font-size-xxl",
         "path": ["font", "size", "xxl"],
-        "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-font-size-2xl\` instead.",
+        "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-font-size-2xl\` instead.",
         "names": {
           "scss": "$calcite-font-size-xxl",
           "css": "var(--calcite-font-size-xxl)",
@@ -21022,12 +21022,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "fontSize"
         }
       },
-      "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-font-size-2xl\` instead.",
+      "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-font-size-2xl\` instead.",
       "filePath": "src/tokens/semantic/font.json",
       "isSource": true,
       "name": "Font Size Xxl",
       "path": ["font", "size", "xxl"],
-      "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-font-size-2xl\` instead."
+      "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-font-size-2xl\` instead."
     },
     {
       "key": "{font.size.2xl}",
@@ -22261,7 +22261,7 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "key": "{font.letter-spacing.tight}",
       "value": "-0.4px",
       "type": "dimension",
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
       "attributes": {
         "category": "font",
         "group": "letter-spacing",
@@ -22269,13 +22269,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "dimension",
         "item": "tight",
         "value": "0 - .4 ",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "filePath": "src/tokens/semantic/font.json",
         "isSource": true,
         "key": "{font.letter-spacing.tight}",
         "name": "calcite-font-letter-spacing-tight",
         "path": ["font", "letter-spacing", "tight"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "names": {
           "scss": "$calcite-font-letter-spacing-tight",
           "css": "var(--calcite-font-letter-spacing-tight)",
@@ -22292,13 +22292,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "isSource": true,
       "name": "Font Letter Spacing Tight",
       "path": ["font", "letter-spacing", "tight"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed."
     },
     {
       "key": "{font.letter-spacing.normal}",
       "value": "0",
       "type": "dimension",
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
       "attributes": {
         "category": "font",
         "group": "letter-spacing",
@@ -22306,13 +22306,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "dimension",
         "item": "normal",
         "value": "0",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "filePath": "src/tokens/semantic/font.json",
         "isSource": true,
         "key": "{font.letter-spacing.normal}",
         "name": "calcite-font-letter-spacing-normal",
         "path": ["font", "letter-spacing", "normal"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "names": {
           "scss": "$calcite-font-letter-spacing-normal",
           "css": "var(--calcite-font-letter-spacing-normal)",
@@ -22329,13 +22329,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "isSource": true,
       "name": "Font Letter Spacing Normal",
       "path": ["font", "letter-spacing", "normal"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed."
     },
     {
       "key": "{font.letter-spacing.wide}",
       "value": "0.4px",
       "type": "dimension",
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
       "attributes": {
         "category": "font",
         "group": "letter-spacing",
@@ -22343,13 +22343,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "dimension",
         "item": "wide",
         "value": "0 + .4 ",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "filePath": "src/tokens/semantic/font.json",
         "isSource": true,
         "key": "{font.letter-spacing.wide}",
         "name": "calcite-font-letter-spacing-wide",
         "path": ["font", "letter-spacing", "wide"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "names": {
           "scss": "$calcite-font-letter-spacing-wide",
           "css": "var(--calcite-font-letter-spacing-wide)",
@@ -22366,26 +22366,26 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "isSource": true,
       "name": "Font Letter Spacing Wide",
       "path": ["font", "letter-spacing", "wide"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed."
     },
     {
       "key": "{font.paragraph-spacing.normal}",
       "value": "4px",
       "type": "dimension",
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
       "attributes": {
         "category": "font",
         "group": "paragraph-spacing",
         "type": "dimension",
         "item": "normal",
         "value": "4px",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "filePath": "src/tokens/semantic/font.json",
         "isSource": true,
         "key": "{font.paragraph-spacing.normal}",
         "name": "calcite-font-paragraph-spacing-normal",
         "path": ["font", "paragraph-spacing", "normal"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "names": {
           "scss": "$calcite-font-paragraph-spacing-normal",
           "css": "var(--calcite-font-paragraph-spacing-normal)",
@@ -22402,13 +22402,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "isSource": true,
       "name": "Font Paragraph Spacing Normal",
       "path": ["font", "paragraph-spacing", "normal"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed."
     },
     {
       "key": "{font.text-decoration.none}",
       "value": "none",
       "type": "textDecoration",
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
       "attributes": {
         "category": "font",
         "group": "text-decoration",
@@ -22416,13 +22416,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "textDecoration",
         "item": "none",
         "value": "none",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "filePath": "src/tokens/semantic/font.json",
         "isSource": true,
         "key": "{font.text-decoration.none}",
         "name": "calcite-font-text-decoration-none",
         "path": ["font", "text-decoration", "none"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "names": {
           "scss": "$calcite-font-text-decoration-none",
           "css": "var(--calcite-font-text-decoration-none)",
@@ -22439,13 +22439,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "isSource": true,
       "name": "Font Text Decoration None",
       "path": ["font", "text-decoration", "none"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed."
     },
     {
       "key": "{font.text-decoration.underline}",
       "value": "underline",
       "type": "textDecoration",
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
       "attributes": {
         "category": "font",
         "group": "text-decoration",
@@ -22453,13 +22453,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "textDecoration",
         "item": "underline",
         "value": "underline",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "filePath": "src/tokens/semantic/font.json",
         "isSource": true,
         "key": "{font.text-decoration.underline}",
         "name": "calcite-font-text-decoration-underline",
         "path": ["font", "text-decoration", "underline"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "names": {
           "scss": "$calcite-font-text-decoration-underline",
           "css": "var(--calcite-font-text-decoration-underline)",
@@ -22476,13 +22476,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "isSource": true,
       "name": "Font Text Decoration Underline",
       "path": ["font", "text-decoration", "underline"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed."
     },
     {
       "key": "{font.text-case.none}",
       "value": "none",
       "type": "textCase",
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
       "attributes": {
         "category": "font",
         "group": "text-case",
@@ -22490,13 +22490,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "textCase",
         "item": "none",
         "value": "none",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "filePath": "src/tokens/semantic/font.json",
         "isSource": true,
         "key": "{font.text-case.none}",
         "name": "calcite-font-text-case-none",
         "path": ["font", "text-case", "none"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "names": {
           "scss": "$calcite-font-text-case-none",
           "css": "var(--calcite-font-text-case-none)",
@@ -22513,13 +22513,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "isSource": true,
       "name": "Font Text Case None",
       "path": ["font", "text-case", "none"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed."
     },
     {
       "key": "{font.text-case.uppercase}",
       "value": "uppercase",
       "type": "textCase",
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
       "attributes": {
         "category": "font",
         "group": "text-case",
@@ -22527,13 +22527,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "textCase",
         "item": "uppercase",
         "value": "uppercase",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "filePath": "src/tokens/semantic/font.json",
         "isSource": true,
         "key": "{font.text-case.uppercase}",
         "name": "calcite-font-text-case-uppercase",
         "path": ["font", "text-case", "uppercase"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "names": {
           "scss": "$calcite-font-text-case-uppercase",
           "css": "var(--calcite-font-text-case-uppercase)",
@@ -22550,13 +22550,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "isSource": true,
       "name": "Font Text Case Uppercase",
       "path": ["font", "text-case", "uppercase"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed."
     },
     {
       "key": "{font.text-case.lowercase}",
       "value": "lowercase",
       "type": "textCase",
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
       "attributes": {
         "category": "font",
         "group": "text-case",
@@ -22564,13 +22564,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "textCase",
         "item": "lowercase",
         "value": "lowercase",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "filePath": "src/tokens/semantic/font.json",
         "isSource": true,
         "key": "{font.text-case.lowercase}",
         "name": "calcite-font-text-case-lowercase",
         "path": ["font", "text-case", "lowercase"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "names": {
           "scss": "$calcite-font-text-case-lowercase",
           "css": "var(--calcite-font-text-case-lowercase)",
@@ -22587,13 +22587,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "isSource": true,
       "name": "Font Text Case Lowercase",
       "path": ["font", "text-case", "lowercase"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed."
     },
     {
       "key": "{font.text-case.capitalize}",
       "value": "capitalize",
       "type": "textCase",
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
       "attributes": {
         "category": "font",
         "group": "text-case",
@@ -22601,13 +22601,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "textCase",
         "item": "capitalize",
         "value": "capitalize",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "filePath": "src/tokens/semantic/font.json",
         "isSource": true,
         "key": "{font.text-case.capitalize}",
         "name": "calcite-font-text-case-capitalize",
         "path": ["font", "text-case", "capitalize"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "names": {
           "scss": "$calcite-font-text-case-capitalize",
           "css": "var(--calcite-font-text-case-capitalize)",
@@ -22624,7 +22624,7 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
       "isSource": true,
       "name": "Font Text Case Capitalize",
       "path": ["font", "text-case", "capitalize"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed."
     },
     {
       "key": "{opacity.disabled}",
@@ -22828,13 +22828,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "dimension",
         "item": "xxxs",
         "value": "2px",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
         "key": "{size.fixed.xxxs}",
         "name": "calcite-size-fixed-xxxs",
         "path": ["size", "fixed", "xxxs"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "names": {
           "scss": "$calcite-size-fixed-xxxs",
           "css": "var(--calcite-size-fixed-xxxs)",
@@ -22847,12 +22847,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Fixed Xxxs",
       "path": ["size", "fixed", "xxxs"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed."
     },
     {
       "key": "{size.fixed.xxs}",
@@ -22864,13 +22864,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "dimension",
         "item": "xxs",
         "value": "4px",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
         "key": "{size.fixed.xxs}",
         "name": "calcite-size-fixed-xxs",
         "path": ["size", "fixed", "xxs"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "names": {
           "scss": "$calcite-size-fixed-xxs",
           "css": "var(--calcite-size-fixed-xxs)",
@@ -22883,12 +22883,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Fixed Xxs",
       "path": ["size", "fixed", "xxs"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed."
     },
     {
       "key": "{size.fixed.xs}",
@@ -22900,13 +22900,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "dimension",
         "item": "xs",
         "value": "6px",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
         "key": "{size.fixed.xs}",
         "name": "calcite-size-fixed-xs",
         "path": ["size", "fixed", "xs"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "names": {
           "scss": "$calcite-size-fixed-xs",
           "css": "var(--calcite-size-fixed-xs)",
@@ -22919,12 +22919,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Fixed Xs",
       "path": ["size", "fixed", "xs"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed."
     },
     {
       "key": "{size.fixed.sm}",
@@ -22936,13 +22936,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "dimension",
         "item": "sm",
         "value": "8px",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
         "key": "{size.fixed.sm}",
         "name": "calcite-size-fixed-sm",
         "path": ["size", "fixed", "sm"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "names": {
           "scss": "$calcite-size-fixed-sm",
           "css": "var(--calcite-size-fixed-sm)",
@@ -22955,12 +22955,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Fixed Sm",
       "path": ["size", "fixed", "sm"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed."
     },
     {
       "key": "{size.fixed.sm+}",
@@ -22972,13 +22972,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "dimension",
         "item": "sm+",
         "value": "10px",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-4xs\` instead.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-4xs\` instead.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
         "key": "{size.fixed.sm+}",
         "name": "calcite-size-fixed-sm",
         "path": ["size", "fixed", "sm+"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-4xs\` instead.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-4xs\` instead.",
         "names": {
           "scss": "$calcite-size-fixed-sm-plus",
           "css": "var(--calcite-size-fixed-sm-plus)",
@@ -22991,12 +22991,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-4xs\` instead.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-4xs\` instead.",
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Fixed Sm Plus",
       "path": ["size", "fixed", "sm+"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-4xs\` instead."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-4xs\` instead."
     },
     {
       "key": "{size.fixed.md}",
@@ -23008,13 +23008,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "dimension",
         "item": "md",
         "value": "12px",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-3xs\` instead.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-3xs\` instead.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
         "key": "{size.fixed.md}",
         "name": "calcite-size-fixed-md",
         "path": ["size", "fixed", "md"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-3xs\` instead.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-3xs\` instead.",
         "names": {
           "scss": "$calcite-size-fixed-md",
           "css": "var(--calcite-size-fixed-md)",
@@ -23027,12 +23027,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-3xs\` instead.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-3xs\` instead.",
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Fixed Md",
       "path": ["size", "fixed", "md"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-3xs\` instead."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-3xs\` instead."
     },
     {
       "key": "{size.fixed.md+}",
@@ -23044,13 +23044,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "dimension",
         "item": "md+",
         "value": "14px",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-2xs\` instead.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-2xs\` instead.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
         "key": "{size.fixed.md+}",
         "name": "calcite-size-fixed-md",
         "path": ["size", "fixed", "md+"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-2xs\` instead.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-2xs\` instead.",
         "names": {
           "scss": "$calcite-size-fixed-md-plus",
           "css": "var(--calcite-size-fixed-md-plus)",
@@ -23063,12 +23063,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-2xs\` instead.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-2xs\` instead.",
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Fixed Md Plus",
       "path": ["size", "fixed", "md+"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-2xs\` instead."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-2xs\` instead."
     },
     {
       "key": "{size.fixed.lg}",
@@ -23080,13 +23080,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "dimension",
         "item": "lg",
         "value": "16px",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-xs\` instead.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-xs\` instead.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
         "key": "{size.fixed.lg}",
         "name": "calcite-size-fixed-lg",
         "path": ["size", "fixed", "lg"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-xs\` instead.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-xs\` instead.",
         "names": {
           "scss": "$calcite-size-fixed-lg",
           "css": "var(--calcite-size-fixed-lg)",
@@ -23099,12 +23099,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-xs\` instead.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-xs\` instead.",
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Fixed Lg",
       "path": ["size", "fixed", "lg"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-xs\` instead."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-xs\` instead."
     },
     {
       "key": "{size.fixed.xl}",
@@ -23116,13 +23116,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "dimension",
         "item": "xl",
         "value": "20px",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
         "key": "{size.fixed.xl}",
         "name": "calcite-size-fixed-xl",
         "path": ["size", "fixed", "xl"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "names": {
           "scss": "$calcite-size-fixed-xl",
           "css": "var(--calcite-size-fixed-xl)",
@@ -23135,12 +23135,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Fixed Xl",
       "path": ["size", "fixed", "xl"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed."
     },
     {
       "key": "{size.fixed.xxl}",
@@ -23152,13 +23152,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "dimension",
         "item": "xxl",
         "value": "24px",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-sm\` instead.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-sm\` instead.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
         "key": "{size.fixed.xxl}",
         "name": "calcite-size-fixed-xxl",
         "path": ["size", "fixed", "xxl"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-sm\` instead.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-sm\` instead.",
         "names": {
           "scss": "$calcite-size-fixed-xxl",
           "css": "var(--calcite-size-fixed-xxl)",
@@ -23171,12 +23171,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-sm\` instead.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-sm\` instead.",
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Fixed Xxl",
       "path": ["size", "fixed", "xxl"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-sm\` instead."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-sm\` instead."
     },
     {
       "key": "{size.fixed.xxxl}",
@@ -23188,13 +23188,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "dimension",
         "item": "xxxl",
         "value": "32px",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-md\` instead.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-md\` instead.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
         "key": "{size.fixed.xxxl}",
         "name": "calcite-size-fixed-xxxl",
         "path": ["size", "fixed", "xxxl"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-md\` instead.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-md\` instead.",
         "names": {
           "scss": "$calcite-size-fixed-xxxl",
           "css": "var(--calcite-size-fixed-xxxl)",
@@ -23207,12 +23207,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-md\` instead.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-md\` instead.",
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Fixed Xxxl",
       "path": ["size", "fixed", "xxxl"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-md\` instead."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-md\` instead."
     },
     {
       "key": "{size.px}",
@@ -23271,13 +23271,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "docs": "deprecated",
         "type": "dimension",
         "value": "12px",
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-3xs\` instead.",
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-3xs\` instead.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
         "key": "{size.xxxs}",
         "name": "calcite-size-xxxs",
         "path": ["size", "xxxs"],
-        "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-3xs\` instead.",
+        "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-3xs\` instead.",
         "names": {
           "scss": "$calcite-size-xxxs",
           "css": "var(--calcite-size-xxxs)",
@@ -23290,12 +23290,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-3xs\` instead.",
+      "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-3xs\` instead.",
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Xxxs",
       "path": ["size", "xxxs"],
-      "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-3xs\` instead."
+      "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-3xs\` instead."
     },
     {
       "key": "{size.3xs}",
@@ -23330,13 +23330,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "docs": "deprecated",
         "type": "dimension",
         "value": "14px",
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-2xs\` instead.",
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-2xs\` instead.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
         "key": "{size.xxs}",
         "name": "calcite-size-xxs",
         "path": ["size", "xxs"],
-        "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-2xs\` instead.",
+        "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-2xs\` instead.",
         "names": {
           "scss": "$calcite-size-xxs",
           "css": "var(--calcite-size-xxs)",
@@ -23349,12 +23349,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-2xs\` instead.",
+      "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-2xs\` instead.",
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Xxs",
       "path": ["size", "xxs"],
-      "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-2xs\` instead."
+      "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-2xs\` instead."
     },
     {
       "key": "{size.2xs}",
@@ -23509,13 +23509,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "docs": "deprecated",
         "type": "dimension",
         "value": "64px",
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-2xl\` instead.",
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-2xl\` instead.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
         "key": "{size.xxl}",
         "name": "calcite-size-xxl",
         "path": ["size", "xxl"],
-        "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-2xl\` instead.",
+        "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-2xl\` instead.",
         "names": {
           "scss": "$calcite-size-xxl",
           "css": "var(--calcite-size-xxl)",
@@ -23528,12 +23528,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-2xl\` instead.",
+      "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-2xl\` instead.",
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Xxl",
       "path": ["size", "xxl"],
-      "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-2xl\` instead."
+      "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-2xl\` instead."
     },
     {
       "key": "{size.2xl}",
@@ -23568,13 +23568,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "docs": "deprecated",
         "type": "dimension",
         "value": "96px",
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-3xl\` instead.",
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-3xl\` instead.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
         "key": "{size.xxxl}",
         "name": "calcite-size-xxxl",
         "path": ["size", "xxxl"],
-        "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-3xl\` instead.",
+        "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-3xl\` instead.",
         "names": {
           "scss": "$calcite-size-xxxl",
           "css": "var(--calcite-size-xxxl)",
@@ -23587,12 +23587,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-3xl\` instead.",
+      "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-3xl\` instead.",
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Xxxl",
       "path": ["size", "xxxl"],
-      "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-3xl\` instead."
+      "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-3xl\` instead."
     },
     {
       "key": "{size.3xl}",
@@ -23628,13 +23628,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "dimension",
         "item": "xxs",
         "value": "4px",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-2xs\` instead.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-2xs\` instead.",
         "filePath": "src/tokens/semantic/space.json",
         "isSource": true,
         "key": "{spacing.fixed.xxs}",
         "name": "calcite-spacing-fixed-xxs",
         "path": ["spacing", "fixed", "xxs"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-2xs\` instead.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-2xs\` instead.",
         "names": {
           "scss": "$calcite-spacing-fixed-xxs",
           "css": "var(--calcite-spacing-fixed-xxs)",
@@ -23647,12 +23647,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-2xs\` instead.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-2xs\` instead.",
       "filePath": "src/tokens/semantic/space.json",
       "isSource": true,
       "name": "Spacing Fixed Xxs",
       "path": ["spacing", "fixed", "xxs"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-2xs\` instead."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-2xs\` instead."
     },
     {
       "key": "{spacing.fixed.xs}",
@@ -23664,13 +23664,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "dimension",
         "item": "xs",
         "value": "6px",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-xs\` instead.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-xs\` instead.",
         "filePath": "src/tokens/semantic/space.json",
         "isSource": true,
         "key": "{spacing.fixed.xs}",
         "name": "calcite-spacing-fixed-xs",
         "path": ["spacing", "fixed", "xs"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-xs\` instead.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-xs\` instead.",
         "names": {
           "scss": "$calcite-spacing-fixed-xs",
           "css": "var(--calcite-spacing-fixed-xs)",
@@ -23683,12 +23683,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-xs\` instead.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-xs\` instead.",
       "filePath": "src/tokens/semantic/space.json",
       "isSource": true,
       "name": "Spacing Fixed Xs",
       "path": ["spacing", "fixed", "xs"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-xs\` instead."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-xs\` instead."
     },
     {
       "key": "{spacing.fixed.sm}",
@@ -23700,13 +23700,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "dimension",
         "item": "sm",
         "value": "8px",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-sm\` instead.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-sm\` instead.",
         "filePath": "src/tokens/semantic/space.json",
         "isSource": true,
         "key": "{spacing.fixed.sm}",
         "name": "calcite-spacing-fixed-sm",
         "path": ["spacing", "fixed", "sm"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-sm\` instead.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-sm\` instead.",
         "names": {
           "scss": "$calcite-spacing-fixed-sm",
           "css": "var(--calcite-spacing-fixed-sm)",
@@ -23719,12 +23719,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-sm\` instead.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-sm\` instead.",
       "filePath": "src/tokens/semantic/space.json",
       "isSource": true,
       "name": "Spacing Fixed Sm",
       "path": ["spacing", "fixed", "sm"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-sm\` instead."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-sm\` instead."
     },
     {
       "key": "{spacing.fixed.md}",
@@ -23736,13 +23736,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "dimension",
         "item": "md",
         "value": "12px",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-md\` instead.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-md\` instead.",
         "filePath": "src/tokens/semantic/space.json",
         "isSource": true,
         "key": "{spacing.fixed.md}",
         "name": "calcite-spacing-fixed-md",
         "path": ["spacing", "fixed", "md"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-md\` instead.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-md\` instead.",
         "names": {
           "scss": "$calcite-spacing-fixed-md",
           "css": "var(--calcite-spacing-fixed-md)",
@@ -23755,12 +23755,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-md\` instead.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-md\` instead.",
       "filePath": "src/tokens/semantic/space.json",
       "isSource": true,
       "name": "Spacing Fixed Md",
       "path": ["spacing", "fixed", "md"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-md\` instead."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-md\` instead."
     },
     {
       "key": "{spacing.fixed.lg}",
@@ -23772,13 +23772,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "dimension",
         "item": "lg",
         "value": "14px",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-md-plus\` instead.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-md-plus\` instead.",
         "filePath": "src/tokens/semantic/space.json",
         "isSource": true,
         "key": "{spacing.fixed.lg}",
         "name": "calcite-spacing-fixed-lg",
         "path": ["spacing", "fixed", "lg"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-md-plus\` instead.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-md-plus\` instead.",
         "names": {
           "scss": "$calcite-spacing-fixed-lg",
           "css": "var(--calcite-spacing-fixed-lg)",
@@ -23791,12 +23791,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-md-plus\` instead.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-md-plus\` instead.",
       "filePath": "src/tokens/semantic/space.json",
       "isSource": true,
       "name": "Spacing Fixed Lg",
       "path": ["spacing", "fixed", "lg"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-md-plus\` instead."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-md-plus\` instead."
     },
     {
       "key": "{spacing.fixed.xl}",
@@ -23808,13 +23808,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "dimension",
         "item": "xl",
         "value": "16px",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-lg\` instead.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-lg\` instead.",
         "filePath": "src/tokens/semantic/space.json",
         "isSource": true,
         "key": "{spacing.fixed.xl}",
         "name": "calcite-spacing-fixed-xl",
         "path": ["spacing", "fixed", "xl"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-lg\` instead.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-lg\` instead.",
         "names": {
           "scss": "$calcite-spacing-fixed-xl",
           "css": "var(--calcite-spacing-fixed-xl)",
@@ -23827,12 +23827,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-lg\` instead.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-lg\` instead.",
       "filePath": "src/tokens/semantic/space.json",
       "isSource": true,
       "name": "Spacing Fixed Xl",
       "path": ["spacing", "fixed", "xl"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-lg\` instead."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-lg\` instead."
     },
     {
       "key": "{spacing.fixed.xxl}",
@@ -23844,13 +23844,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "dimension",
         "item": "xxl",
         "value": "20px",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-xl\` instead.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-xl\` instead.",
         "filePath": "src/tokens/semantic/space.json",
         "isSource": true,
         "key": "{spacing.fixed.xxl}",
         "name": "calcite-spacing-fixed-xxl",
         "path": ["spacing", "fixed", "xxl"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-xl\` instead.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-xl\` instead.",
         "names": {
           "scss": "$calcite-spacing-fixed-xxl",
           "css": "var(--calcite-spacing-fixed-xxl)",
@@ -23863,12 +23863,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-xl\` instead.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-xl\` instead.",
       "filePath": "src/tokens/semantic/space.json",
       "isSource": true,
       "name": "Spacing Fixed Xxl",
       "path": ["spacing", "fixed", "xxl"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-xl\` instead."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-xl\` instead."
     },
     {
       "key": "{spacing.fixed.xxxl}",
@@ -23880,13 +23880,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "dimension",
         "item": "xxxl",
         "value": "32px",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-3xl\` instead.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-3xl\` instead.",
         "filePath": "src/tokens/semantic/space.json",
         "isSource": true,
         "key": "{spacing.fixed.xxxl}",
         "name": "calcite-spacing-fixed-xxxl",
         "path": ["spacing", "fixed", "xxxl"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-3xl\` instead.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-3xl\` instead.",
         "names": {
           "scss": "$calcite-spacing-fixed-xxxl",
           "css": "var(--calcite-spacing-fixed-xxxl)",
@@ -23899,12 +23899,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-3xl\` instead.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-3xl\` instead.",
       "filePath": "src/tokens/semantic/space.json",
       "isSource": true,
       "name": "Spacing Fixed Xxxl",
       "path": ["spacing", "fixed", "xxxl"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-3xl\` instead."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-3xl\` instead."
     },
     {
       "key": "{spacing.default.none}",
@@ -23916,13 +23916,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "dimension",
         "item": "none",
         "value": "0",
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-none\` instead.",
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-none\` instead.",
         "filePath": "src/tokens/semantic/space.json",
         "isSource": true,
         "key": "{spacing.default.none}",
         "name": "calcite-spacing-default-none",
         "path": ["spacing", "default", "none"],
-        "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-none\` instead.",
+        "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-none\` instead.",
         "names": {
           "scss": "$calcite-spacing-none",
           "css": "var(--calcite-spacing-none)",
@@ -23935,12 +23935,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-none\` instead.",
+      "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-none\` instead.",
       "filePath": "src/tokens/semantic/space.json",
       "isSource": true,
       "name": "Spacing None",
       "path": ["spacing", "default", "none"],
-      "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-none\` instead."
+      "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-none\` instead."
     },
     {
       "key": "{spacing.default.px}",
@@ -23952,13 +23952,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "dimension",
         "item": "px",
         "value": "1px",
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-px\` instead.",
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-px\` instead.",
         "filePath": "src/tokens/semantic/space.json",
         "isSource": true,
         "key": "{spacing.default.px}",
         "name": "calcite-spacing-default-px",
         "path": ["spacing", "default", "px"],
-        "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-px\` instead.",
+        "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-px\` instead.",
         "names": {
           "scss": "$calcite-spacing-px",
           "css": "var(--calcite-spacing-px)",
@@ -23971,12 +23971,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-px\` instead.",
+      "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-px\` instead.",
       "filePath": "src/tokens/semantic/space.json",
       "isSource": true,
       "name": "Spacing Px",
       "path": ["spacing", "default", "px"],
-      "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-px\` instead."
+      "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-px\` instead."
     },
     {
       "key": "{spacing.default.base}",
@@ -23988,13 +23988,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "dimension",
         "item": "base",
         "value": "2px",
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-base\` instead.",
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-base\` instead.",
         "filePath": "src/tokens/semantic/space.json",
         "isSource": true,
         "key": "{spacing.default.base}",
         "name": "calcite-spacing-default-base",
         "path": ["spacing", "default", "base"],
-        "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-base\` instead.",
+        "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-base\` instead.",
         "names": {
           "scss": "$calcite-spacing-base",
           "css": "var(--calcite-spacing-base)",
@@ -24007,12 +24007,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-base\` instead.",
+      "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-base\` instead.",
       "filePath": "src/tokens/semantic/space.json",
       "isSource": true,
       "name": "Spacing Base",
       "path": ["spacing", "default", "base"],
-      "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-base\` instead."
+      "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-base\` instead."
     },
     {
       "key": "{spacing.default.xxs}",
@@ -24024,13 +24024,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "dimension",
         "item": "xxs",
         "value": "4px",
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-2xs\` instead.",
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-2xs\` instead.",
         "filePath": "src/tokens/semantic/space.json",
         "isSource": true,
         "key": "{spacing.default.xxs}",
         "name": "calcite-spacing-default-xxs",
         "path": ["spacing", "default", "xxs"],
-        "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-2xs\` instead.",
+        "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-2xs\` instead.",
         "names": {
           "scss": "$calcite-spacing-xxs",
           "css": "var(--calcite-spacing-xxs)",
@@ -24043,12 +24043,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-2xs\` instead.",
+      "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-2xs\` instead.",
       "filePath": "src/tokens/semantic/space.json",
       "isSource": true,
       "name": "Spacing Xxs",
       "path": ["spacing", "default", "xxs"],
-      "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-2xs\` instead."
+      "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-2xs\` instead."
     },
     {
       "key": "{spacing.default.xs}",
@@ -24060,13 +24060,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "dimension",
         "item": "xs",
         "value": "6px",
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-xs\` instead.",
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-xs\` instead.",
         "filePath": "src/tokens/semantic/space.json",
         "isSource": true,
         "key": "{spacing.default.xs}",
         "name": "calcite-spacing-default-xs",
         "path": ["spacing", "default", "xs"],
-        "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-xs\` instead.",
+        "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-xs\` instead.",
         "names": {
           "scss": "$calcite-spacing-xs",
           "css": "var(--calcite-spacing-xs)",
@@ -24079,12 +24079,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-xs\` instead.",
+      "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-xs\` instead.",
       "filePath": "src/tokens/semantic/space.json",
       "isSource": true,
       "name": "Spacing Xs",
       "path": ["spacing", "default", "xs"],
-      "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-xs\` instead."
+      "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-xs\` instead."
     },
     {
       "key": "{spacing.default.sm}",
@@ -24096,13 +24096,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "dimension",
         "item": "sm",
         "value": "8px",
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-sm\` instead.",
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-sm\` instead.",
         "filePath": "src/tokens/semantic/space.json",
         "isSource": true,
         "key": "{spacing.default.sm}",
         "name": "calcite-spacing-default-sm",
         "path": ["spacing", "default", "sm"],
-        "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-sm\` instead.",
+        "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-sm\` instead.",
         "names": {
           "scss": "$calcite-spacing-sm",
           "css": "var(--calcite-spacing-sm)",
@@ -24115,12 +24115,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-sm\` instead.",
+      "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-sm\` instead.",
       "filePath": "src/tokens/semantic/space.json",
       "isSource": true,
       "name": "Spacing Sm",
       "path": ["spacing", "default", "sm"],
-      "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-sm\` instead."
+      "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-sm\` instead."
     },
     {
       "key": "{spacing.default.sm+}",
@@ -24132,13 +24132,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "dimension",
         "item": "sm+",
         "value": "10px",
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-sm-plus\` instead.",
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-sm-plus\` instead.",
         "filePath": "src/tokens/semantic/space.json",
         "isSource": true,
         "key": "{spacing.default.sm+}",
         "name": "calcite-spacing-default-sm",
         "path": ["spacing", "default", "sm+"],
-        "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-sm-plus\` instead.",
+        "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-sm-plus\` instead.",
         "names": {
           "scss": "$calcite-spacing-sm-plus",
           "css": "var(--calcite-spacing-sm-plus)",
@@ -24151,12 +24151,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-sm-plus\` instead.",
+      "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-sm-plus\` instead.",
       "filePath": "src/tokens/semantic/space.json",
       "isSource": true,
       "name": "Spacing Sm Plus",
       "path": ["spacing", "default", "sm+"],
-      "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-sm-plus\` instead."
+      "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-sm-plus\` instead."
     },
     {
       "key": "{spacing.default.md}",
@@ -24168,13 +24168,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "dimension",
         "item": "md",
         "value": "12px",
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-md\` instead.",
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-md\` instead.",
         "filePath": "src/tokens/semantic/space.json",
         "isSource": true,
         "key": "{spacing.default.md}",
         "name": "calcite-spacing-default-md",
         "path": ["spacing", "default", "md"],
-        "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-md\` instead.",
+        "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-md\` instead.",
         "names": {
           "scss": "$calcite-spacing-md",
           "css": "var(--calcite-spacing-md)",
@@ -24187,12 +24187,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-md\` instead.",
+      "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-md\` instead.",
       "filePath": "src/tokens/semantic/space.json",
       "isSource": true,
       "name": "Spacing Md",
       "path": ["spacing", "default", "md"],
-      "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-md\` instead."
+      "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-md\` instead."
     },
     {
       "key": "{spacing.default.md+}",
@@ -24204,13 +24204,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "dimension",
         "item": "md+",
         "value": "14px",
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-md-plus\` instead.",
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-md-plus\` instead.",
         "filePath": "src/tokens/semantic/space.json",
         "isSource": true,
         "key": "{spacing.default.md+}",
         "name": "calcite-spacing-default-md",
         "path": ["spacing", "default", "md+"],
-        "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-md-plus\` instead.",
+        "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-md-plus\` instead.",
         "names": {
           "scss": "$calcite-spacing-md-plus",
           "css": "var(--calcite-spacing-md-plus)",
@@ -24223,12 +24223,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-md-plus\` instead.",
+      "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-md-plus\` instead.",
       "filePath": "src/tokens/semantic/space.json",
       "isSource": true,
       "name": "Spacing Md Plus",
       "path": ["spacing", "default", "md+"],
-      "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-md-plus\` instead."
+      "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-md-plus\` instead."
     },
     {
       "key": "{spacing.default.lg}",
@@ -24240,13 +24240,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "dimension",
         "item": "lg",
         "value": "16px",
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-lg\` instead.",
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-lg\` instead.",
         "filePath": "src/tokens/semantic/space.json",
         "isSource": true,
         "key": "{spacing.default.lg}",
         "name": "calcite-spacing-default-lg",
         "path": ["spacing", "default", "lg"],
-        "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-lg\` instead.",
+        "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-lg\` instead.",
         "names": {
           "scss": "$calcite-spacing-lg",
           "css": "var(--calcite-spacing-lg)",
@@ -24259,12 +24259,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-lg\` instead.",
+      "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-lg\` instead.",
       "filePath": "src/tokens/semantic/space.json",
       "isSource": true,
       "name": "Spacing Lg",
       "path": ["spacing", "default", "lg"],
-      "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-lg\` instead."
+      "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-lg\` instead."
     },
     {
       "key": "{spacing.default.xl}",
@@ -24276,13 +24276,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "dimension",
         "item": "xl",
         "value": "20px",
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-xl\` instead.",
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-xl\` instead.",
         "filePath": "src/tokens/semantic/space.json",
         "isSource": true,
         "key": "{spacing.default.xl}",
         "name": "calcite-spacing-default-xl",
         "path": ["spacing", "default", "xl"],
-        "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-xl\` instead.",
+        "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-xl\` instead.",
         "names": {
           "scss": "$calcite-spacing-xl",
           "css": "var(--calcite-spacing-xl)",
@@ -24295,12 +24295,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-xl\` instead.",
+      "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-xl\` instead.",
       "filePath": "src/tokens/semantic/space.json",
       "isSource": true,
       "name": "Spacing Xl",
       "path": ["spacing", "default", "xl"],
-      "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-xl\` instead."
+      "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-xl\` instead."
     },
     {
       "key": "{spacing.default.xxl}",
@@ -24312,13 +24312,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "dimension",
         "item": "xxl",
         "value": "24px",
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-2xl\` instead.",
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-2xl\` instead.",
         "filePath": "src/tokens/semantic/space.json",
         "isSource": true,
         "key": "{spacing.default.xxl}",
         "name": "calcite-spacing-default-xxl",
         "path": ["spacing", "default", "xxl"],
-        "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-2xl\` instead.",
+        "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-2xl\` instead.",
         "names": {
           "scss": "$calcite-spacing-xxl",
           "css": "var(--calcite-spacing-xxl)",
@@ -24331,12 +24331,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-2xl\` instead.",
+      "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-2xl\` instead.",
       "filePath": "src/tokens/semantic/space.json",
       "isSource": true,
       "name": "Spacing Xxl",
       "path": ["spacing", "default", "xxl"],
-      "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-2xl\` instead."
+      "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-2xl\` instead."
     },
     {
       "key": "{spacing.default.xxxl}",
@@ -24348,13 +24348,13 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
         "type": "dimension",
         "item": "xxxl",
         "value": "32px",
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-3xl\` instead.",
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-3xl\` instead.",
         "filePath": "src/tokens/semantic/space.json",
         "isSource": true,
         "key": "{spacing.default.xxxl}",
         "name": "calcite-spacing-default-xxxl",
         "path": ["spacing", "default", "xxxl"],
-        "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-3xl\` instead.",
+        "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-3xl\` instead.",
         "names": {
           "scss": "$calcite-spacing-xxxl",
           "css": "var(--calcite-spacing-xxxl)",
@@ -24367,12 +24367,12 @@ exports[`generated tokens > DOCS (internal) > global should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-3xl\` instead.",
+      "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-3xl\` instead.",
       "filePath": "src/tokens/semantic/space.json",
       "isSource": true,
       "name": "Spacing Xxxl",
       "path": ["spacing", "default", "xxxl"],
-      "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-3xl\` instead."
+      "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-3xl\` instead."
     },
     {
       "key": "{space.none}",
@@ -27398,13 +27398,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
         "docs": "deprecated",
         "type": "dimension",
         "value": "0",
-        "description": "Deprecated in v3.2.0, removal target v6.0.0 - Use \`--calcite-corner-radius-none\` instead.",
+        "description": "Deprecated in v3.1.0, removal target v5.0.0 - Use \`--calcite-corner-radius-none\` instead.",
         "filePath": "src/tokens/semantic/corner-radius.json",
         "isSource": true,
         "key": "{corner-radius.sharp}",
         "name": "calcite-corner-radius-sharp",
         "path": ["corner-radius", "sharp"],
-        "comment": "Deprecated in v3.2.0, removal target v6.0.0 - Use \`--calcite-corner-radius-none\` instead.",
+        "comment": "Deprecated in v3.1.0, removal target v5.0.0 - Use \`--calcite-corner-radius-none\` instead.",
         "names": {
           "scss": "$calcite-corner-radius-sharp",
           "css": "var(--calcite-corner-radius-sharp)",
@@ -27417,12 +27417,12 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v3.2.0, removal target v6.0.0 - Use \`--calcite-corner-radius-none\` instead.",
+      "description": "Deprecated in v3.1.0, removal target v5.0.0 - Use \`--calcite-corner-radius-none\` instead.",
       "filePath": "src/tokens/semantic/corner-radius.json",
       "isSource": true,
       "name": "Corner Radius Sharp",
       "path": ["corner-radius", "sharp"],
-      "comment": "Deprecated in v3.2.0, removal target v6.0.0 - Use \`--calcite-corner-radius-none\` instead."
+      "comment": "Deprecated in v3.1.0, removal target v5.0.0 - Use \`--calcite-corner-radius-none\` instead."
     },
     {
       "key": "{corner-radius.none}",
@@ -27505,13 +27505,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
         "docs": "deprecated",
         "type": "dimension",
         "value": "4px",
-        "description": "Deprecated in v3.2.0, removal target v6.0.0 - Use \`--calcite-corner-radius-sm\` instead.",
+        "description": "Deprecated in v3.1.0, removal target v5.0.0 - Use \`--calcite-corner-radius-sm\` instead.",
         "filePath": "src/tokens/semantic/corner-radius.json",
         "isSource": true,
         "key": "{corner-radius.round}",
         "name": "calcite-corner-radius-round",
         "path": ["corner-radius", "round"],
-        "comment": "Deprecated in v3.2.0, removal target v6.0.0 - Use \`--calcite-corner-radius-sm\` instead.",
+        "comment": "Deprecated in v3.1.0, removal target v5.0.0 - Use \`--calcite-corner-radius-sm\` instead.",
         "names": {
           "scss": "$calcite-corner-radius-round",
           "css": "var(--calcite-corner-radius-round)",
@@ -27524,12 +27524,12 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v3.2.0, removal target v6.0.0 - Use \`--calcite-corner-radius-sm\` instead.",
+      "description": "Deprecated in v3.1.0, removal target v5.0.0 - Use \`--calcite-corner-radius-sm\` instead.",
       "filePath": "src/tokens/semantic/corner-radius.json",
       "isSource": true,
       "name": "Corner Radius Round",
       "path": ["corner-radius", "round"],
-      "comment": "Deprecated in v3.2.0, removal target v6.0.0 - Use \`--calcite-corner-radius-sm\` instead."
+      "comment": "Deprecated in v3.1.0, removal target v5.0.0 - Use \`--calcite-corner-radius-sm\` instead."
     },
     {
       "key": "{corner-radius.pill}",
@@ -27680,13 +27680,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
         "extensions": {
           "calcite.deprecated": true
         },
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-font-weight-regular\` instead.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-font-weight-regular\` instead.",
         "filePath": "src/tokens/semantic/font.json",
         "isSource": true,
         "key": "{font.weight.normal}",
         "name": "calcite-font-weight-normal",
         "path": ["font", "weight", "normal"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-font-weight-regular\` instead.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-font-weight-regular\` instead.",
         "names": {
           "scss": "$calcite-font-weight-normal",
           "css": "var(--calcite-font-weight-normal)",
@@ -27699,12 +27699,12 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
           "type": "fontWeight"
         }
       },
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-font-weight-regular\` instead.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-font-weight-regular\` instead.",
       "filePath": "src/tokens/semantic/font.json",
       "isSource": true,
       "name": "Font Weight Normal",
       "path": ["font", "weight", "normal"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-font-weight-regular\` instead."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-font-weight-regular\` instead."
     },
     {
       "key": "{font.weight.regular}",
@@ -27977,13 +27977,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
         "type": "fontSize",
         "item": "xxl",
         "value": "24px",
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-font-size-2xl\` instead.",
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-font-size-2xl\` instead.",
         "filePath": "src/tokens/semantic/font.json",
         "isSource": true,
         "key": "{font.size.xxl}",
         "name": "calcite-font-size-xxl",
         "path": ["font", "size", "xxl"],
-        "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-font-size-2xl\` instead.",
+        "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-font-size-2xl\` instead.",
         "names": {
           "scss": "$calcite-font-size-xxl",
           "css": "var(--calcite-font-size-xxl)",
@@ -27996,12 +27996,12 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
           "type": "fontSize"
         }
       },
-      "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-font-size-2xl\` instead.",
+      "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-font-size-2xl\` instead.",
       "filePath": "src/tokens/semantic/font.json",
       "isSource": true,
       "name": "Font Size Xxl",
       "path": ["font", "size", "xxl"],
-      "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-font-size-2xl\` instead."
+      "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-font-size-2xl\` instead."
     },
     {
       "key": "{font.size.2xl}",
@@ -29235,7 +29235,7 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "key": "{font.letter-spacing.tight}",
       "value": "-0.4px",
       "type": "dimension",
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
       "attributes": {
         "category": "font",
         "group": "letter-spacing",
@@ -29243,13 +29243,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
         "type": "dimension",
         "item": "tight",
         "value": "0 - .4 ",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "filePath": "src/tokens/semantic/font.json",
         "isSource": true,
         "key": "{font.letter-spacing.tight}",
         "name": "calcite-font-letter-spacing-tight",
         "path": ["font", "letter-spacing", "tight"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "names": {
           "scss": "$calcite-font-letter-spacing-tight",
           "css": "var(--calcite-font-letter-spacing-tight)",
@@ -29266,13 +29266,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "isSource": true,
       "name": "Font Letter Spacing Tight",
       "path": ["font", "letter-spacing", "tight"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed."
     },
     {
       "key": "{font.letter-spacing.normal}",
       "value": "0",
       "type": "dimension",
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
       "attributes": {
         "category": "font",
         "group": "letter-spacing",
@@ -29280,13 +29280,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
         "type": "dimension",
         "item": "normal",
         "value": "0",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "filePath": "src/tokens/semantic/font.json",
         "isSource": true,
         "key": "{font.letter-spacing.normal}",
         "name": "calcite-font-letter-spacing-normal",
         "path": ["font", "letter-spacing", "normal"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "names": {
           "scss": "$calcite-font-letter-spacing-normal",
           "css": "var(--calcite-font-letter-spacing-normal)",
@@ -29303,13 +29303,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "isSource": true,
       "name": "Font Letter Spacing Normal",
       "path": ["font", "letter-spacing", "normal"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed."
     },
     {
       "key": "{font.letter-spacing.wide}",
       "value": "0.4px",
       "type": "dimension",
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
       "attributes": {
         "category": "font",
         "group": "letter-spacing",
@@ -29317,13 +29317,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
         "type": "dimension",
         "item": "wide",
         "value": "0 + .4 ",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "filePath": "src/tokens/semantic/font.json",
         "isSource": true,
         "key": "{font.letter-spacing.wide}",
         "name": "calcite-font-letter-spacing-wide",
         "path": ["font", "letter-spacing", "wide"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "names": {
           "scss": "$calcite-font-letter-spacing-wide",
           "css": "var(--calcite-font-letter-spacing-wide)",
@@ -29340,26 +29340,26 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "isSource": true,
       "name": "Font Letter Spacing Wide",
       "path": ["font", "letter-spacing", "wide"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed."
     },
     {
       "key": "{font.paragraph-spacing.normal}",
       "value": "4px",
       "type": "dimension",
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
       "attributes": {
         "category": "font",
         "group": "paragraph-spacing",
         "type": "dimension",
         "item": "normal",
         "value": "4px",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "filePath": "src/tokens/semantic/font.json",
         "isSource": true,
         "key": "{font.paragraph-spacing.normal}",
         "name": "calcite-font-paragraph-spacing-normal",
         "path": ["font", "paragraph-spacing", "normal"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "names": {
           "scss": "$calcite-font-paragraph-spacing-normal",
           "css": "var(--calcite-font-paragraph-spacing-normal)",
@@ -29376,13 +29376,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "isSource": true,
       "name": "Font Paragraph Spacing Normal",
       "path": ["font", "paragraph-spacing", "normal"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed."
     },
     {
       "key": "{font.text-decoration.none}",
       "value": "none",
       "type": "textDecoration",
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
       "attributes": {
         "category": "font",
         "group": "text-decoration",
@@ -29390,13 +29390,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
         "type": "textDecoration",
         "item": "none",
         "value": "none",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "filePath": "src/tokens/semantic/font.json",
         "isSource": true,
         "key": "{font.text-decoration.none}",
         "name": "calcite-font-text-decoration-none",
         "path": ["font", "text-decoration", "none"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "names": {
           "scss": "$calcite-font-text-decoration-none",
           "css": "var(--calcite-font-text-decoration-none)",
@@ -29413,13 +29413,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "isSource": true,
       "name": "Font Text Decoration None",
       "path": ["font", "text-decoration", "none"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed."
     },
     {
       "key": "{font.text-decoration.underline}",
       "value": "underline",
       "type": "textDecoration",
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
       "attributes": {
         "category": "font",
         "group": "text-decoration",
@@ -29427,13 +29427,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
         "type": "textDecoration",
         "item": "underline",
         "value": "underline",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "filePath": "src/tokens/semantic/font.json",
         "isSource": true,
         "key": "{font.text-decoration.underline}",
         "name": "calcite-font-text-decoration-underline",
         "path": ["font", "text-decoration", "underline"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "names": {
           "scss": "$calcite-font-text-decoration-underline",
           "css": "var(--calcite-font-text-decoration-underline)",
@@ -29450,13 +29450,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "isSource": true,
       "name": "Font Text Decoration Underline",
       "path": ["font", "text-decoration", "underline"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed."
     },
     {
       "key": "{font.text-case.none}",
       "value": "none",
       "type": "textCase",
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
       "attributes": {
         "category": "font",
         "group": "text-case",
@@ -29464,13 +29464,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
         "type": "textCase",
         "item": "none",
         "value": "none",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "filePath": "src/tokens/semantic/font.json",
         "isSource": true,
         "key": "{font.text-case.none}",
         "name": "calcite-font-text-case-none",
         "path": ["font", "text-case", "none"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "names": {
           "scss": "$calcite-font-text-case-none",
           "css": "var(--calcite-font-text-case-none)",
@@ -29487,13 +29487,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "isSource": true,
       "name": "Font Text Case None",
       "path": ["font", "text-case", "none"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed."
     },
     {
       "key": "{font.text-case.uppercase}",
       "value": "uppercase",
       "type": "textCase",
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
       "attributes": {
         "category": "font",
         "group": "text-case",
@@ -29501,13 +29501,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
         "type": "textCase",
         "item": "uppercase",
         "value": "uppercase",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "filePath": "src/tokens/semantic/font.json",
         "isSource": true,
         "key": "{font.text-case.uppercase}",
         "name": "calcite-font-text-case-uppercase",
         "path": ["font", "text-case", "uppercase"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "names": {
           "scss": "$calcite-font-text-case-uppercase",
           "css": "var(--calcite-font-text-case-uppercase)",
@@ -29524,13 +29524,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "isSource": true,
       "name": "Font Text Case Uppercase",
       "path": ["font", "text-case", "uppercase"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed."
     },
     {
       "key": "{font.text-case.lowercase}",
       "value": "lowercase",
       "type": "textCase",
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
       "attributes": {
         "category": "font",
         "group": "text-case",
@@ -29538,13 +29538,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
         "type": "textCase",
         "item": "lowercase",
         "value": "lowercase",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "filePath": "src/tokens/semantic/font.json",
         "isSource": true,
         "key": "{font.text-case.lowercase}",
         "name": "calcite-font-text-case-lowercase",
         "path": ["font", "text-case", "lowercase"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "names": {
           "scss": "$calcite-font-text-case-lowercase",
           "css": "var(--calcite-font-text-case-lowercase)",
@@ -29561,13 +29561,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "isSource": true,
       "name": "Font Text Case Lowercase",
       "path": ["font", "text-case", "lowercase"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed."
     },
     {
       "key": "{font.text-case.capitalize}",
       "value": "capitalize",
       "type": "textCase",
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
       "attributes": {
         "category": "font",
         "group": "text-case",
@@ -29575,13 +29575,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
         "type": "textCase",
         "item": "capitalize",
         "value": "capitalize",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "filePath": "src/tokens/semantic/font.json",
         "isSource": true,
         "key": "{font.text-case.capitalize}",
         "name": "calcite-font-text-case-capitalize",
         "path": ["font", "text-case", "capitalize"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "names": {
           "scss": "$calcite-font-text-case-capitalize",
           "css": "var(--calcite-font-text-case-capitalize)",
@@ -29598,7 +29598,7 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
       "isSource": true,
       "name": "Font Text Case Capitalize",
       "path": ["font", "text-case", "capitalize"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed."
     },
     {
       "key": "{opacity.disabled}",
@@ -29802,13 +29802,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
         "type": "dimension",
         "item": "xxxs",
         "value": "2px",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
         "key": "{size.fixed.xxxs}",
         "name": "calcite-size-fixed-xxxs",
         "path": ["size", "fixed", "xxxs"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "names": {
           "scss": "$calcite-size-fixed-xxxs",
           "css": "var(--calcite-size-fixed-xxxs)",
@@ -29821,12 +29821,12 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Fixed Xxxs",
       "path": ["size", "fixed", "xxxs"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed."
     },
     {
       "key": "{size.fixed.xxs}",
@@ -29838,13 +29838,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
         "type": "dimension",
         "item": "xxs",
         "value": "4px",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
         "key": "{size.fixed.xxs}",
         "name": "calcite-size-fixed-xxs",
         "path": ["size", "fixed", "xxs"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "names": {
           "scss": "$calcite-size-fixed-xxs",
           "css": "var(--calcite-size-fixed-xxs)",
@@ -29857,12 +29857,12 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Fixed Xxs",
       "path": ["size", "fixed", "xxs"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed."
     },
     {
       "key": "{size.fixed.xs}",
@@ -29874,13 +29874,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
         "type": "dimension",
         "item": "xs",
         "value": "6px",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
         "key": "{size.fixed.xs}",
         "name": "calcite-size-fixed-xs",
         "path": ["size", "fixed", "xs"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "names": {
           "scss": "$calcite-size-fixed-xs",
           "css": "var(--calcite-size-fixed-xs)",
@@ -29893,12 +29893,12 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Fixed Xs",
       "path": ["size", "fixed", "xs"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed."
     },
     {
       "key": "{size.fixed.sm}",
@@ -29910,13 +29910,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
         "type": "dimension",
         "item": "sm",
         "value": "8px",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
         "key": "{size.fixed.sm}",
         "name": "calcite-size-fixed-sm",
         "path": ["size", "fixed", "sm"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "names": {
           "scss": "$calcite-size-fixed-sm",
           "css": "var(--calcite-size-fixed-sm)",
@@ -29929,12 +29929,12 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Fixed Sm",
       "path": ["size", "fixed", "sm"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed."
     },
     {
       "key": "{size.fixed.sm+}",
@@ -29946,13 +29946,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
         "type": "dimension",
         "item": "sm+",
         "value": "10px",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-4xs\` instead.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-4xs\` instead.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
         "key": "{size.fixed.sm+}",
         "name": "calcite-size-fixed-sm",
         "path": ["size", "fixed", "sm+"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-4xs\` instead.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-4xs\` instead.",
         "names": {
           "scss": "$calcite-size-fixed-sm-plus",
           "css": "var(--calcite-size-fixed-sm-plus)",
@@ -29965,12 +29965,12 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-4xs\` instead.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-4xs\` instead.",
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Fixed Sm Plus",
       "path": ["size", "fixed", "sm+"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-4xs\` instead."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-4xs\` instead."
     },
     {
       "key": "{size.fixed.md}",
@@ -29982,13 +29982,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
         "type": "dimension",
         "item": "md",
         "value": "12px",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-3xs\` instead.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-3xs\` instead.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
         "key": "{size.fixed.md}",
         "name": "calcite-size-fixed-md",
         "path": ["size", "fixed", "md"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-3xs\` instead.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-3xs\` instead.",
         "names": {
           "scss": "$calcite-size-fixed-md",
           "css": "var(--calcite-size-fixed-md)",
@@ -30001,12 +30001,12 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-3xs\` instead.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-3xs\` instead.",
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Fixed Md",
       "path": ["size", "fixed", "md"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-3xs\` instead."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-3xs\` instead."
     },
     {
       "key": "{size.fixed.md+}",
@@ -30018,13 +30018,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
         "type": "dimension",
         "item": "md+",
         "value": "14px",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-2xs\` instead.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-2xs\` instead.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
         "key": "{size.fixed.md+}",
         "name": "calcite-size-fixed-md",
         "path": ["size", "fixed", "md+"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-2xs\` instead.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-2xs\` instead.",
         "names": {
           "scss": "$calcite-size-fixed-md-plus",
           "css": "var(--calcite-size-fixed-md-plus)",
@@ -30037,12 +30037,12 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-2xs\` instead.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-2xs\` instead.",
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Fixed Md Plus",
       "path": ["size", "fixed", "md+"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-2xs\` instead."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-2xs\` instead."
     },
     {
       "key": "{size.fixed.lg}",
@@ -30054,13 +30054,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
         "type": "dimension",
         "item": "lg",
         "value": "16px",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-xs\` instead.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-xs\` instead.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
         "key": "{size.fixed.lg}",
         "name": "calcite-size-fixed-lg",
         "path": ["size", "fixed", "lg"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-xs\` instead.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-xs\` instead.",
         "names": {
           "scss": "$calcite-size-fixed-lg",
           "css": "var(--calcite-size-fixed-lg)",
@@ -30073,12 +30073,12 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-xs\` instead.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-xs\` instead.",
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Fixed Lg",
       "path": ["size", "fixed", "lg"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-xs\` instead."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-xs\` instead."
     },
     {
       "key": "{size.fixed.xl}",
@@ -30090,13 +30090,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
         "type": "dimension",
         "item": "xl",
         "value": "20px",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
         "key": "{size.fixed.xl}",
         "name": "calcite-size-fixed-xl",
         "path": ["size", "fixed", "xl"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
         "names": {
           "scss": "$calcite-size-fixed-xl",
           "css": "var(--calcite-size-fixed-xl)",
@@ -30109,12 +30109,12 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.",
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Fixed Xl",
       "path": ["size", "fixed", "xl"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - No longer needed."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - No longer needed."
     },
     {
       "key": "{size.fixed.xxl}",
@@ -30126,13 +30126,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
         "type": "dimension",
         "item": "xxl",
         "value": "24px",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-sm\` instead.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-sm\` instead.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
         "key": "{size.fixed.xxl}",
         "name": "calcite-size-fixed-xxl",
         "path": ["size", "fixed", "xxl"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-sm\` instead.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-sm\` instead.",
         "names": {
           "scss": "$calcite-size-fixed-xxl",
           "css": "var(--calcite-size-fixed-xxl)",
@@ -30145,12 +30145,12 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-sm\` instead.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-sm\` instead.",
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Fixed Xxl",
       "path": ["size", "fixed", "xxl"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-sm\` instead."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-sm\` instead."
     },
     {
       "key": "{size.fixed.xxxl}",
@@ -30162,13 +30162,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
         "type": "dimension",
         "item": "xxxl",
         "value": "32px",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-md\` instead.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-md\` instead.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
         "key": "{size.fixed.xxxl}",
         "name": "calcite-size-fixed-xxxl",
         "path": ["size", "fixed", "xxxl"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-md\` instead.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-md\` instead.",
         "names": {
           "scss": "$calcite-size-fixed-xxxl",
           "css": "var(--calcite-size-fixed-xxxl)",
@@ -30181,12 +30181,12 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-md\` instead.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-md\` instead.",
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Fixed Xxxl",
       "path": ["size", "fixed", "xxxl"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-md\` instead."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-md\` instead."
     },
     {
       "key": "{size.px}",
@@ -30245,13 +30245,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
         "docs": "deprecated",
         "type": "dimension",
         "value": "12px",
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-3xs\` instead.",
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-3xs\` instead.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
         "key": "{size.xxxs}",
         "name": "calcite-size-xxxs",
         "path": ["size", "xxxs"],
-        "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-3xs\` instead.",
+        "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-3xs\` instead.",
         "names": {
           "scss": "$calcite-size-xxxs",
           "css": "var(--calcite-size-xxxs)",
@@ -30264,12 +30264,12 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-3xs\` instead.",
+      "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-3xs\` instead.",
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Xxxs",
       "path": ["size", "xxxs"],
-      "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-3xs\` instead."
+      "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-3xs\` instead."
     },
     {
       "key": "{size.3xs}",
@@ -30304,13 +30304,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
         "docs": "deprecated",
         "type": "dimension",
         "value": "14px",
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-2xs\` instead.",
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-2xs\` instead.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
         "key": "{size.xxs}",
         "name": "calcite-size-xxs",
         "path": ["size", "xxs"],
-        "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-2xs\` instead.",
+        "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-2xs\` instead.",
         "names": {
           "scss": "$calcite-size-xxs",
           "css": "var(--calcite-size-xxs)",
@@ -30323,12 +30323,12 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-2xs\` instead.",
+      "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-2xs\` instead.",
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Xxs",
       "path": ["size", "xxs"],
-      "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-2xs\` instead."
+      "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-2xs\` instead."
     },
     {
       "key": "{size.2xs}",
@@ -30483,13 +30483,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
         "docs": "deprecated",
         "type": "dimension",
         "value": "64px",
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-2xl\` instead.",
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-2xl\` instead.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
         "key": "{size.xxl}",
         "name": "calcite-size-xxl",
         "path": ["size", "xxl"],
-        "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-2xl\` instead.",
+        "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-2xl\` instead.",
         "names": {
           "scss": "$calcite-size-xxl",
           "css": "var(--calcite-size-xxl)",
@@ -30502,12 +30502,12 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-2xl\` instead.",
+      "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-2xl\` instead.",
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Xxl",
       "path": ["size", "xxl"],
-      "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-2xl\` instead."
+      "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-2xl\` instead."
     },
     {
       "key": "{size.2xl}",
@@ -30542,13 +30542,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
         "docs": "deprecated",
         "type": "dimension",
         "value": "96px",
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-3xl\` instead.",
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-3xl\` instead.",
         "filePath": "src/tokens/semantic/size.json",
         "isSource": true,
         "key": "{size.xxxl}",
         "name": "calcite-size-xxxl",
         "path": ["size", "xxxl"],
-        "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-3xl\` instead.",
+        "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-3xl\` instead.",
         "names": {
           "scss": "$calcite-size-xxxl",
           "css": "var(--calcite-size-xxxl)",
@@ -30561,12 +30561,12 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-3xl\` instead.",
+      "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-3xl\` instead.",
       "filePath": "src/tokens/semantic/size.json",
       "isSource": true,
       "name": "Size Xxxl",
       "path": ["size", "xxxl"],
-      "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-3xl\` instead."
+      "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-3xl\` instead."
     },
     {
       "key": "{size.3xl}",
@@ -30602,13 +30602,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
         "type": "dimension",
         "item": "xxs",
         "value": "4px",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-2xs\` instead.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-2xs\` instead.",
         "filePath": "src/tokens/semantic/space.json",
         "isSource": true,
         "key": "{spacing.fixed.xxs}",
         "name": "calcite-spacing-fixed-xxs",
         "path": ["spacing", "fixed", "xxs"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-2xs\` instead.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-2xs\` instead.",
         "names": {
           "scss": "$calcite-spacing-fixed-xxs",
           "css": "var(--calcite-spacing-fixed-xxs)",
@@ -30621,12 +30621,12 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-2xs\` instead.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-2xs\` instead.",
       "filePath": "src/tokens/semantic/space.json",
       "isSource": true,
       "name": "Spacing Fixed Xxs",
       "path": ["spacing", "fixed", "xxs"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-2xs\` instead."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-2xs\` instead."
     },
     {
       "key": "{spacing.fixed.xs}",
@@ -30638,13 +30638,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
         "type": "dimension",
         "item": "xs",
         "value": "6px",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-xs\` instead.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-xs\` instead.",
         "filePath": "src/tokens/semantic/space.json",
         "isSource": true,
         "key": "{spacing.fixed.xs}",
         "name": "calcite-spacing-fixed-xs",
         "path": ["spacing", "fixed", "xs"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-xs\` instead.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-xs\` instead.",
         "names": {
           "scss": "$calcite-spacing-fixed-xs",
           "css": "var(--calcite-spacing-fixed-xs)",
@@ -30657,12 +30657,12 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-xs\` instead.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-xs\` instead.",
       "filePath": "src/tokens/semantic/space.json",
       "isSource": true,
       "name": "Spacing Fixed Xs",
       "path": ["spacing", "fixed", "xs"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-xs\` instead."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-xs\` instead."
     },
     {
       "key": "{spacing.fixed.sm}",
@@ -30674,13 +30674,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
         "type": "dimension",
         "item": "sm",
         "value": "8px",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-sm\` instead.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-sm\` instead.",
         "filePath": "src/tokens/semantic/space.json",
         "isSource": true,
         "key": "{spacing.fixed.sm}",
         "name": "calcite-spacing-fixed-sm",
         "path": ["spacing", "fixed", "sm"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-sm\` instead.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-sm\` instead.",
         "names": {
           "scss": "$calcite-spacing-fixed-sm",
           "css": "var(--calcite-spacing-fixed-sm)",
@@ -30693,12 +30693,12 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-sm\` instead.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-sm\` instead.",
       "filePath": "src/tokens/semantic/space.json",
       "isSource": true,
       "name": "Spacing Fixed Sm",
       "path": ["spacing", "fixed", "sm"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-sm\` instead."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-sm\` instead."
     },
     {
       "key": "{spacing.fixed.md}",
@@ -30710,13 +30710,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
         "type": "dimension",
         "item": "md",
         "value": "12px",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-md\` instead.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-md\` instead.",
         "filePath": "src/tokens/semantic/space.json",
         "isSource": true,
         "key": "{spacing.fixed.md}",
         "name": "calcite-spacing-fixed-md",
         "path": ["spacing", "fixed", "md"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-md\` instead.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-md\` instead.",
         "names": {
           "scss": "$calcite-spacing-fixed-md",
           "css": "var(--calcite-spacing-fixed-md)",
@@ -30729,12 +30729,12 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-md\` instead.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-md\` instead.",
       "filePath": "src/tokens/semantic/space.json",
       "isSource": true,
       "name": "Spacing Fixed Md",
       "path": ["spacing", "fixed", "md"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-md\` instead."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-md\` instead."
     },
     {
       "key": "{spacing.fixed.lg}",
@@ -30746,13 +30746,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
         "type": "dimension",
         "item": "lg",
         "value": "14px",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-md-plus\` instead.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-md-plus\` instead.",
         "filePath": "src/tokens/semantic/space.json",
         "isSource": true,
         "key": "{spacing.fixed.lg}",
         "name": "calcite-spacing-fixed-lg",
         "path": ["spacing", "fixed", "lg"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-md-plus\` instead.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-md-plus\` instead.",
         "names": {
           "scss": "$calcite-spacing-fixed-lg",
           "css": "var(--calcite-spacing-fixed-lg)",
@@ -30765,12 +30765,12 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-md-plus\` instead.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-md-plus\` instead.",
       "filePath": "src/tokens/semantic/space.json",
       "isSource": true,
       "name": "Spacing Fixed Lg",
       "path": ["spacing", "fixed", "lg"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-md-plus\` instead."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-md-plus\` instead."
     },
     {
       "key": "{spacing.fixed.xl}",
@@ -30782,13 +30782,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
         "type": "dimension",
         "item": "xl",
         "value": "16px",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-lg\` instead.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-lg\` instead.",
         "filePath": "src/tokens/semantic/space.json",
         "isSource": true,
         "key": "{spacing.fixed.xl}",
         "name": "calcite-spacing-fixed-xl",
         "path": ["spacing", "fixed", "xl"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-lg\` instead.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-lg\` instead.",
         "names": {
           "scss": "$calcite-spacing-fixed-xl",
           "css": "var(--calcite-spacing-fixed-xl)",
@@ -30801,12 +30801,12 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-lg\` instead.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-lg\` instead.",
       "filePath": "src/tokens/semantic/space.json",
       "isSource": true,
       "name": "Spacing Fixed Xl",
       "path": ["spacing", "fixed", "xl"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-lg\` instead."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-lg\` instead."
     },
     {
       "key": "{spacing.fixed.xxl}",
@@ -30818,13 +30818,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
         "type": "dimension",
         "item": "xxl",
         "value": "20px",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-xl\` instead.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-xl\` instead.",
         "filePath": "src/tokens/semantic/space.json",
         "isSource": true,
         "key": "{spacing.fixed.xxl}",
         "name": "calcite-spacing-fixed-xxl",
         "path": ["spacing", "fixed", "xxl"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-xl\` instead.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-xl\` instead.",
         "names": {
           "scss": "$calcite-spacing-fixed-xxl",
           "css": "var(--calcite-spacing-fixed-xxl)",
@@ -30837,12 +30837,12 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-xl\` instead.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-xl\` instead.",
       "filePath": "src/tokens/semantic/space.json",
       "isSource": true,
       "name": "Spacing Fixed Xxl",
       "path": ["spacing", "fixed", "xxl"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-xl\` instead."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-xl\` instead."
     },
     {
       "key": "{spacing.fixed.xxxl}",
@@ -30854,13 +30854,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
         "type": "dimension",
         "item": "xxxl",
         "value": "32px",
-        "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-3xl\` instead.",
+        "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-3xl\` instead.",
         "filePath": "src/tokens/semantic/space.json",
         "isSource": true,
         "key": "{spacing.fixed.xxxl}",
         "name": "calcite-spacing-fixed-xxxl",
         "path": ["spacing", "fixed", "xxxl"],
-        "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-3xl\` instead.",
+        "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-3xl\` instead.",
         "names": {
           "scss": "$calcite-spacing-fixed-xxxl",
           "css": "var(--calcite-spacing-fixed-xxxl)",
@@ -30873,12 +30873,12 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-3xl\` instead.",
+      "description": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-3xl\` instead.",
       "filePath": "src/tokens/semantic/space.json",
       "isSource": true,
       "name": "Spacing Fixed Xxxl",
       "path": ["spacing", "fixed", "xxxl"],
-      "comment": "Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-3xl\` instead."
+      "comment": "Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-3xl\` instead."
     },
     {
       "key": "{spacing.default.none}",
@@ -30890,13 +30890,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
         "type": "dimension",
         "item": "none",
         "value": "0",
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-none\` instead.",
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-none\` instead.",
         "filePath": "src/tokens/semantic/space.json",
         "isSource": true,
         "key": "{spacing.default.none}",
         "name": "calcite-spacing-default-none",
         "path": ["spacing", "default", "none"],
-        "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-none\` instead.",
+        "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-none\` instead.",
         "names": {
           "scss": "$calcite-spacing-none",
           "css": "var(--calcite-spacing-none)",
@@ -30909,12 +30909,12 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-none\` instead.",
+      "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-none\` instead.",
       "filePath": "src/tokens/semantic/space.json",
       "isSource": true,
       "name": "Spacing None",
       "path": ["spacing", "default", "none"],
-      "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-none\` instead."
+      "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-none\` instead."
     },
     {
       "key": "{spacing.default.px}",
@@ -30926,13 +30926,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
         "type": "dimension",
         "item": "px",
         "value": "1px",
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-px\` instead.",
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-px\` instead.",
         "filePath": "src/tokens/semantic/space.json",
         "isSource": true,
         "key": "{spacing.default.px}",
         "name": "calcite-spacing-default-px",
         "path": ["spacing", "default", "px"],
-        "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-px\` instead.",
+        "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-px\` instead.",
         "names": {
           "scss": "$calcite-spacing-px",
           "css": "var(--calcite-spacing-px)",
@@ -30945,12 +30945,12 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-px\` instead.",
+      "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-px\` instead.",
       "filePath": "src/tokens/semantic/space.json",
       "isSource": true,
       "name": "Spacing Px",
       "path": ["spacing", "default", "px"],
-      "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-px\` instead."
+      "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-px\` instead."
     },
     {
       "key": "{spacing.default.base}",
@@ -30962,13 +30962,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
         "type": "dimension",
         "item": "base",
         "value": "2px",
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-base\` instead.",
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-base\` instead.",
         "filePath": "src/tokens/semantic/space.json",
         "isSource": true,
         "key": "{spacing.default.base}",
         "name": "calcite-spacing-default-base",
         "path": ["spacing", "default", "base"],
-        "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-base\` instead.",
+        "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-base\` instead.",
         "names": {
           "scss": "$calcite-spacing-base",
           "css": "var(--calcite-spacing-base)",
@@ -30981,12 +30981,12 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-base\` instead.",
+      "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-base\` instead.",
       "filePath": "src/tokens/semantic/space.json",
       "isSource": true,
       "name": "Spacing Base",
       "path": ["spacing", "default", "base"],
-      "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-base\` instead."
+      "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-base\` instead."
     },
     {
       "key": "{spacing.default.xxs}",
@@ -30998,13 +30998,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
         "type": "dimension",
         "item": "xxs",
         "value": "4px",
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-2xs\` instead.",
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-2xs\` instead.",
         "filePath": "src/tokens/semantic/space.json",
         "isSource": true,
         "key": "{spacing.default.xxs}",
         "name": "calcite-spacing-default-xxs",
         "path": ["spacing", "default", "xxs"],
-        "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-2xs\` instead.",
+        "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-2xs\` instead.",
         "names": {
           "scss": "$calcite-spacing-xxs",
           "css": "var(--calcite-spacing-xxs)",
@@ -31017,12 +31017,12 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-2xs\` instead.",
+      "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-2xs\` instead.",
       "filePath": "src/tokens/semantic/space.json",
       "isSource": true,
       "name": "Spacing Xxs",
       "path": ["spacing", "default", "xxs"],
-      "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-2xs\` instead."
+      "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-2xs\` instead."
     },
     {
       "key": "{spacing.default.xs}",
@@ -31034,13 +31034,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
         "type": "dimension",
         "item": "xs",
         "value": "6px",
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-xs\` instead.",
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-xs\` instead.",
         "filePath": "src/tokens/semantic/space.json",
         "isSource": true,
         "key": "{spacing.default.xs}",
         "name": "calcite-spacing-default-xs",
         "path": ["spacing", "default", "xs"],
-        "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-xs\` instead.",
+        "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-xs\` instead.",
         "names": {
           "scss": "$calcite-spacing-xs",
           "css": "var(--calcite-spacing-xs)",
@@ -31053,12 +31053,12 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-xs\` instead.",
+      "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-xs\` instead.",
       "filePath": "src/tokens/semantic/space.json",
       "isSource": true,
       "name": "Spacing Xs",
       "path": ["spacing", "default", "xs"],
-      "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-xs\` instead."
+      "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-xs\` instead."
     },
     {
       "key": "{spacing.default.sm}",
@@ -31070,13 +31070,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
         "type": "dimension",
         "item": "sm",
         "value": "8px",
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-sm\` instead.",
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-sm\` instead.",
         "filePath": "src/tokens/semantic/space.json",
         "isSource": true,
         "key": "{spacing.default.sm}",
         "name": "calcite-spacing-default-sm",
         "path": ["spacing", "default", "sm"],
-        "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-sm\` instead.",
+        "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-sm\` instead.",
         "names": {
           "scss": "$calcite-spacing-sm",
           "css": "var(--calcite-spacing-sm)",
@@ -31089,12 +31089,12 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-sm\` instead.",
+      "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-sm\` instead.",
       "filePath": "src/tokens/semantic/space.json",
       "isSource": true,
       "name": "Spacing Sm",
       "path": ["spacing", "default", "sm"],
-      "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-sm\` instead."
+      "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-sm\` instead."
     },
     {
       "key": "{spacing.default.sm+}",
@@ -31106,13 +31106,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
         "type": "dimension",
         "item": "sm+",
         "value": "10px",
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-sm-plus\` instead.",
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-sm-plus\` instead.",
         "filePath": "src/tokens/semantic/space.json",
         "isSource": true,
         "key": "{spacing.default.sm+}",
         "name": "calcite-spacing-default-sm",
         "path": ["spacing", "default", "sm+"],
-        "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-sm-plus\` instead.",
+        "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-sm-plus\` instead.",
         "names": {
           "scss": "$calcite-spacing-sm-plus",
           "css": "var(--calcite-spacing-sm-plus)",
@@ -31125,12 +31125,12 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-sm-plus\` instead.",
+      "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-sm-plus\` instead.",
       "filePath": "src/tokens/semantic/space.json",
       "isSource": true,
       "name": "Spacing Sm Plus",
       "path": ["spacing", "default", "sm+"],
-      "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-sm-plus\` instead."
+      "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-sm-plus\` instead."
     },
     {
       "key": "{spacing.default.md}",
@@ -31142,13 +31142,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
         "type": "dimension",
         "item": "md",
         "value": "12px",
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-md\` instead.",
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-md\` instead.",
         "filePath": "src/tokens/semantic/space.json",
         "isSource": true,
         "key": "{spacing.default.md}",
         "name": "calcite-spacing-default-md",
         "path": ["spacing", "default", "md"],
-        "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-md\` instead.",
+        "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-md\` instead.",
         "names": {
           "scss": "$calcite-spacing-md",
           "css": "var(--calcite-spacing-md)",
@@ -31161,12 +31161,12 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-md\` instead.",
+      "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-md\` instead.",
       "filePath": "src/tokens/semantic/space.json",
       "isSource": true,
       "name": "Spacing Md",
       "path": ["spacing", "default", "md"],
-      "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-md\` instead."
+      "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-md\` instead."
     },
     {
       "key": "{spacing.default.md+}",
@@ -31178,13 +31178,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
         "type": "dimension",
         "item": "md+",
         "value": "14px",
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-md-plus\` instead.",
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-md-plus\` instead.",
         "filePath": "src/tokens/semantic/space.json",
         "isSource": true,
         "key": "{spacing.default.md+}",
         "name": "calcite-spacing-default-md",
         "path": ["spacing", "default", "md+"],
-        "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-md-plus\` instead.",
+        "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-md-plus\` instead.",
         "names": {
           "scss": "$calcite-spacing-md-plus",
           "css": "var(--calcite-spacing-md-plus)",
@@ -31197,12 +31197,12 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-md-plus\` instead.",
+      "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-md-plus\` instead.",
       "filePath": "src/tokens/semantic/space.json",
       "isSource": true,
       "name": "Spacing Md Plus",
       "path": ["spacing", "default", "md+"],
-      "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-md-plus\` instead."
+      "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-md-plus\` instead."
     },
     {
       "key": "{spacing.default.lg}",
@@ -31214,13 +31214,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
         "type": "dimension",
         "item": "lg",
         "value": "16px",
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-lg\` instead.",
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-lg\` instead.",
         "filePath": "src/tokens/semantic/space.json",
         "isSource": true,
         "key": "{spacing.default.lg}",
         "name": "calcite-spacing-default-lg",
         "path": ["spacing", "default", "lg"],
-        "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-lg\` instead.",
+        "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-lg\` instead.",
         "names": {
           "scss": "$calcite-spacing-lg",
           "css": "var(--calcite-spacing-lg)",
@@ -31233,12 +31233,12 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-lg\` instead.",
+      "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-lg\` instead.",
       "filePath": "src/tokens/semantic/space.json",
       "isSource": true,
       "name": "Spacing Lg",
       "path": ["spacing", "default", "lg"],
-      "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-lg\` instead."
+      "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-lg\` instead."
     },
     {
       "key": "{spacing.default.xl}",
@@ -31250,13 +31250,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
         "type": "dimension",
         "item": "xl",
         "value": "20px",
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-xl\` instead.",
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-xl\` instead.",
         "filePath": "src/tokens/semantic/space.json",
         "isSource": true,
         "key": "{spacing.default.xl}",
         "name": "calcite-spacing-default-xl",
         "path": ["spacing", "default", "xl"],
-        "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-xl\` instead.",
+        "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-xl\` instead.",
         "names": {
           "scss": "$calcite-spacing-xl",
           "css": "var(--calcite-spacing-xl)",
@@ -31269,12 +31269,12 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-xl\` instead.",
+      "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-xl\` instead.",
       "filePath": "src/tokens/semantic/space.json",
       "isSource": true,
       "name": "Spacing Xl",
       "path": ["spacing", "default", "xl"],
-      "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-xl\` instead."
+      "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-xl\` instead."
     },
     {
       "key": "{spacing.default.xxl}",
@@ -31286,13 +31286,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
         "type": "dimension",
         "item": "xxl",
         "value": "24px",
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-2xl\` instead.",
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-2xl\` instead.",
         "filePath": "src/tokens/semantic/space.json",
         "isSource": true,
         "key": "{spacing.default.xxl}",
         "name": "calcite-spacing-default-xxl",
         "path": ["spacing", "default", "xxl"],
-        "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-2xl\` instead.",
+        "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-2xl\` instead.",
         "names": {
           "scss": "$calcite-spacing-xxl",
           "css": "var(--calcite-spacing-xxl)",
@@ -31305,12 +31305,12 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-2xl\` instead.",
+      "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-2xl\` instead.",
       "filePath": "src/tokens/semantic/space.json",
       "isSource": true,
       "name": "Spacing Xxl",
       "path": ["spacing", "default", "xxl"],
-      "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-2xl\` instead."
+      "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-2xl\` instead."
     },
     {
       "key": "{spacing.default.xxxl}",
@@ -31322,13 +31322,13 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
         "type": "dimension",
         "item": "xxxl",
         "value": "32px",
-        "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-3xl\` instead.",
+        "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-3xl\` instead.",
         "filePath": "src/tokens/semantic/space.json",
         "isSource": true,
         "key": "{spacing.default.xxxl}",
         "name": "calcite-spacing-default-xxxl",
         "path": ["spacing", "default", "xxxl"],
-        "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-3xl\` instead.",
+        "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-3xl\` instead.",
         "names": {
           "scss": "$calcite-spacing-xxxl",
           "css": "var(--calcite-spacing-xxxl)",
@@ -31341,12 +31341,12 @@ exports[`generated tokens > DOCS (internal) > semantic should match 1`] = `
           "type": "dimension"
         }
       },
-      "description": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-3xl\` instead.",
+      "description": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-3xl\` instead.",
       "filePath": "src/tokens/semantic/space.json",
       "isSource": true,
       "name": "Spacing Xxxl",
       "path": ["spacing", "default", "xxxl"],
-      "comment": "Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-3xl\` instead."
+      "comment": "Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-3xl\` instead."
     },
     {
       "key": "{space.none}",
@@ -31935,14 +31935,14 @@ exports[`generated tokens > ES6 > breakpoints should match 1`] = `
  * Do not edit directly, this file was auto-generated.
  */
 
-export const calciteContainerSizeHeightXxs = { min: "0", max: "154px" }; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-container-size-height-2xs-min|max\` instead.
+export const calciteContainerSizeHeightXxs = { min: "0", max: "154px" }; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-container-size-height-2xs-min|max\` instead.
 export const calciteContainerSizeHeight2xs = { min: "0", max: "154px" }; // Small handheld devices and mini-windows
 export const calciteContainerSizeHeightXs = { min: "155px", max: "328px" }; // Handheld devices
 export const calciteContainerSizeHeightSm = { min: "329px", max: "504px" }; // Small tablets
 export const calciteContainerSizeHeightMd = { min: "505px", max: "678px" }; // Small laptops
 export const calciteContainerSizeHeightLg = { min: "679px", max: "854px" }; // Large laptops and desktop computers
 export const calciteContainerSizeHeightXl = { min: "855px" }; // Projectors and televisions
-export const calciteContainerSizeWidthXxs = { min: "0", max: "320px" }; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-container-size-width-2xs-min|max\` instead.
+export const calciteContainerSizeWidthXxs = { min: "0", max: "320px" }; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-container-size-width-2xs-min|max\` instead.
 export const calciteContainerSizeWidth2xs = { min: "0", max: "320px" }; // Small handheld devices and mini-windows
 export const calciteContainerSizeWidthXs = { min: "321px", max: "476px" }; // Handheld devices
 export const calciteContainerSizeWidthSm = { min: "477px", max: "768px" }; // Small tablets
@@ -31958,7 +31958,7 @@ exports[`generated tokens > ES6 > breakpoints types should match 1`] = `
  * Do not edit directly, this file was auto-generated.
  */
 
-/** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-container-size-height-2xs-min|max\` instead. */
+/** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-container-size-height-2xs-min|max\` instead. */
 export const calciteContainerSizeHeightXxs: { min: string; max: string };
 /** Small handheld devices and mini-windows */
 export const calciteContainerSizeHeight2xs: { min: string; max: string };
@@ -31972,7 +31972,7 @@ export const calciteContainerSizeHeightMd: { min: string; max: string };
 export const calciteContainerSizeHeightLg: { min: string; max: string };
 /** Projectors and televisions */
 export const calciteContainerSizeHeightXl: { min: string };
-/** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-container-size-width-2xs-min|max\` instead. */
+/** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-container-size-width-2xs-min|max\` instead. */
 export const calciteContainerSizeWidthXxs: { min: string; max: string };
 /** Small handheld devices and mini-windows */
 export const calciteContainerSizeWidth2xs: { min: string; max: string };
@@ -32152,7 +32152,7 @@ export const calciteColorLowSaturationVioletLVv070 = "#6f6783";
 export const calciteColorLowSaturationVioletLVv080 = "#504b60";
 export const calciteColorLowSaturationVioletLVv090 = "#322e3d";
 export const calciteColorLowSaturationVioletLVv100 = "#13111a";
-export const calciteColorLowSaturationVioletLVv1000 = "#13111a"; // Deprecated in v3.3.0, removal target v6.0.0 - Use \`--calcite-color-low-saturation-violet-l-vv-100\` instead.
+export const calciteColorLowSaturationVioletLVv1000 = "#13111a"; // Deprecated in v3.2.0, removal target v5.0.0 - Use \`--calcite-color-low-saturation-violet-l-vv-100\` instead.
 export const calciteColorMediumSaturationBlueMBb010 = "#dfeffa";
 export const calciteColorMediumSaturationBlueMBb020 = "#c8e3f5";
 export const calciteColorMediumSaturationBlueMBb030 = "#b1d8f1";
@@ -32493,12 +32493,12 @@ export const calciteFontWeightBold = "700";
 export const calciteFontWeightExtrabold = "800"; // only for Avenir Next World (secondary font family)
 export const calciteFontWeightBlack = "900"; // only for Avenir Next World (secondary font family)
 export const calciteFontWeightHeavy = "900";
-export const calciteFontTextDecorationNone = "none"; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-export const calciteFontTextDecorationUnderline = "underline"; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-export const calciteFontTextCaseNone = "none"; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-export const calciteFontTextCaseUppercase = "uppercase"; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-export const calciteFontTextCaseLowercase = "lowercase"; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-export const calciteFontTextCaseCapitalize = "capitalize"; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
+export const calciteFontTextDecorationNone = "none"; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+export const calciteFontTextDecorationUnderline = "underline"; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+export const calciteFontTextCaseNone = "none"; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+export const calciteFontTextCaseUppercase = "uppercase"; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+export const calciteFontTextCaseLowercase = "lowercase"; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+export const calciteFontTextCaseCapitalize = "capitalize"; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
 export const calciteOpacity0 = "0";
 export const calciteOpacity4 = "0.04";
 export const calciteOpacity8 = "0.08";
@@ -32782,7 +32782,7 @@ export const calciteColorLowSaturationVioletLVv070: string;
 export const calciteColorLowSaturationVioletLVv080: string;
 export const calciteColorLowSaturationVioletLVv090: string;
 export const calciteColorLowSaturationVioletLVv100: string;
-/** Deprecated in v3.3.0, removal target v6.0.0 - Use \`--calcite-color-low-saturation-violet-l-vv-100\` instead. */
+/** Deprecated in v3.2.0, removal target v5.0.0 - Use \`--calcite-color-low-saturation-violet-l-vv-100\` instead. */
 export const calciteColorLowSaturationVioletLVv1000: string;
 export const calciteColorMediumSaturationBlueMBb010: string;
 export const calciteColorMediumSaturationBlueMBb020: string;
@@ -33137,17 +33137,17 @@ export const calciteFontWeightExtrabold: string;
 /** only for Avenir Next World (secondary font family) */
 export const calciteFontWeightBlack: string;
 export const calciteFontWeightHeavy: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
 export const calciteFontTextDecorationNone: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
 export const calciteFontTextDecorationUnderline: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
 export const calciteFontTextCaseNone: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
 export const calciteFontTextCaseUppercase: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
 export const calciteFontTextCaseLowercase: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
 export const calciteFontTextCaseCapitalize: string;
 export const calciteOpacity0: string;
 export const calciteOpacity4: string;
@@ -33284,15 +33284,15 @@ export const calciteColorSurfaceHighlight = {
   light: "#d6efff",
   dark: "#2b465f",
 };
-export const calciteColorBackground = { light: "#f7f7f7", dark: "#212121" }; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-1\` instead.
-export const calciteColorBackgroundNone = "rgba(255, 255, 255, 0)"; // Deprecated in v5.0.0, removal target v6.0.0 - No longer needed.
-export const calciteColorForeground1 = { light: "#ffffff", dark: "#2b2b2b" }; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-2\` instead.
-export const calciteColorForeground2 = { light: "#f2f2f2", dark: "#363636" }; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-3\` instead.
-export const calciteColorForeground3 = { light: "#ebebeb", dark: "#404040" }; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-4\` instead.
+export const calciteColorBackground = { light: "#f7f7f7", dark: "#212121" }; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-1\` instead.
+export const calciteColorBackgroundNone = "rgba(255, 255, 255, 0)"; // Deprecated in v4.0.0, removal target v5.0.0 - No longer needed.
+export const calciteColorForeground1 = { light: "#ffffff", dark: "#2b2b2b" }; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-2\` instead.
+export const calciteColorForeground2 = { light: "#f2f2f2", dark: "#363636" }; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-3\` instead.
+export const calciteColorForeground3 = { light: "#ebebeb", dark: "#404040" }; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-4\` instead.
 export const calciteColorForegroundCurrent = {
   light: "#d6efff",
   dark: "#2b465f",
-}; // Deprecated in v3.3.0, removal target v6.0.0 - Use \`--calcite-color-surface-highlight\` instead.
+}; // Deprecated in v3.2.0, removal target v5.0.0 - Use \`--calcite-color-surface-highlight\` instead.
 export const calciteColorText1 = { light: "#141414", dark: "#ffffff" };
 export const calciteColorText2 = { light: "#4a4a4a", dark: "#bfbfbf" };
 export const calciteColorText3 = { light: "#6b6b6b", dark: "#9e9e9e" };
@@ -33306,8 +33306,8 @@ export const calciteColorBorderInput = { light: "#949494", dark: "#757575" };
 export const calciteColorBorderGhost = {
   light: "rgba(0, 0, 0, 0.3)",
   dark: "rgba(117, 117, 117, 0.3)",
-}; // Deprecated in v5.0.0, removal target v6.0.0 - No longer needed.
-export const calciteColorBorderWhite = { light: "#ffffff", dark: "#f7f7f7" }; // Deprecated in v5.0.0, removal target v6.0.0 - No longer needed.
+}; // Deprecated in v4.0.0, removal target v5.0.0 - No longer needed.
+export const calciteColorBorderWhite = { light: "#ffffff", dark: "#f7f7f7" }; // Deprecated in v4.0.0, removal target v5.0.0 - No longer needed.
 export const calciteColorBrand = { light: "#007ac2", dark: "#009af2" };
 export const calciteColorBrandHover = { light: "#00619b", dark: "#007ac2" };
 export const calciteColorBrandPress = { light: "#004874", dark: "#00619b" };
@@ -33387,14 +33387,14 @@ export const calciteBorderWidthNone = "0";
 export const calciteBorderWidthSm = "1px";
 export const calciteBorderWidthMd = "2px";
 export const calciteBorderWidthLg = "4px";
-export const calciteContainerSizeHeightXxs = { min: "0", max: "154px" }; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-container-size-height-2xs-min|max\` instead.
+export const calciteContainerSizeHeightXxs = { min: "0", max: "154px" }; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-container-size-height-2xs-min|max\` instead.
 export const calciteContainerSizeHeight2xs = { min: "0", max: "154px" }; // Small handheld devices and mini-windows
 export const calciteContainerSizeHeightXs = { min: "155px", max: "328px" }; // Handheld devices
 export const calciteContainerSizeHeightSm = { min: "329px", max: "504px" }; // Small tablets
 export const calciteContainerSizeHeightMd = { min: "505px", max: "678px" }; // Small laptops
 export const calciteContainerSizeHeightLg = { min: "679px", max: "854px" }; // Large laptops and desktop computers
 export const calciteContainerSizeHeightXl = { min: "855px" }; // Projectors and televisions
-export const calciteContainerSizeWidthXxs = { min: "0", max: "320px" }; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-container-size-width-2xs-min|max\` instead.
+export const calciteContainerSizeWidthXxs = { min: "0", max: "320px" }; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-container-size-width-2xs-min|max\` instead.
 export const calciteContainerSizeWidth2xs = { min: "0", max: "320px" }; // Small handheld devices and mini-windows
 export const calciteContainerSizeWidthXs = { min: "321px", max: "476px" }; // Handheld devices
 export const calciteContainerSizeWidthSm = { min: "477px", max: "768px" }; // Small tablets
@@ -33406,11 +33406,11 @@ export const calciteContainerSizeGutter = "16px";
 export const calciteContainerSizeContentFluid = "100%"; // for fluid grid widths
 export const calciteContainerSizeContentFixed = "1440px"; // only for lg breakpoint fixed grid width
 export const calciteCornerRadius = "0";
-export const calciteCornerRadiusSharp = "0"; // Deprecated in v3.2.0, removal target v6.0.0 - Use \`--calcite-corner-radius-none\` instead.
+export const calciteCornerRadiusSharp = "0"; // Deprecated in v3.1.0, removal target v5.0.0 - Use \`--calcite-corner-radius-none\` instead.
 export const calciteCornerRadiusNone = "0";
 export const calciteCornerRadiusXs = "2px";
 export const calciteCornerRadiusSm = "4px";
-export const calciteCornerRadiusRound = "4px"; // Deprecated in v3.2.0, removal target v6.0.0 - Use \`--calcite-corner-radius-sm\` instead.
+export const calciteCornerRadiusRound = "4px"; // Deprecated in v3.1.0, removal target v5.0.0 - Use \`--calcite-corner-radius-sm\` instead.
 export const calciteCornerRadiusPill = "9999px";
 export const calciteFontFamily = [
   "Avenir Next",
@@ -33426,7 +33426,7 @@ export const calciteFontFamilyCode = [
   "monospace",
 ]; // Font family for code with fallbacks
 export const calciteFontWeightLight = "300"; // For Avenir Next World (secondary font family)
-export const calciteFontWeightNormal = "400"; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-font-weight-regular\` instead.
+export const calciteFontWeightNormal = "400"; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-font-weight-regular\` instead.
 export const calciteFontWeightRegular = "400";
 export const calciteFontWeightMedium = "500";
 export const calciteFontWeightSemibold = "600";
@@ -33437,7 +33437,7 @@ export const calciteFontSize = "14px";
 export const calciteFontSizeMd = "16px";
 export const calciteFontSizeLg = "18px";
 export const calciteFontSizeXl = "20px";
-export const calciteFontSizeXxl = "24px"; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-font-size-2xl\` instead.
+export const calciteFontSizeXxl = "24px"; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-font-size-2xl\` instead.
 export const calciteFontSize2xl = "24px";
 export const calciteFontSizeRelativeXs = "0.625rem";
 export const calciteFontSizeRelativeSm = "0.75rem";
@@ -33480,16 +33480,16 @@ export const calciteFontLineHeight4xl = "3rem";
 export const calciteFontLineHeight5xl = "4rem";
 export const calciteFontLineHeight6xl = "4rem";
 export const calciteFontLineHeight7xl = "5rem";
-export const calciteFontLetterSpacingTight = "-0.4px"; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-export const calciteFontLetterSpacingNormal = "0"; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-export const calciteFontLetterSpacingWide = "0.4px"; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-export const calciteFontParagraphSpacingNormal = "4px"; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-export const calciteFontTextDecorationNone = "none"; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-export const calciteFontTextDecorationUnderline = "underline"; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-export const calciteFontTextCaseNone = "none"; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-export const calciteFontTextCaseUppercase = "uppercase"; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-export const calciteFontTextCaseLowercase = "lowercase"; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-export const calciteFontTextCaseCapitalize = "capitalize"; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
+export const calciteFontLetterSpacingTight = "-0.4px"; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+export const calciteFontLetterSpacingNormal = "0"; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+export const calciteFontLetterSpacingWide = "0.4px"; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+export const calciteFontParagraphSpacingNormal = "4px"; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+export const calciteFontTextDecorationNone = "none"; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+export const calciteFontTextDecorationUnderline = "underline"; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+export const calciteFontTextCaseNone = "none"; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+export const calciteFontTextCaseUppercase = "uppercase"; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+export const calciteFontTextCaseLowercase = "lowercase"; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+export const calciteFontTextCaseCapitalize = "capitalize"; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
 export const calciteOpacityDisabled = "0.5";
 export const calciteOpacityLight = "0.4";
 export const calciteOpacityHalf = "0.5";
@@ -33516,53 +33516,53 @@ export const calciteShadowMd = [
     y: "12px",
   },
 ];
-export const calciteSizeFixedXxxs = "2px"; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-export const calciteSizeFixedXxs = "4px"; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-export const calciteSizeFixedXs = "6px"; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-export const calciteSizeFixedSm = "8px"; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-export const calciteSizeFixedSmPlus = "10px"; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-4xs\` instead.
-export const calciteSizeFixedMd = "12px"; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-3xs\` instead.
-export const calciteSizeFixedMdPlus = "14px"; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-2xs\` instead.
-export const calciteSizeFixedLg = "16px"; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-xs\` instead.
-export const calciteSizeFixedXl = "20px"; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-export const calciteSizeFixedXxl = "24px"; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-sm\` instead.
-export const calciteSizeFixedXxxl = "32px"; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-md\` instead.
+export const calciteSizeFixedXxxs = "2px"; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+export const calciteSizeFixedXxs = "4px"; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+export const calciteSizeFixedXs = "6px"; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+export const calciteSizeFixedSm = "8px"; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+export const calciteSizeFixedSmPlus = "10px"; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-4xs\` instead.
+export const calciteSizeFixedMd = "12px"; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-3xs\` instead.
+export const calciteSizeFixedMdPlus = "14px"; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-2xs\` instead.
+export const calciteSizeFixedLg = "16px"; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-xs\` instead.
+export const calciteSizeFixedXl = "20px"; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+export const calciteSizeFixedXxl = "24px"; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-sm\` instead.
+export const calciteSizeFixedXxxl = "32px"; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-md\` instead.
 export const calciteSizePx = "1px";
 export const calciteSize4xs = "0.625rem";
-export const calciteSizeXxxs = "0.75rem"; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-3xs\` instead.
+export const calciteSizeXxxs = "0.75rem"; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-3xs\` instead.
 export const calciteSize3xs = "0.75rem";
-export const calciteSizeXxs = "0.875rem"; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-2xs\` instead.
+export const calciteSizeXxs = "0.875rem"; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-2xs\` instead.
 export const calciteSize2xs = "0.875rem";
 export const calciteSizeXs = "1rem";
 export const calciteSizeSm = "1.5rem";
 export const calciteSizeMd = "2rem";
 export const calciteSizeLg = "2.75rem";
 export const calciteSizeXl = "3rem";
-export const calciteSizeXxl = "4rem"; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-2xl\` instead.
+export const calciteSizeXxl = "4rem"; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-2xl\` instead.
 export const calciteSize2xl = "4rem";
-export const calciteSizeXxxl = "6rem"; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-3xl\` instead.
+export const calciteSizeXxxl = "6rem"; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-3xl\` instead.
 export const calciteSize3xl = "6rem";
-export const calciteSpacingFixedXxs = "4px"; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-2xs\` instead.
-export const calciteSpacingFixedXs = "6px"; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-xs\` instead.
-export const calciteSpacingFixedSm = "8px"; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-sm\` instead.
-export const calciteSpacingFixedMd = "12px"; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-md\` instead.
-export const calciteSpacingFixedLg = "14px"; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-md-plus\` instead.
-export const calciteSpacingFixedXl = "16px"; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-lg\` instead.
-export const calciteSpacingFixedXxl = "20px"; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-xl\` instead.
-export const calciteSpacingFixedXxxl = "32px"; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-3xl\` instead.
-export const calciteSpacingNone = "0"; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-none\` instead.
-export const calciteSpacingPx = "1px"; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-px\` instead.
-export const calciteSpacingBase = "2px"; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-base\` instead.
-export const calciteSpacingXxs = "0.25rem"; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-2xs\` instead.
-export const calciteSpacingXs = "0.375rem"; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-xs\` instead.
-export const calciteSpacingSm = "0.5rem"; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-sm\` instead.
-export const calciteSpacingSmPlus = "0.625rem"; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-sm-plus\` instead.
-export const calciteSpacingMd = "0.75rem"; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-md\` instead.
-export const calciteSpacingMdPlus = "0.875rem"; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-md-plus\` instead.
-export const calciteSpacingLg = "1rem"; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-lg\` instead.
-export const calciteSpacingXl = "1.25rem"; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-xl\` instead.
-export const calciteSpacingXxl = "1.5rem"; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-2xl\` instead.
-export const calciteSpacingXxxl = "2rem"; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-3xl\` instead.
+export const calciteSpacingFixedXxs = "4px"; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-2xs\` instead.
+export const calciteSpacingFixedXs = "6px"; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-xs\` instead.
+export const calciteSpacingFixedSm = "8px"; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-sm\` instead.
+export const calciteSpacingFixedMd = "12px"; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-md\` instead.
+export const calciteSpacingFixedLg = "14px"; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-md-plus\` instead.
+export const calciteSpacingFixedXl = "16px"; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-lg\` instead.
+export const calciteSpacingFixedXxl = "20px"; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-xl\` instead.
+export const calciteSpacingFixedXxxl = "32px"; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-3xl\` instead.
+export const calciteSpacingNone = "0"; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-none\` instead.
+export const calciteSpacingPx = "1px"; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-px\` instead.
+export const calciteSpacingBase = "2px"; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-base\` instead.
+export const calciteSpacingXxs = "0.25rem"; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-2xs\` instead.
+export const calciteSpacingXs = "0.375rem"; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-xs\` instead.
+export const calciteSpacingSm = "0.5rem"; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-sm\` instead.
+export const calciteSpacingSmPlus = "0.625rem"; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-sm-plus\` instead.
+export const calciteSpacingMd = "0.75rem"; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-md\` instead.
+export const calciteSpacingMdPlus = "0.875rem"; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-md-plus\` instead.
+export const calciteSpacingLg = "1rem"; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-lg\` instead.
+export const calciteSpacingXl = "1.25rem"; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-xl\` instead.
+export const calciteSpacingXxl = "1.5rem"; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-2xl\` instead.
+export const calciteSpacingXxxl = "2rem"; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-3xl\` instead.
 export const calciteSpaceNone = "0";
 export const calciteSpacePx = "1px";
 export const calciteSpaceBase = "2px";
@@ -33857,17 +33857,17 @@ export const calciteColorSurface2: { light: string; dark: string };
 export const calciteColorSurface3: { light: string; dark: string };
 export const calciteColorSurface4: { light: string; dark: string };
 export const calciteColorSurfaceHighlight: { light: string; dark: string };
-/** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-1\` instead. */
+/** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-1\` instead. */
 export const calciteColorBackground: { light: string; dark: string };
-/** Deprecated in v5.0.0, removal target v6.0.0 - No longer needed. */
+/** Deprecated in v4.0.0, removal target v5.0.0 - No longer needed. */
 export const calciteColorBackgroundNone: string;
-/** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-2\` instead. */
+/** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-2\` instead. */
 export const calciteColorForeground1: { light: string; dark: string };
-/** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-3\` instead. */
+/** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-3\` instead. */
 export const calciteColorForeground2: { light: string; dark: string };
-/** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-4\` instead. */
+/** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-4\` instead. */
 export const calciteColorForeground3: { light: string; dark: string };
-/** Deprecated in v3.3.0, removal target v6.0.0 - Use \`--calcite-color-surface-highlight\` instead. */
+/** Deprecated in v3.2.0, removal target v5.0.0 - Use \`--calcite-color-surface-highlight\` instead. */
 export const calciteColorForegroundCurrent: { light: string; dark: string };
 export const calciteColorText1: { light: string; dark: string };
 export const calciteColorText2: { light: string; dark: string };
@@ -33879,9 +33879,9 @@ export const calciteColorBorder1: { light: string; dark: string };
 export const calciteColorBorder2: { light: string; dark: string };
 export const calciteColorBorder3: { light: string; dark: string };
 export const calciteColorBorderInput: { light: string; dark: string };
-/** Deprecated in v5.0.0, removal target v6.0.0 - No longer needed. */
+/** Deprecated in v4.0.0, removal target v5.0.0 - No longer needed. */
 export const calciteColorBorderGhost: { light: string; dark: string };
-/** Deprecated in v5.0.0, removal target v6.0.0 - No longer needed. */
+/** Deprecated in v4.0.0, removal target v5.0.0 - No longer needed. */
 export const calciteColorBorderWhite: { light: string; dark: string };
 export const calciteColorBrand: { light: string; dark: string };
 export const calciteColorBrandHover: { light: string; dark: string };
@@ -33920,7 +33920,7 @@ export const calciteBorderWidthNone: string;
 export const calciteBorderWidthSm: string;
 export const calciteBorderWidthMd: string;
 export const calciteBorderWidthLg: string;
-/** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-container-size-height-2xs-min|max\` instead. */
+/** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-container-size-height-2xs-min|max\` instead. */
 export const calciteContainerSizeHeightXxs: { min: string; max: string };
 /** Small handheld devices and mini-windows */
 export const calciteContainerSizeHeight2xs: { min: string; max: string };
@@ -33934,7 +33934,7 @@ export const calciteContainerSizeHeightMd: { min: string; max: string };
 export const calciteContainerSizeHeightLg: { min: string; max: string };
 /** Projectors and televisions */
 export const calciteContainerSizeHeightXl: { min: string };
-/** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-container-size-width-2xs-min|max\` instead. */
+/** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-container-size-width-2xs-min|max\` instead. */
 export const calciteContainerSizeWidthXxs: { min: string; max: string };
 /** Small handheld devices and mini-windows */
 export const calciteContainerSizeWidth2xs: { min: string; max: string };
@@ -33955,12 +33955,12 @@ export const calciteContainerSizeContentFluid: string;
 /** only for lg breakpoint fixed grid width */
 export const calciteContainerSizeContentFixed: string;
 export const calciteCornerRadius: string;
-/** Deprecated in v3.2.0, removal target v6.0.0 - Use \`--calcite-corner-radius-none\` instead. */
+/** Deprecated in v3.1.0, removal target v5.0.0 - Use \`--calcite-corner-radius-none\` instead. */
 export const calciteCornerRadiusSharp: string;
 export const calciteCornerRadiusNone: string;
 export const calciteCornerRadiusXs: string;
 export const calciteCornerRadiusSm: string;
-/** Deprecated in v3.2.0, removal target v6.0.0 - Use \`--calcite-corner-radius-sm\` instead. */
+/** Deprecated in v3.1.0, removal target v5.0.0 - Use \`--calcite-corner-radius-sm\` instead. */
 export const calciteCornerRadiusRound: string;
 export const calciteCornerRadiusPill: string;
 /** Primary font with fallbacks */
@@ -33969,7 +33969,7 @@ export const calciteFontFamily: string[];
 export const calciteFontFamilyCode: string[];
 /** For Avenir Next World (secondary font family) */
 export const calciteFontWeightLight: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-font-weight-regular\` instead. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-font-weight-regular\` instead. */
 export const calciteFontWeightNormal: string;
 export const calciteFontWeightRegular: string;
 export const calciteFontWeightMedium: string;
@@ -33981,7 +33981,7 @@ export const calciteFontSize: string;
 export const calciteFontSizeMd: string;
 export const calciteFontSizeLg: string;
 export const calciteFontSizeXl: string;
-/** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-font-size-2xl\` instead. */
+/** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-font-size-2xl\` instead. */
 export const calciteFontSizeXxl: string;
 export const calciteFontSize2xl: string;
 export const calciteFontSizeRelativeXs: string;
@@ -34033,25 +34033,25 @@ export const calciteFontLineHeight4xl: string;
 export const calciteFontLineHeight5xl: string;
 export const calciteFontLineHeight6xl: string;
 export const calciteFontLineHeight7xl: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
 export const calciteFontLetterSpacingTight: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
 export const calciteFontLetterSpacingNormal: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
 export const calciteFontLetterSpacingWide: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
 export const calciteFontParagraphSpacingNormal: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
 export const calciteFontTextDecorationNone: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
 export const calciteFontTextDecorationUnderline: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
 export const calciteFontTextCaseNone: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
 export const calciteFontTextCaseUppercase: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
 export const calciteFontTextCaseLowercase: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
 export const calciteFontTextCaseCapitalize: string;
 export const calciteOpacityDisabled: string;
 export const calciteOpacityLight: string;
@@ -34079,34 +34079,34 @@ export const calciteShadowMd: {
   x: string;
   y: string;
 }[];
-/** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
 export const calciteSizeFixedXxxs: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
 export const calciteSizeFixedXxs: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
 export const calciteSizeFixedXs: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
 export const calciteSizeFixedSm: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-4xs\` instead. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-4xs\` instead. */
 export const calciteSizeFixedSmPlus: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-3xs\` instead. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-3xs\` instead. */
 export const calciteSizeFixedMd: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-2xs\` instead. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-2xs\` instead. */
 export const calciteSizeFixedMdPlus: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-xs\` instead. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-xs\` instead. */
 export const calciteSizeFixedLg: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
 export const calciteSizeFixedXl: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-sm\` instead. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-sm\` instead. */
 export const calciteSizeFixedXxl: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-md\` instead. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-md\` instead. */
 export const calciteSizeFixedXxxl: string;
 export const calciteSizePx: string;
 export const calciteSize4xs: string;
-/** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-3xs\` instead. */
+/** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-3xs\` instead. */
 export const calciteSizeXxxs: string;
 export const calciteSize3xs: string;
-/** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-2xs\` instead. */
+/** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-2xs\` instead. */
 export const calciteSizeXxs: string;
 export const calciteSize2xs: string;
 export const calciteSizeXs: string;
@@ -34114,53 +34114,53 @@ export const calciteSizeSm: string;
 export const calciteSizeMd: string;
 export const calciteSizeLg: string;
 export const calciteSizeXl: string;
-/** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-2xl\` instead. */
+/** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-2xl\` instead. */
 export const calciteSizeXxl: string;
 export const calciteSize2xl: string;
-/** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-3xl\` instead. */
+/** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-3xl\` instead. */
 export const calciteSizeXxxl: string;
 export const calciteSize3xl: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-2xs\` instead. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-2xs\` instead. */
 export const calciteSpacingFixedXxs: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-xs\` instead. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-xs\` instead. */
 export const calciteSpacingFixedXs: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-sm\` instead. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-sm\` instead. */
 export const calciteSpacingFixedSm: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-md\` instead. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-md\` instead. */
 export const calciteSpacingFixedMd: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-md-plus\` instead. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-md-plus\` instead. */
 export const calciteSpacingFixedLg: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-lg\` instead. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-lg\` instead. */
 export const calciteSpacingFixedXl: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-xl\` instead. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-xl\` instead. */
 export const calciteSpacingFixedXxl: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-3xl\` instead. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-3xl\` instead. */
 export const calciteSpacingFixedXxxl: string;
-/** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-none\` instead. */
+/** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-none\` instead. */
 export const calciteSpacingNone: string;
-/** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-px\` instead. */
+/** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-px\` instead. */
 export const calciteSpacingPx: string;
-/** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-base\` instead. */
+/** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-base\` instead. */
 export const calciteSpacingBase: string;
-/** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-2xs\` instead. */
+/** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-2xs\` instead. */
 export const calciteSpacingXxs: string;
-/** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-xs\` instead. */
+/** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-xs\` instead. */
 export const calciteSpacingXs: string;
-/** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-sm\` instead. */
+/** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-sm\` instead. */
 export const calciteSpacingSm: string;
-/** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-sm-plus\` instead. */
+/** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-sm-plus\` instead. */
 export const calciteSpacingSmPlus: string;
-/** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-md\` instead. */
+/** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-md\` instead. */
 export const calciteSpacingMd: string;
-/** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-md-plus\` instead. */
+/** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-md-plus\` instead. */
 export const calciteSpacingMdPlus: string;
-/** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-lg\` instead. */
+/** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-lg\` instead. */
 export const calciteSpacingLg: string;
-/** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-xl\` instead. */
+/** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-xl\` instead. */
 export const calciteSpacingXl: string;
-/** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-2xl\` instead. */
+/** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-2xl\` instead. */
 export const calciteSpacingXxl: string;
-/** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-3xl\` instead. */
+/** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-3xl\` instead. */
 export const calciteSpacingXxxl: string;
 export const calciteSpaceNone: string;
 export const calciteSpacePx: string;
@@ -34459,11 +34459,11 @@ export const calciteContainerSizeGutter = "16px";
 export const calciteContainerSizeContentFluid = "100%"; // for fluid grid widths
 export const calciteContainerSizeContentFixed = "1440px"; // only for lg breakpoint fixed grid width
 export const calciteCornerRadius = "0";
-export const calciteCornerRadiusSharp = "0"; // Deprecated in v3.2.0, removal target v6.0.0 - Use \`--calcite-corner-radius-none\` instead.
+export const calciteCornerRadiusSharp = "0"; // Deprecated in v3.1.0, removal target v5.0.0 - Use \`--calcite-corner-radius-none\` instead.
 export const calciteCornerRadiusNone = "0";
 export const calciteCornerRadiusXs = "2px";
 export const calciteCornerRadiusSm = "4px";
-export const calciteCornerRadiusRound = "4px"; // Deprecated in v3.2.0, removal target v6.0.0 - Use \`--calcite-corner-radius-sm\` instead.
+export const calciteCornerRadiusRound = "4px"; // Deprecated in v3.1.0, removal target v5.0.0 - Use \`--calcite-corner-radius-sm\` instead.
 export const calciteCornerRadiusPill = "9999px";
 export const calciteFontFamily = [
   "Avenir Next",
@@ -34479,7 +34479,7 @@ export const calciteFontFamilyCode = [
   "monospace",
 ]; // Font family for code with fallbacks
 export const calciteFontWeightLight = "300"; // For Avenir Next World (secondary font family)
-export const calciteFontWeightNormal = "400"; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-font-weight-regular\` instead.
+export const calciteFontWeightNormal = "400"; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-font-weight-regular\` instead.
 export const calciteFontWeightRegular = "400";
 export const calciteFontWeightMedium = "500";
 export const calciteFontWeightSemibold = "600";
@@ -34490,7 +34490,7 @@ export const calciteFontSize = "14px";
 export const calciteFontSizeMd = "16px";
 export const calciteFontSizeLg = "18px";
 export const calciteFontSizeXl = "20px";
-export const calciteFontSizeXxl = "24px"; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-font-size-2xl\` instead.
+export const calciteFontSizeXxl = "24px"; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-font-size-2xl\` instead.
 export const calciteFontSize2xl = "24px";
 export const calciteFontSizeRelativeXs = "0.625rem";
 export const calciteFontSizeRelativeSm = "0.75rem";
@@ -34533,16 +34533,16 @@ export const calciteFontLineHeight4xl = "3rem";
 export const calciteFontLineHeight5xl = "4rem";
 export const calciteFontLineHeight6xl = "4rem";
 export const calciteFontLineHeight7xl = "5rem";
-export const calciteFontLetterSpacingTight = "-0.4px"; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-export const calciteFontLetterSpacingNormal = "0"; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-export const calciteFontLetterSpacingWide = "0.4px"; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-export const calciteFontParagraphSpacingNormal = "4px"; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-export const calciteFontTextDecorationNone = "none"; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-export const calciteFontTextDecorationUnderline = "underline"; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-export const calciteFontTextCaseNone = "none"; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-export const calciteFontTextCaseUppercase = "uppercase"; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-export const calciteFontTextCaseLowercase = "lowercase"; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-export const calciteFontTextCaseCapitalize = "capitalize"; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
+export const calciteFontLetterSpacingTight = "-0.4px"; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+export const calciteFontLetterSpacingNormal = "0"; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+export const calciteFontLetterSpacingWide = "0.4px"; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+export const calciteFontParagraphSpacingNormal = "4px"; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+export const calciteFontTextDecorationNone = "none"; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+export const calciteFontTextDecorationUnderline = "underline"; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+export const calciteFontTextCaseNone = "none"; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+export const calciteFontTextCaseUppercase = "uppercase"; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+export const calciteFontTextCaseLowercase = "lowercase"; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+export const calciteFontTextCaseCapitalize = "capitalize"; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
 export const calciteOpacityDisabled = "0.5";
 export const calciteOpacityLight = "0.4";
 export const calciteOpacityHalf = "0.5";
@@ -34569,53 +34569,53 @@ export const calciteShadowMd = [
     y: "12px",
   },
 ];
-export const calciteSizeFixedXxxs = "2px"; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-export const calciteSizeFixedXxs = "4px"; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-export const calciteSizeFixedXs = "6px"; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-export const calciteSizeFixedSm = "8px"; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-export const calciteSizeFixedSmPlus = "10px"; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-4xs\` instead.
-export const calciteSizeFixedMd = "12px"; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-3xs\` instead.
-export const calciteSizeFixedMdPlus = "14px"; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-2xs\` instead.
-export const calciteSizeFixedLg = "16px"; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-xs\` instead.
-export const calciteSizeFixedXl = "20px"; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-export const calciteSizeFixedXxl = "24px"; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-sm\` instead.
-export const calciteSizeFixedXxxl = "32px"; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-md\` instead.
+export const calciteSizeFixedXxxs = "2px"; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+export const calciteSizeFixedXxs = "4px"; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+export const calciteSizeFixedXs = "6px"; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+export const calciteSizeFixedSm = "8px"; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+export const calciteSizeFixedSmPlus = "10px"; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-4xs\` instead.
+export const calciteSizeFixedMd = "12px"; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-3xs\` instead.
+export const calciteSizeFixedMdPlus = "14px"; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-2xs\` instead.
+export const calciteSizeFixedLg = "16px"; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-xs\` instead.
+export const calciteSizeFixedXl = "20px"; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+export const calciteSizeFixedXxl = "24px"; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-sm\` instead.
+export const calciteSizeFixedXxxl = "32px"; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-md\` instead.
 export const calciteSizePx = "1px";
 export const calciteSize4xs = "0.625rem";
-export const calciteSizeXxxs = "0.75rem"; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-3xs\` instead.
+export const calciteSizeXxxs = "0.75rem"; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-3xs\` instead.
 export const calciteSize3xs = "0.75rem";
-export const calciteSizeXxs = "0.875rem"; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-2xs\` instead.
+export const calciteSizeXxs = "0.875rem"; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-2xs\` instead.
 export const calciteSize2xs = "0.875rem";
 export const calciteSizeXs = "1rem";
 export const calciteSizeSm = "1.5rem";
 export const calciteSizeMd = "2rem";
 export const calciteSizeLg = "2.75rem";
 export const calciteSizeXl = "3rem";
-export const calciteSizeXxl = "4rem"; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-2xl\` instead.
+export const calciteSizeXxl = "4rem"; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-2xl\` instead.
 export const calciteSize2xl = "4rem";
-export const calciteSizeXxxl = "6rem"; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-3xl\` instead.
+export const calciteSizeXxxl = "6rem"; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-3xl\` instead.
 export const calciteSize3xl = "6rem";
-export const calciteSpacingFixedXxs = "4px"; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-2xs\` instead.
-export const calciteSpacingFixedXs = "6px"; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-xs\` instead.
-export const calciteSpacingFixedSm = "8px"; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-sm\` instead.
-export const calciteSpacingFixedMd = "12px"; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-md\` instead.
-export const calciteSpacingFixedLg = "14px"; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-md-plus\` instead.
-export const calciteSpacingFixedXl = "16px"; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-lg\` instead.
-export const calciteSpacingFixedXxl = "20px"; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-xl\` instead.
-export const calciteSpacingFixedXxxl = "32px"; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-3xl\` instead.
-export const calciteSpacingNone = "0"; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-none\` instead.
-export const calciteSpacingPx = "1px"; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-px\` instead.
-export const calciteSpacingBase = "2px"; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-base\` instead.
-export const calciteSpacingXxs = "0.25rem"; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-2xs\` instead.
-export const calciteSpacingXs = "0.375rem"; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-xs\` instead.
-export const calciteSpacingSm = "0.5rem"; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-sm\` instead.
-export const calciteSpacingSmPlus = "0.625rem"; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-sm-plus\` instead.
-export const calciteSpacingMd = "0.75rem"; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-md\` instead.
-export const calciteSpacingMdPlus = "0.875rem"; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-md-plus\` instead.
-export const calciteSpacingLg = "1rem"; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-lg\` instead.
-export const calciteSpacingXl = "1.25rem"; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-xl\` instead.
-export const calciteSpacingXxl = "1.5rem"; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-2xl\` instead.
-export const calciteSpacingXxxl = "2rem"; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-3xl\` instead.
+export const calciteSpacingFixedXxs = "4px"; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-2xs\` instead.
+export const calciteSpacingFixedXs = "6px"; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-xs\` instead.
+export const calciteSpacingFixedSm = "8px"; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-sm\` instead.
+export const calciteSpacingFixedMd = "12px"; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-md\` instead.
+export const calciteSpacingFixedLg = "14px"; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-md-plus\` instead.
+export const calciteSpacingFixedXl = "16px"; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-lg\` instead.
+export const calciteSpacingFixedXxl = "20px"; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-xl\` instead.
+export const calciteSpacingFixedXxxl = "32px"; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-3xl\` instead.
+export const calciteSpacingNone = "0"; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-none\` instead.
+export const calciteSpacingPx = "1px"; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-px\` instead.
+export const calciteSpacingBase = "2px"; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-base\` instead.
+export const calciteSpacingXxs = "0.25rem"; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-2xs\` instead.
+export const calciteSpacingXs = "0.375rem"; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-xs\` instead.
+export const calciteSpacingSm = "0.5rem"; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-sm\` instead.
+export const calciteSpacingSmPlus = "0.625rem"; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-sm-plus\` instead.
+export const calciteSpacingMd = "0.75rem"; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-md\` instead.
+export const calciteSpacingMdPlus = "0.875rem"; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-md-plus\` instead.
+export const calciteSpacingLg = "1rem"; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-lg\` instead.
+export const calciteSpacingXl = "1.25rem"; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-xl\` instead.
+export const calciteSpacingXxl = "1.5rem"; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-2xl\` instead.
+export const calciteSpacingXxxl = "2rem"; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-3xl\` instead.
 export const calciteSpaceNone = "0";
 export const calciteSpacePx = "1px";
 export const calciteSpaceBase = "2px";
@@ -34660,12 +34660,12 @@ export const calciteContainerSizeContentFluid: string;
 /** only for lg breakpoint fixed grid width */
 export const calciteContainerSizeContentFixed: string;
 export const calciteCornerRadius: string;
-/** Deprecated in v3.2.0, removal target v6.0.0 - Use \`--calcite-corner-radius-none\` instead. */
+/** Deprecated in v3.1.0, removal target v5.0.0 - Use \`--calcite-corner-radius-none\` instead. */
 export const calciteCornerRadiusSharp: string;
 export const calciteCornerRadiusNone: string;
 export const calciteCornerRadiusXs: string;
 export const calciteCornerRadiusSm: string;
-/** Deprecated in v3.2.0, removal target v6.0.0 - Use \`--calcite-corner-radius-sm\` instead. */
+/** Deprecated in v3.1.0, removal target v5.0.0 - Use \`--calcite-corner-radius-sm\` instead. */
 export const calciteCornerRadiusRound: string;
 export const calciteCornerRadiusPill: string;
 /** Primary font with fallbacks */
@@ -34674,7 +34674,7 @@ export const calciteFontFamily: string[];
 export const calciteFontFamilyCode: string[];
 /** For Avenir Next World (secondary font family) */
 export const calciteFontWeightLight: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-font-weight-regular\` instead. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-font-weight-regular\` instead. */
 export const calciteFontWeightNormal: string;
 export const calciteFontWeightRegular: string;
 export const calciteFontWeightMedium: string;
@@ -34686,7 +34686,7 @@ export const calciteFontSize: string;
 export const calciteFontSizeMd: string;
 export const calciteFontSizeLg: string;
 export const calciteFontSizeXl: string;
-/** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-font-size-2xl\` instead. */
+/** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-font-size-2xl\` instead. */
 export const calciteFontSizeXxl: string;
 export const calciteFontSize2xl: string;
 export const calciteFontSizeRelativeXs: string;
@@ -34738,25 +34738,25 @@ export const calciteFontLineHeight4xl: string;
 export const calciteFontLineHeight5xl: string;
 export const calciteFontLineHeight6xl: string;
 export const calciteFontLineHeight7xl: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
 export const calciteFontLetterSpacingTight: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
 export const calciteFontLetterSpacingNormal: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
 export const calciteFontLetterSpacingWide: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
 export const calciteFontParagraphSpacingNormal: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
 export const calciteFontTextDecorationNone: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
 export const calciteFontTextDecorationUnderline: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
 export const calciteFontTextCaseNone: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
 export const calciteFontTextCaseUppercase: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
 export const calciteFontTextCaseLowercase: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
 export const calciteFontTextCaseCapitalize: string;
 export const calciteOpacityDisabled: string;
 export const calciteOpacityLight: string;
@@ -34784,34 +34784,34 @@ export const calciteShadowMd: {
   x: string;
   y: string;
 }[];
-/** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
 export const calciteSizeFixedXxxs: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
 export const calciteSizeFixedXxs: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
 export const calciteSizeFixedXs: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
 export const calciteSizeFixedSm: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-4xs\` instead. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-4xs\` instead. */
 export const calciteSizeFixedSmPlus: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-3xs\` instead. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-3xs\` instead. */
 export const calciteSizeFixedMd: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-2xs\` instead. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-2xs\` instead. */
 export const calciteSizeFixedMdPlus: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-xs\` instead. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-xs\` instead. */
 export const calciteSizeFixedLg: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - No longer needed. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - No longer needed. */
 export const calciteSizeFixedXl: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-sm\` instead. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-sm\` instead. */
 export const calciteSizeFixedXxl: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-md\` instead. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-md\` instead. */
 export const calciteSizeFixedXxxl: string;
 export const calciteSizePx: string;
 export const calciteSize4xs: string;
-/** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-3xs\` instead. */
+/** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-3xs\` instead. */
 export const calciteSizeXxxs: string;
 export const calciteSize3xs: string;
-/** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-2xs\` instead. */
+/** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-2xs\` instead. */
 export const calciteSizeXxs: string;
 export const calciteSize2xs: string;
 export const calciteSizeXs: string;
@@ -34819,53 +34819,53 @@ export const calciteSizeSm: string;
 export const calciteSizeMd: string;
 export const calciteSizeLg: string;
 export const calciteSizeXl: string;
-/** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-2xl\` instead. */
+/** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-2xl\` instead. */
 export const calciteSizeXxl: string;
 export const calciteSize2xl: string;
-/** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-3xl\` instead. */
+/** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-3xl\` instead. */
 export const calciteSizeXxxl: string;
 export const calciteSize3xl: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-2xs\` instead. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-2xs\` instead. */
 export const calciteSpacingFixedXxs: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-xs\` instead. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-xs\` instead. */
 export const calciteSpacingFixedXs: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-sm\` instead. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-sm\` instead. */
 export const calciteSpacingFixedSm: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-md\` instead. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-md\` instead. */
 export const calciteSpacingFixedMd: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-md-plus\` instead. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-md-plus\` instead. */
 export const calciteSpacingFixedLg: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-lg\` instead. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-lg\` instead. */
 export const calciteSpacingFixedXl: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-xl\` instead. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-xl\` instead. */
 export const calciteSpacingFixedXxl: string;
-/** Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-3xl\` instead. */
+/** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-3xl\` instead. */
 export const calciteSpacingFixedXxxl: string;
-/** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-none\` instead. */
+/** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-none\` instead. */
 export const calciteSpacingNone: string;
-/** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-px\` instead. */
+/** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-px\` instead. */
 export const calciteSpacingPx: string;
-/** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-base\` instead. */
+/** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-base\` instead. */
 export const calciteSpacingBase: string;
-/** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-2xs\` instead. */
+/** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-2xs\` instead. */
 export const calciteSpacingXxs: string;
-/** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-xs\` instead. */
+/** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-xs\` instead. */
 export const calciteSpacingXs: string;
-/** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-sm\` instead. */
+/** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-sm\` instead. */
 export const calciteSpacingSm: string;
-/** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-sm-plus\` instead. */
+/** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-sm-plus\` instead. */
 export const calciteSpacingSmPlus: string;
-/** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-md\` instead. */
+/** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-md\` instead. */
 export const calciteSpacingMd: string;
-/** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-md-plus\` instead. */
+/** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-md-plus\` instead. */
 export const calciteSpacingMdPlus: string;
-/** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-lg\` instead. */
+/** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-lg\` instead. */
 export const calciteSpacingLg: string;
-/** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-xl\` instead. */
+/** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-xl\` instead. */
 export const calciteSpacingXl: string;
-/** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-2xl\` instead. */
+/** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-2xl\` instead. */
 export const calciteSpacingXxl: string;
-/** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-3xl\` instead. */
+/** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-3xl\` instead. */
 export const calciteSpacingXxxl: string;
 export const calciteSpaceNone: string;
 export const calciteSpacePx: string;
@@ -34899,11 +34899,11 @@ exports[`generated tokens > SCSS > breakpoints should match 1`] = `
 // Calcite Design System
 // Do not edit directly, this file was auto-generated.
 
-$calcite-container-size-height-xxs-min: 0; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-container-size-height-2xs-min|max\` instead.
+$calcite-container-size-height-xxs-min: 0; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-container-size-height-2xs-min|max\` instead.
 $calcite-container-size-height-2xs-min: 0; // Small handheld devices and mini-windows
-$calcite-container-size-width-xxs-min: 0; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-container-size-width-2xs-min|max\` instead.
+$calcite-container-size-width-xxs-min: 0; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-container-size-width-2xs-min|max\` instead.
 $calcite-container-size-width-2xs-min: 0; // Small handheld devices and mini-windows
-$calcite-container-size-height-xxs-max: 154px; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-container-size-height-2xs-min|max\` instead.
+$calcite-container-size-height-xxs-max: 154px; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-container-size-height-2xs-min|max\` instead.
 $calcite-container-size-height-2xs-max: 154px; // Small handheld devices and mini-windows
 $calcite-container-size-height-xs-min: 155px; // Handheld devices
 $calcite-container-size-height-xs-max: 328px; // Handheld devices
@@ -34914,7 +34914,7 @@ $calcite-container-size-height-md-max: 678px; // Small laptops
 $calcite-container-size-height-lg-min: 679px; // Large laptops and desktop computers
 $calcite-container-size-height-lg-max: 854px; // Large laptops and desktop computers
 $calcite-container-size-height-xl-min: 855px; // Projectors and televisions
-$calcite-container-size-width-xxs-max: 320px; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-container-size-width-2xs-min|max\` instead.
+$calcite-container-size-width-xxs-max: 320px; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-container-size-width-2xs-min|max\` instead.
 $calcite-container-size-width-2xs-max: 320px; // Small handheld devices and mini-windows
 $calcite-container-size-width-xs-min: 321px; // Handheld devices
 $calcite-container-size-width-xs-max: 476px; // Handheld devices
@@ -35090,7 +35090,7 @@ $calcite-color-low-saturation-violet-l-vv-070: #6f6783;
 $calcite-color-low-saturation-violet-l-vv-080: #504b60;
 $calcite-color-low-saturation-violet-l-vv-090: #322e3d;
 $calcite-color-low-saturation-violet-l-vv-100: #13111a;
-$calcite-color-low-saturation-violet-l-vv-1000: #13111a; // Deprecated in v3.3.0, removal target v6.0.0 - Use \`--calcite-color-low-saturation-violet-l-vv-100\` instead.
+$calcite-color-low-saturation-violet-l-vv-1000: #13111a; // Deprecated in v3.2.0, removal target v5.0.0 - Use \`--calcite-color-low-saturation-violet-l-vv-100\` instead.
 $calcite-color-medium-saturation-blue-m-bb-010: #dfeffa;
 $calcite-color-medium-saturation-blue-m-bb-020: #c8e3f5;
 $calcite-color-medium-saturation-blue-m-bb-030: #b1d8f1;
@@ -35431,12 +35431,12 @@ $calcite-font-weight-bold: 700;
 $calcite-font-weight-extrabold: 800; // only for Avenir Next World (secondary font family)
 $calcite-font-weight-black: 900; // only for Avenir Next World (secondary font family)
 $calcite-font-weight-heavy: 900;
-$calcite-font-text-decoration-none: none; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-$calcite-font-text-decoration-underline: underline; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-$calcite-font-text-case-none: none; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-$calcite-font-text-case-uppercase: uppercase; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-$calcite-font-text-case-lowercase: lowercase; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-$calcite-font-text-case-capitalize: capitalize; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
+$calcite-font-text-decoration-none: none; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+$calcite-font-text-decoration-underline: underline; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+$calcite-font-text-case-none: none; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+$calcite-font-text-case-uppercase: uppercase; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+$calcite-font-text-case-lowercase: lowercase; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+$calcite-font-text-case-capitalize: capitalize; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
 $calcite-opacity-0: 0;
 $calcite-opacity-4: 0.04;
 $calcite-opacity-8: 0.08;
@@ -35537,12 +35537,12 @@ $calcite-color-surface-2: #2b2b2b;
 $calcite-color-surface-3: #363636;
 $calcite-color-surface-4: #404040;
 $calcite-color-surface-highlight: #2b465f;
-$calcite-color-background: #212121; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-1\` instead.
-$calcite-color-background-none: rgba(255, 255, 255, 0); // Deprecated in v5.0.0, removal target v6.0.0 - No longer needed.
-$calcite-color-foreground-1: #2b2b2b; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-2\` instead.
-$calcite-color-foreground-2: #363636; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-3\` instead.
-$calcite-color-foreground-3: #404040; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-4\` instead.
-$calcite-color-foreground-current: #2b465f; // Deprecated in v3.3.0, removal target v6.0.0 - Use \`--calcite-color-surface-highlight\` instead.
+$calcite-color-background: #212121; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-1\` instead.
+$calcite-color-background-none: rgba(255, 255, 255, 0); // Deprecated in v4.0.0, removal target v5.0.0 - No longer needed.
+$calcite-color-foreground-1: #2b2b2b; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-2\` instead.
+$calcite-color-foreground-2: #363636; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-3\` instead.
+$calcite-color-foreground-3: #404040; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-4\` instead.
+$calcite-color-foreground-current: #2b465f; // Deprecated in v3.2.0, removal target v5.0.0 - Use \`--calcite-color-surface-highlight\` instead.
 $calcite-color-text-1: #ffffff;
 $calcite-color-text-2: #bfbfbf;
 $calcite-color-text-3: #9e9e9e;
@@ -35553,8 +35553,8 @@ $calcite-color-border-1: #545454;
 $calcite-color-border-2: #4a4a4a;
 $calcite-color-border-3: #404040;
 $calcite-color-border-input: #757575;
-$calcite-color-border-ghost: rgba(117, 117, 117, 0.3); // Deprecated in v5.0.0, removal target v6.0.0 - No longer needed.
-$calcite-color-border-white: #f7f7f7; // Deprecated in v5.0.0, removal target v6.0.0 - No longer needed.
+$calcite-color-border-ghost: rgba(117, 117, 117, 0.3); // Deprecated in v4.0.0, removal target v5.0.0 - No longer needed.
+$calcite-color-border-white: #f7f7f7; // Deprecated in v4.0.0, removal target v5.0.0 - No longer needed.
 $calcite-color-brand: #009af2;
 $calcite-color-brand-hover: #007ac2;
 $calcite-color-brand-press: #00619b;
@@ -35591,7 +35591,7 @@ exports[`generated tokens > SCSS > global should match 1`] = `
 // File to be deprecated in next major release
 // Do not edit directly, this file was auto-generated.
 
-$calcite-color-background-none: rgba(255, 255, 255, 0); // Deprecated in v5.0.0, removal target v6.0.0 - No longer needed.
+$calcite-color-background-none: rgba(255, 255, 255, 0); // Deprecated in v4.0.0, removal target v5.0.0 - No longer needed.
 $calcite-border-width-none: 0;
 $calcite-border-width-sm: 1px;
 $calcite-border-width-md: 2px;
@@ -35600,17 +35600,17 @@ $calcite-container-size-margin: 24px;
 $calcite-container-size-gutter: 16px;
 $calcite-container-size-content-fluid: 100%; // for fluid grid widths
 $calcite-container-size-content-fixed: 1440px; // only for lg breakpoint fixed grid width
-$calcite-corner-radius-sharp: 0; // Deprecated in v3.2.0, removal target v6.0.0 - Use \`--calcite-corner-radius-none\` instead.
+$calcite-corner-radius-sharp: 0; // Deprecated in v3.1.0, removal target v5.0.0 - Use \`--calcite-corner-radius-none\` instead.
 $calcite-corner-radius-none: 0;
 $calcite-corner-radius-xs: 2px;
 $calcite-corner-radius-sm: 4px;
-$calcite-corner-radius-round: 4px; // Deprecated in v3.2.0, removal target v6.0.0 - Use \`--calcite-corner-radius-sm\` instead.
+$calcite-corner-radius-round: 4px; // Deprecated in v3.1.0, removal target v5.0.0 - Use \`--calcite-corner-radius-sm\` instead.
 $calcite-corner-radius-pill: 9999px;
 $calcite-font-family: 'Avenir Next', Avenir, 'Helvetica Neue', sans-serif; // Primary font with fallbacks
 $calcite-font-family-code: Monaco, Consolas, 'Andale Mono', 'Lucida Console', monospace; // Font family for code with fallbacks
 $calcite-font-weight-light: 300; // For Avenir Next World (secondary font family)
 $calcite-font-weight-regular: 400;
-$calcite-font-weight-normal: 400; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-font-weight-regular\` instead.
+$calcite-font-weight-normal: 400; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-font-weight-regular\` instead.
 $calcite-font-weight-medium: 500;
 $calcite-font-weight-semibold: 600;
 $calcite-font-weight-bold: 600;
@@ -35620,7 +35620,7 @@ $calcite-font-size: 14px;
 $calcite-font-size-md: 16px;
 $calcite-font-size-lg: 18px;
 $calcite-font-size-xl: 20px;
-$calcite-font-size-xxl: 24px; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-font-size-2xl\` instead.
+$calcite-font-size-xxl: 24px; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-font-size-2xl\` instead.
 $calcite-font-size-2xl: 24px;
 $calcite-font-size-relative-xs: 0.625rem;
 $calcite-font-size-relative-sm: 0.75rem;
@@ -35663,68 +35663,68 @@ $calcite-font-line-height-4xl: 3rem;
 $calcite-font-line-height-5xl: 4rem;
 $calcite-font-line-height-6xl: 4rem;
 $calcite-font-line-height-7xl: 5rem;
-$calcite-font-letter-spacing-tight: -0.4px; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-$calcite-font-letter-spacing-normal: 0; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-$calcite-font-letter-spacing-wide: 0.4px; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-$calcite-font-paragraph-spacing-normal: 4px; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-$calcite-font-text-decoration-none: none; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-$calcite-font-text-decoration-underline: underline; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-$calcite-font-text-case-none: none; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-$calcite-font-text-case-uppercase: uppercase; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-$calcite-font-text-case-lowercase: lowercase; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-$calcite-font-text-case-capitalize: capitalize; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
+$calcite-font-letter-spacing-tight: -0.4px; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+$calcite-font-letter-spacing-normal: 0; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+$calcite-font-letter-spacing-wide: 0.4px; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+$calcite-font-paragraph-spacing-normal: 4px; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+$calcite-font-text-decoration-none: none; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+$calcite-font-text-decoration-underline: underline; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+$calcite-font-text-case-none: none; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+$calcite-font-text-case-uppercase: uppercase; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+$calcite-font-text-case-lowercase: lowercase; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+$calcite-font-text-case-capitalize: capitalize; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
 $calcite-opacity-disabled: 0.5;
 $calcite-opacity-light: 0.4;
 $calcite-opacity-half: 0.5;
 $calcite-opacity-dark: 0.85;
 $calcite-opacity-full: 1;
-$calcite-size-fixed-xxxs: 2px; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-$calcite-size-fixed-xxs: 4px; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-$calcite-size-fixed-xs: 6px; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-$calcite-size-fixed-sm: 8px; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-$calcite-size-fixed-sm-plus: 10px; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-4xs\` instead.
-$calcite-size-fixed-md: 12px; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-3xs\` instead.
-$calcite-size-fixed-md-plus: 14px; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-2xs\` instead.
-$calcite-size-fixed-lg: 16px; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-xs\` instead.
-$calcite-size-fixed-xl: 20px; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-$calcite-size-fixed-xxl: 24px; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-sm\` instead.
-$calcite-size-fixed-xxxl: 32px; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-md\` instead.
+$calcite-size-fixed-xxxs: 2px; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+$calcite-size-fixed-xxs: 4px; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+$calcite-size-fixed-xs: 6px; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+$calcite-size-fixed-sm: 8px; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+$calcite-size-fixed-sm-plus: 10px; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-4xs\` instead.
+$calcite-size-fixed-md: 12px; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-3xs\` instead.
+$calcite-size-fixed-md-plus: 14px; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-2xs\` instead.
+$calcite-size-fixed-lg: 16px; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-xs\` instead.
+$calcite-size-fixed-xl: 20px; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+$calcite-size-fixed-xxl: 24px; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-sm\` instead.
+$calcite-size-fixed-xxxl: 32px; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-md\` instead.
 $calcite-size-px: 1px;
 $calcite-size-4xs: 0.625rem;
-$calcite-size-xxxs: 0.75rem; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-3xs\` instead.
+$calcite-size-xxxs: 0.75rem; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-3xs\` instead.
 $calcite-size-3xs: 0.75rem;
-$calcite-size-xxs: 0.875rem; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-2xs\` instead.
+$calcite-size-xxs: 0.875rem; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-2xs\` instead.
 $calcite-size-2xs: 0.875rem;
 $calcite-size-xs: 1rem;
 $calcite-size-sm: 1.5rem;
 $calcite-size-md: 2rem;
 $calcite-size-lg: 2.75rem;
 $calcite-size-xl: 3rem;
-$calcite-size-xxl: 4rem; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-2xl\` instead.
+$calcite-size-xxl: 4rem; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-2xl\` instead.
 $calcite-size-2xl: 4rem;
-$calcite-size-xxxl: 6rem; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-3xl\` instead.
+$calcite-size-xxxl: 6rem; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-3xl\` instead.
 $calcite-size-3xl: 6rem;
-$calcite-spacing-fixed-xxs: 4px; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-2xs\` instead.
-$calcite-spacing-fixed-xs: 6px; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-xs\` instead.
-$calcite-spacing-fixed-sm: 8px; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-sm\` instead.
-$calcite-spacing-fixed-md: 12px; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-md\` instead.
-$calcite-spacing-fixed-lg: 14px; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-md-plus\` instead.
-$calcite-spacing-fixed-xl: 16px; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-lg\` instead.
-$calcite-spacing-fixed-xxl: 20px; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-xl\` instead.
-$calcite-spacing-fixed-xxxl: 32px; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-3xl\` instead.
-$calcite-spacing-none: 0; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-none\` instead.
-$calcite-spacing-px: 1px; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-px\` instead.
-$calcite-spacing-base: 2px; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-base\` instead.
-$calcite-spacing-xxs: 0.25rem; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-2xs\` instead.
-$calcite-spacing-xs: 0.375rem; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-xs\` instead.
-$calcite-spacing-sm: 0.5rem; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-sm\` instead.
-$calcite-spacing-sm-plus: 0.625rem; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-sm-plus\` instead.
-$calcite-spacing-md: 0.75rem; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-md\` instead.
-$calcite-spacing-md-plus: 0.875rem; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-md-plus\` instead.
-$calcite-spacing-lg: 1rem; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-lg\` instead.
-$calcite-spacing-xl: 1.25rem; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-xl\` instead.
-$calcite-spacing-xxl: 1.5rem; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-2xl\` instead.
-$calcite-spacing-xxxl: 2rem; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-3xl\` instead.
+$calcite-spacing-fixed-xxs: 4px; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-2xs\` instead.
+$calcite-spacing-fixed-xs: 6px; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-xs\` instead.
+$calcite-spacing-fixed-sm: 8px; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-sm\` instead.
+$calcite-spacing-fixed-md: 12px; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-md\` instead.
+$calcite-spacing-fixed-lg: 14px; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-md-plus\` instead.
+$calcite-spacing-fixed-xl: 16px; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-lg\` instead.
+$calcite-spacing-fixed-xxl: 20px; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-xl\` instead.
+$calcite-spacing-fixed-xxxl: 32px; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-3xl\` instead.
+$calcite-spacing-none: 0; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-none\` instead.
+$calcite-spacing-px: 1px; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-px\` instead.
+$calcite-spacing-base: 2px; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-base\` instead.
+$calcite-spacing-xxs: 0.25rem; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-2xs\` instead.
+$calcite-spacing-xs: 0.375rem; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-xs\` instead.
+$calcite-spacing-sm: 0.5rem; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-sm\` instead.
+$calcite-spacing-sm-plus: 0.625rem; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-sm-plus\` instead.
+$calcite-spacing-md: 0.75rem; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-md\` instead.
+$calcite-spacing-md-plus: 0.875rem; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-md-plus\` instead.
+$calcite-spacing-lg: 1rem; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-lg\` instead.
+$calcite-spacing-xl: 1.25rem; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-xl\` instead.
+$calcite-spacing-xxl: 1.5rem; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-2xl\` instead.
+$calcite-spacing-xxxl: 2rem; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-3xl\` instead.
 $calcite-space-none: 0;
 $calcite-space-px: 1px;
 $calcite-space-base: 2px;
@@ -35792,13 +35792,13 @@ exports[`generated tokens > SCSS > index should match 1`] = `
   --calcite-color-brand-press: #004874;
   --calcite-color-brand-hover: #00619b;
   --calcite-color-brand: #007ac2;
-  --calcite-color-border-white: #ffffff; /** Deprecated in v5.0.0, removal target v6.0.0 - No longer needed. */
+  --calcite-color-border-white: #ffffff; /** Deprecated in v4.0.0, removal target v5.0.0 - No longer needed. */
   --calcite-color-border-ghost: rgba(
     0,
     0,
     0,
     0.3
-  ); /** Deprecated in v5.0.0, removal target v6.0.0 - No longer needed. */
+  ); /** Deprecated in v4.0.0, removal target v5.0.0 - No longer needed. */
   --calcite-color-border-input: #949494;
   --calcite-color-border-3: #ebebeb;
   --calcite-color-border-2: #dedede;
@@ -35809,17 +35809,17 @@ exports[`generated tokens > SCSS > index should match 1`] = `
   --calcite-color-text-3: #6b6b6b;
   --calcite-color-text-2: #4a4a4a;
   --calcite-color-text-1: #141414;
-  --calcite-color-foreground-current: #d6efff; /** Deprecated in v3.3.0, removal target v6.0.0 - Use \`--calcite-color-surface-highlight\` instead. */
-  --calcite-color-foreground-3: #ebebeb; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-4\` instead. */
-  --calcite-color-foreground-2: #f2f2f2; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-3\` instead. */
-  --calcite-color-foreground-1: #ffffff; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-2\` instead. */
+  --calcite-color-foreground-current: #d6efff; /** Deprecated in v3.2.0, removal target v5.0.0 - Use \`--calcite-color-surface-highlight\` instead. */
+  --calcite-color-foreground-3: #ebebeb; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-4\` instead. */
+  --calcite-color-foreground-2: #f2f2f2; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-3\` instead. */
+  --calcite-color-foreground-1: #ffffff; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-2\` instead. */
   --calcite-color-background-none: rgba(
     255,
     255,
     255,
     0
-  ); /** Deprecated in v5.0.0, removal target v6.0.0 - No longer needed. */
-  --calcite-color-background: #f7f7f7; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-1\` instead. */
+  ); /** Deprecated in v4.0.0, removal target v5.0.0 - No longer needed. */
+  --calcite-color-background: #f7f7f7; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-1\` instead. */
   --calcite-color-surface-highlight: #d6efff;
   --calcite-color-surface-4: #ebebeb;
   --calcite-color-surface-3: #f2f2f2;
@@ -35854,13 +35854,13 @@ exports[`generated tokens > SCSS > index should match 1`] = `
   --calcite-color-brand-press: #00619b;
   --calcite-color-brand-hover: #007ac2;
   --calcite-color-brand: #009af2;
-  --calcite-color-border-white: #f7f7f7; /** Deprecated in v5.0.0, removal target v6.0.0 - No longer needed. */
+  --calcite-color-border-white: #f7f7f7; /** Deprecated in v4.0.0, removal target v5.0.0 - No longer needed. */
   --calcite-color-border-ghost: rgba(
     117,
     117,
     117,
     0.3
-  ); /** Deprecated in v5.0.0, removal target v6.0.0 - No longer needed. */
+  ); /** Deprecated in v4.0.0, removal target v5.0.0 - No longer needed. */
   --calcite-color-border-input: #757575;
   --calcite-color-border-3: #404040;
   --calcite-color-border-2: #4a4a4a;
@@ -35871,17 +35871,17 @@ exports[`generated tokens > SCSS > index should match 1`] = `
   --calcite-color-text-3: #9e9e9e;
   --calcite-color-text-2: #bfbfbf;
   --calcite-color-text-1: #ffffff;
-  --calcite-color-foreground-current: #2b465f; /** Deprecated in v3.3.0, removal target v6.0.0 - Use \`--calcite-color-surface-highlight\` instead. */
-  --calcite-color-foreground-3: #404040; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-4\` instead. */
-  --calcite-color-foreground-2: #363636; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-3\` instead. */
-  --calcite-color-foreground-1: #2b2b2b; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-2\` instead. */
+  --calcite-color-foreground-current: #2b465f; /** Deprecated in v3.2.0, removal target v5.0.0 - Use \`--calcite-color-surface-highlight\` instead. */
+  --calcite-color-foreground-3: #404040; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-4\` instead. */
+  --calcite-color-foreground-2: #363636; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-3\` instead. */
+  --calcite-color-foreground-1: #2b2b2b; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-2\` instead. */
   --calcite-color-background-none: rgba(
     255,
     255,
     255,
     0
-  ); /** Deprecated in v5.0.0, removal target v6.0.0 - No longer needed. */
-  --calcite-color-background: #212121; /** Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-1\` instead. */
+  ); /** Deprecated in v4.0.0, removal target v5.0.0 - No longer needed. */
+  --calcite-color-background: #212121; /** Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-1\` instead. */
   --calcite-color-surface-highlight: #2b465f;
   --calcite-color-surface-4: #404040;
   --calcite-color-surface-3: #363636;
@@ -35902,12 +35902,12 @@ $calcite-color-surface-2: #ffffff;
 $calcite-color-surface-3: #f2f2f2;
 $calcite-color-surface-4: #ebebeb;
 $calcite-color-surface-highlight: #d6efff;
-$calcite-color-background: #f7f7f7; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-1\` instead.
-$calcite-color-background-none: rgba(255, 255, 255, 0); // Deprecated in v5.0.0, removal target v6.0.0 - No longer needed.
-$calcite-color-foreground-1: #ffffff; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-2\` instead.
-$calcite-color-foreground-2: #f2f2f2; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-3\` instead.
-$calcite-color-foreground-3: #ebebeb; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-color-surface-4\` instead.
-$calcite-color-foreground-current: #d6efff; // Deprecated in v3.3.0, removal target v6.0.0 - Use \`--calcite-color-surface-highlight\` instead.
+$calcite-color-background: #f7f7f7; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-1\` instead.
+$calcite-color-background-none: rgba(255, 255, 255, 0); // Deprecated in v4.0.0, removal target v5.0.0 - No longer needed.
+$calcite-color-foreground-1: #ffffff; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-2\` instead.
+$calcite-color-foreground-2: #f2f2f2; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-3\` instead.
+$calcite-color-foreground-3: #ebebeb; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-color-surface-4\` instead.
+$calcite-color-foreground-current: #d6efff; // Deprecated in v3.2.0, removal target v5.0.0 - Use \`--calcite-color-surface-highlight\` instead.
 $calcite-color-text-1: #141414;
 $calcite-color-text-2: #4a4a4a;
 $calcite-color-text-3: #6b6b6b;
@@ -35918,8 +35918,8 @@ $calcite-color-border-1: #d4d4d4;
 $calcite-color-border-2: #dedede;
 $calcite-color-border-3: #ebebeb;
 $calcite-color-border-input: #949494;
-$calcite-color-border-ghost: rgba(0, 0, 0, 0.3); // Deprecated in v5.0.0, removal target v6.0.0 - No longer needed.
-$calcite-color-border-white: #ffffff; // Deprecated in v5.0.0, removal target v6.0.0 - No longer needed.
+$calcite-color-border-ghost: rgba(0, 0, 0, 0.3); // Deprecated in v4.0.0, removal target v5.0.0 - No longer needed.
+$calcite-color-border-white: #ffffff; // Deprecated in v4.0.0, removal target v5.0.0 - No longer needed.
 $calcite-color-brand: #007ac2;
 $calcite-color-brand-hover: #00619b;
 $calcite-color-brand-press: #004874;
@@ -36293,17 +36293,17 @@ $calcite-container-size-margin: 24px;
 $calcite-container-size-gutter: 16px;
 $calcite-container-size-content-fluid: 100%; // for fluid grid widths
 $calcite-container-size-content-fixed: 1440px; // only for lg breakpoint fixed grid width
-$calcite-corner-radius-sharp: 0; // Deprecated in v3.2.0, removal target v6.0.0 - Use \`--calcite-corner-radius-none\` instead.
+$calcite-corner-radius-sharp: 0; // Deprecated in v3.1.0, removal target v5.0.0 - Use \`--calcite-corner-radius-none\` instead.
 $calcite-corner-radius-none: 0;
 $calcite-corner-radius-xs: 2px;
 $calcite-corner-radius-sm: 4px;
-$calcite-corner-radius-round: 4px; // Deprecated in v3.2.0, removal target v6.0.0 - Use \`--calcite-corner-radius-sm\` instead.
+$calcite-corner-radius-round: 4px; // Deprecated in v3.1.0, removal target v5.0.0 - Use \`--calcite-corner-radius-sm\` instead.
 $calcite-corner-radius-pill: 9999px;
 $calcite-font-family: 'Avenir Next', Avenir, 'Helvetica Neue', sans-serif; // Primary font with fallbacks
 $calcite-font-family-code: Monaco, Consolas, 'Andale Mono', 'Lucida Console', monospace; // Font family for code with fallbacks
 $calcite-font-weight-light: 300; // For Avenir Next World (secondary font family)
 $calcite-font-weight-regular: 400;
-$calcite-font-weight-normal: 400; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-font-weight-regular\` instead.
+$calcite-font-weight-normal: 400; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-font-weight-regular\` instead.
 $calcite-font-weight-medium: 500;
 $calcite-font-weight-semibold: 600;
 $calcite-font-weight-bold: 600;
@@ -36313,7 +36313,7 @@ $calcite-font-size: 14px;
 $calcite-font-size-md: 16px;
 $calcite-font-size-lg: 18px;
 $calcite-font-size-xl: 20px;
-$calcite-font-size-xxl: 24px; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-font-size-2xl\` instead.
+$calcite-font-size-xxl: 24px; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-font-size-2xl\` instead.
 $calcite-font-size-2xl: 24px;
 $calcite-font-size-relative-xs: 0.625rem;
 $calcite-font-size-relative-sm: 0.75rem;
@@ -36356,68 +36356,68 @@ $calcite-font-line-height-4xl: 3rem;
 $calcite-font-line-height-5xl: 4rem;
 $calcite-font-line-height-6xl: 4rem;
 $calcite-font-line-height-7xl: 5rem;
-$calcite-font-letter-spacing-tight: -0.4px; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-$calcite-font-letter-spacing-normal: 0; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-$calcite-font-letter-spacing-wide: 0.4px; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-$calcite-font-paragraph-spacing-normal: 4px; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-$calcite-font-text-decoration-none: none; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-$calcite-font-text-decoration-underline: underline; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-$calcite-font-text-case-none: none; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-$calcite-font-text-case-uppercase: uppercase; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-$calcite-font-text-case-lowercase: lowercase; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-$calcite-font-text-case-capitalize: capitalize; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
+$calcite-font-letter-spacing-tight: -0.4px; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+$calcite-font-letter-spacing-normal: 0; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+$calcite-font-letter-spacing-wide: 0.4px; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+$calcite-font-paragraph-spacing-normal: 4px; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+$calcite-font-text-decoration-none: none; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+$calcite-font-text-decoration-underline: underline; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+$calcite-font-text-case-none: none; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+$calcite-font-text-case-uppercase: uppercase; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+$calcite-font-text-case-lowercase: lowercase; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+$calcite-font-text-case-capitalize: capitalize; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
 $calcite-opacity-disabled: 0.5;
 $calcite-opacity-light: 0.4;
 $calcite-opacity-half: 0.5;
 $calcite-opacity-dark: 0.85;
 $calcite-opacity-full: 1;
-$calcite-size-fixed-xxxs: 2px; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-$calcite-size-fixed-xxs: 4px; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-$calcite-size-fixed-xs: 6px; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-$calcite-size-fixed-sm: 8px; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-$calcite-size-fixed-sm-plus: 10px; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-4xs\` instead.
-$calcite-size-fixed-md: 12px; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-3xs\` instead.
-$calcite-size-fixed-md-plus: 14px; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-2xs\` instead.
-$calcite-size-fixed-lg: 16px; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-xs\` instead.
-$calcite-size-fixed-xl: 20px; // Deprecated in v3.0.0, removal target v6.0.0 - No longer needed.
-$calcite-size-fixed-xxl: 24px; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-sm\` instead.
-$calcite-size-fixed-xxxl: 32px; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-size-md\` instead.
+$calcite-size-fixed-xxxs: 2px; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+$calcite-size-fixed-xxs: 4px; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+$calcite-size-fixed-xs: 6px; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+$calcite-size-fixed-sm: 8px; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+$calcite-size-fixed-sm-plus: 10px; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-4xs\` instead.
+$calcite-size-fixed-md: 12px; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-3xs\` instead.
+$calcite-size-fixed-md-plus: 14px; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-2xs\` instead.
+$calcite-size-fixed-lg: 16px; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-xs\` instead.
+$calcite-size-fixed-xl: 20px; // Deprecated in v3.0.0, removal target v5.0.0 - No longer needed.
+$calcite-size-fixed-xxl: 24px; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-sm\` instead.
+$calcite-size-fixed-xxxl: 32px; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-size-md\` instead.
 $calcite-size-px: 1px;
 $calcite-size-4xs: 0.625rem;
-$calcite-size-xxxs: 0.75rem; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-3xs\` instead.
+$calcite-size-xxxs: 0.75rem; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-3xs\` instead.
 $calcite-size-3xs: 0.75rem;
-$calcite-size-xxs: 0.875rem; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-2xs\` instead.
+$calcite-size-xxs: 0.875rem; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-2xs\` instead.
 $calcite-size-2xs: 0.875rem;
 $calcite-size-xs: 1rem;
 $calcite-size-sm: 1.5rem;
 $calcite-size-md: 2rem;
 $calcite-size-lg: 2.75rem;
 $calcite-size-xl: 3rem;
-$calcite-size-xxl: 4rem; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-2xl\` instead.
+$calcite-size-xxl: 4rem; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-2xl\` instead.
 $calcite-size-2xl: 4rem;
-$calcite-size-xxxl: 6rem; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-size-3xl\` instead.
+$calcite-size-xxxl: 6rem; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-size-3xl\` instead.
 $calcite-size-3xl: 6rem;
-$calcite-spacing-fixed-xxs: 4px; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-2xs\` instead.
-$calcite-spacing-fixed-xs: 6px; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-xs\` instead.
-$calcite-spacing-fixed-sm: 8px; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-sm\` instead.
-$calcite-spacing-fixed-md: 12px; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-md\` instead.
-$calcite-spacing-fixed-lg: 14px; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-md-plus\` instead.
-$calcite-spacing-fixed-xl: 16px; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-lg\` instead.
-$calcite-spacing-fixed-xxl: 20px; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-xl\` instead.
-$calcite-spacing-fixed-xxxl: 32px; // Deprecated in v3.0.0, removal target v6.0.0 - Use \`--calcite-space-3xl\` instead.
-$calcite-spacing-none: 0; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-none\` instead.
-$calcite-spacing-px: 1px; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-px\` instead.
-$calcite-spacing-base: 2px; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-base\` instead.
-$calcite-spacing-xxs: 0.25rem; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-2xs\` instead.
-$calcite-spacing-xs: 0.375rem; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-xs\` instead.
-$calcite-spacing-sm: 0.5rem; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-sm\` instead.
-$calcite-spacing-sm-plus: 0.625rem; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-sm-plus\` instead.
-$calcite-spacing-md: 0.75rem; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-md\` instead.
-$calcite-spacing-md-plus: 0.875rem; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-md-plus\` instead.
-$calcite-spacing-lg: 1rem; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-lg\` instead.
-$calcite-spacing-xl: 1.25rem; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-xl\` instead.
-$calcite-spacing-xxl: 1.5rem; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-2xl\` instead.
-$calcite-spacing-xxxl: 2rem; // Deprecated in v5.0.0, removal target v6.0.0 - Use \`--calcite-space-3xl\` instead.
+$calcite-spacing-fixed-xxs: 4px; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-2xs\` instead.
+$calcite-spacing-fixed-xs: 6px; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-xs\` instead.
+$calcite-spacing-fixed-sm: 8px; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-sm\` instead.
+$calcite-spacing-fixed-md: 12px; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-md\` instead.
+$calcite-spacing-fixed-lg: 14px; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-md-plus\` instead.
+$calcite-spacing-fixed-xl: 16px; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-lg\` instead.
+$calcite-spacing-fixed-xxl: 20px; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-xl\` instead.
+$calcite-spacing-fixed-xxxl: 32px; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-space-3xl\` instead.
+$calcite-spacing-none: 0; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-none\` instead.
+$calcite-spacing-px: 1px; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-px\` instead.
+$calcite-spacing-base: 2px; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-base\` instead.
+$calcite-spacing-xxs: 0.25rem; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-2xs\` instead.
+$calcite-spacing-xs: 0.375rem; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-xs\` instead.
+$calcite-spacing-sm: 0.5rem; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-sm\` instead.
+$calcite-spacing-sm-plus: 0.625rem; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-sm-plus\` instead.
+$calcite-spacing-md: 0.75rem; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-md\` instead.
+$calcite-spacing-md-plus: 0.875rem; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-md-plus\` instead.
+$calcite-spacing-lg: 1rem; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-lg\` instead.
+$calcite-spacing-xl: 1.25rem; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-xl\` instead.
+$calcite-spacing-xxl: 1.5rem; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-2xl\` instead.
+$calcite-spacing-xxxl: 2rem; // Deprecated in v4.0.0, removal target v5.0.0 - Use \`--calcite-space-3xl\` instead.
 $calcite-space-none: 0;
 $calcite-space-px: 1px;
 $calcite-space-base: 2px;


### PR DESCRIPTION
**Related Issue:** #12829

## Summary

- updates all core and semantic token deprecation descriptions to reference design-tokens package versions instead of component package versions

### How component package versions map to design-tokens package versions:
```
components  /  design-tokens
     3.0.0  /  3.0.0
     3.1.0  /  3.0.0
     3.2.0  /  3.1.0
     3.3.0  /  3.2.0
     5.0.0  /  4.0.0
     6.0.0  /  5.0.0
```