### PR TITLE
fix(popover): implement missing `extraContainers` parameter on `updateFocusTrapElements()`

### DIFF
--- a/packages/components/src/components/popover/popover.tsx
+++ b/packages/components/src/components/popover/popover.tsx
@@ -272,9 +272,16 @@ export class Popover extends LitElement implements FloatingUIComponent {
     return this.focusSetter(() => this.el, options);
   }
 
-  /** Updates the element(s) that are used within the focus-trap of the component. */
+  /**
+   * Updates the element(s) that are included in the component's focus-trap.
+   *
+   * @param extraContainers - Additional elements to include in the focus trap. This is useful for including elements that may have related parts rendered outside the main focus trapping element.
+   */
   @method()
-  async updateFocusTrapElements(): Promise<void> {
+  async updateFocusTrapElements(
+    extraContainers?: FocusTrapOptions["extraContainers"],
+  ): Promise<void> {
+    this.focusTrap.setExtraContainers(extraContainers);
     this.focusTrap.updateContainerElements();
   }
 


### PR DESCRIPTION
**Related Issue:** #13807

## Summary
Unlike Sheet and Dialog, Popover's `updateFocusTrapElements()` method never had the `extraContainers` parameter implemented. This PR adds the parameter as an option and calls the `setExtraContainers()` method with the passed value.
