### PR TITLE
fix(input-number): trigger validation error when supported non-numeric characters are entered in a way that produces an invalid number value

### DIFF
--- a/packages/components/src/components/input-number/input-number.e2e.ts
+++ b/packages/components/src/components/input-number/input-number.e2e.ts
@@ -1789,6 +1789,13 @@ describe("calcite-input-number", () => {
       validation: true,
     });
 
+    formAssociated("calcite-input-number", {
+      testValue: "-",
+      submitsOnEnter: true,
+      inputType: "number",
+      validation: true,
+    });
+
     testPostValidationFocusing("calcite-input-number");
 
     testHiddenInputSyncing("calcite-input-number");

--- a/packages/components/src/components/input-number/input-number.tsx
+++ b/packages/components/src/components/input-number/input-number.tsx
@@ -480,10 +480,12 @@ export class InputNumber
     if (!inputValue) {
       return;
     }
+    // TODO: figure out other invalid values to check for
     if (inputValue !== this.value && ["-", ".", "e", "E", ","].includes(inputValue)) {
       event.preventDefault();
       event.stopPropagation();
-      // TODO: trigger validation error
+      this.status = "invalid";
+      this.validationIcon = true;
     }
   }
 
@@ -889,7 +891,9 @@ export class InputNumber
     this.userChangedValue = origin === "user" && this.value !== newValue;
 
     if (newValue) {
-      this.status = isValidNumber(newValue) ? "valid" : "invalid";
+      const valid = isValidNumber(newValue);
+      this.status = valid ? "valid" : "invalid";
+      this.validationIcon = !valid;
     }
 
     // don't sanitize the start of negative/decimal numbers, but

--- a/packages/components/src/components/input-number/input-number.tsx
+++ b/packages/components/src/components/input-number/input-number.tsx
@@ -475,6 +475,18 @@ export class InputNumber
 
   //#region Private Methods
 
+  onFormSubmit(event: SubmitEvent): void {
+    const inputValue = this.childNumberRef?.value.value;
+    if (!inputValue) {
+      return;
+    }
+    if (inputValue !== this.value && ["-", ".", "e", "E", ","].includes(inputValue)) {
+      event.preventDefault();
+      event.stopPropagation();
+      // TODO: trigger validation error
+    }
+  }
+
   private stopNudging() {
     window.clearInterval(this.nudgeNumberValueIntervalId);
   }
@@ -875,6 +887,11 @@ export class InputNumber
     this.setPreviousNumberValue(previousValue ?? this.value);
     this.previousValueOrigin = origin;
     this.userChangedValue = origin === "user" && this.value !== newValue;
+
+    if (newValue) {
+      this.status = isValidNumber(newValue) ? "valid" : "invalid";
+    }
+
     // don't sanitize the start of negative/decimal numbers, but
     // don't set value to an invalid number
     const validNewValue = ["-", "."].includes(newValue) ? "" : newValue;

--- a/packages/components/src/utils/form.tsx
+++ b/packages/components/src/utils/form.tsx
@@ -123,6 +123,9 @@ export interface FormComponent<T = any> extends FormOwner {
   /** Hook for components to provide custom form reset behavior. */
   onFormReset?: () => void;
 
+  /** Hook for components to provide custom form submit behavior. */
+  onFormSubmit?: (event: SubmitEvent) => void;
+
   /**
    * Hook for components to sync _extra_ props on the hidden input form element used for form-submitting.
    *
@@ -153,6 +156,7 @@ function isCheckable(component: FormComponent): component is CheckableFormCompon
 }
 
 const onFormResetMap = new WeakMap<HTMLElement, FormComponent["onFormReset"]>();
+const onFormSubmitMap = new WeakMap<HTMLElement, FormComponent["onFormSubmit"]>();
 const formComponentSet = new WeakSet<HTMLElement>();
 
 /**
@@ -371,6 +375,11 @@ export function connectForm<T>(component: FormComponent<T>): void {
   const boundOnFormReset = onFormReset.bind(component);
   associatedForm.addEventListener("reset", boundOnFormReset);
   onFormResetMap.set(component.el, boundOnFormReset);
+
+  const boundOnFormSubmit = onFormSubmit.bind(component);
+  associatedForm.addEventListener("submit", boundOnFormSubmit);
+  onFormSubmitMap.set(component.el, boundOnFormSubmit);
+
   formComponentSet.add(el);
 }
 
@@ -410,6 +419,10 @@ function onFormReset<T>(this: FormComponent<T>): void {
   this.onFormReset?.();
 }
 
+function onFormSubmit(event: SubmitEvent): void {
+  this.onFormSubmit?.(event);
+}
+
 /**
  * Helper to tear down form interactions on disconnectedCallback.
  *
@@ -425,6 +438,11 @@ export function disconnectForm<T>(component: FormComponent<T>): void {
   const boundOnFormReset = onFormResetMap.get(el);
   formEl.removeEventListener("reset", boundOnFormReset);
   onFormResetMap.delete(el);
+
+  const boundOnFormSubmit = onFormSubmitMap.get(el);
+  formEl.removeEventListener("submit", boundOnFormSubmit);
+  onFormSubmitMap.delete(el);
+
   component.formEl = null;
   formComponentSet.delete(el);
 }


### PR DESCRIPTION
**Related Issue:** #10406 

## Summary

This PR fixes an issue where entering the non-numeric allowed characters (`-`, `,`, `.`, `e`, `E`) was not triggering a validation error state.
