### PR TITLE
ci(actions): sync all current assignees to new Monday column

### DIFF
--- a/.github/scripts/support/monday.js
+++ b/.github/scripts/support/monday.js
@@ -65,7 +65,7 @@ module.exports = function Monday(issue, core, updateIssueBody) {
   /** @typedef {object} MondayColumn
    * @property {string} id - The Monday.com column ID
    * @property {string} title - The Monday.com column title. Used for logging, not critical to functionality
-   * @property {"dropdown" | "comma"} [type] - The type of the column, used for special handling
+   * @property {"multiMutable" | "multiAppendable"} [type] - The type of the column, used for special handling
    */
   /** @type {Record<string, MondayColumn>} */
   const mondayColumns = {
@@ -73,21 +73,21 @@ module.exports = function Monday(issue, core, updateIssueBody) {
     title: { id: "name", title: "Item" },
     issueNumber: { id: "numeric_mknk2xhh", title: "Issue Number" },
     link: { id: "link", title: "GH Link" },
-    designers: { id: "people", title: "Designer", type: "comma" },
+    designers: { id: "people", title: "Designer", type: "multiAppendable" },
     developers: {
       id: "multiple_person_mkt920b0",
       title: "Developer",
-      type: "comma",
+      type: "multiAppendable",
     },
     productEngineers: {
       id: "multiple_person_mkt9pzj9",
       title: "Verified by",
-      type: "comma",
+      type: "multiAppendable",
     },
     allAssignees: {
       id: "multiple_person_mm0pwfy",
       title: "Github Assignee",
-      type: "comma",
+      type: "multiAppendable",
     },
     status: { id: "dup__of_overall_status__1", title: "Status" },
     date: { id: "date6", title: "Milestone" },
@@ -95,9 +95,9 @@ module.exports = function Monday(issue, core, updateIssueBody) {
     typeDropdown: {
       id: "dropdown_mkwhjde2",
       title: "Issue Type",
-      type: "dropdown",
+      type: "multiMutable",
     },
-    product: { id: "dropdown_mkwzz3b", title: "Esri Team", type: "dropdown" },
+    product: { id: "dropdown_mkwzz3b", title: "Esri Team", type: "multiMutable" },
     designEstimate: { id: "color_mkrbg2b9", title: "Design Estimate" },
     devEstimate: { id: "numeric_mkswahrw", title: "Dev Estimate" },
     designIssue: { id: "color_mkswbke0", title: "Design Issue" },
@@ -705,16 +705,16 @@ module.exports = function Monday(issue, core, updateIssueBody) {
   }
 
   /**
-   * Add or remove a label from a DropdownValues object. Creates a new object if none exists.
+   * Add or remove a label from a multiMutable object. Creates a new object if none exists.
    * @private
    * @param {MondayLabel} labelInfo - The label information
    * @param {("add" | "remove")} action - The action to perform: "add" or "remove"
-   * @returns {{ labels: string[] } | string} - The updated dropdown object or an empty string if no labels remain
+   * @returns {{ labels: string[] } | string} - The updated multiMutable object or an empty string if no labels remain
    */
-  function createDropdownValues(labelInfo, action) {
+  function updateMultiMutableValue(labelInfo, action) {
     if (action !== "add" && action !== "remove") {
       throw new Error(
-        `Invalid action "${action}" in createDropdownValues. Use "add" or "remove".`,
+        `Invalid action "${action}" in updateMultiMutableValue. Use "add" or "remove".`,
       );
     }
 
@@ -737,15 +737,15 @@ module.exports = function Monday(issue, core, updateIssueBody) {
       }
     }
 
-    const dropdownSet = new Set(existingLabels);
-    const present = dropdownSet.has(labelValue);
+    const valueSet = new Set(existingLabels);
+    const present = valueSet.has(labelValue);
     if (action === "add" && !present) {
-      dropdownSet.add(labelValue);
+      valueSet.add(labelValue);
     } else if (action === "remove" && present) {
-      dropdownSet.delete(labelValue);
+      valueSet.delete(labelValue);
     }
 
-    return dropdownSet.size ? { labels: Array.from(dropdownSet) } : "";
+    return valueSet.size ? { labels: Array.from(valueSet) } : "";
   }
 
   /**
@@ -773,17 +773,17 @@ module.exports = function Monday(issue, core, updateIssueBody) {
       return;
     }
 
-    const isDropdown = info.column.type === "dropdown";
+    const isMultiMutable= info.column.type === "multiMutable";
     if (action === "add") {
       setColumnValue(
         info.column,
-        isDropdown ? createDropdownValues(info, "add") : info.value,
+        isMultiMutable ? updateMultiMutableValue(info, "add") : info.value,
         logParams,
       );
     } else if (info.clearable) {
       setColumnValue(
         info.column,
-        isDropdown ? createDropdownValues(info, "remove") : "",
+        isMultiMutable ? updateMultiMutableValue(info, "remove") : "",
         logParams,
       );
     }
@@ -912,7 +912,7 @@ module.exports = function Monday(issue, core, updateIssueBody) {
 
   /**
    * Set a specific column value in columnUpdates.
-   * If `column.type` is `"comma"` and `value` is not empty, the value will be appended via comma-separation to any existing values in the column.
+   * If `column.type` is `"multiAppendable"` and `value` is not empty, the value will be appended via comma-separation to any existing values in the column.
    * @param {MondayColumn} column
    * @param {ColumnValue} value
    * @param {import('@actions/core').AnnotationProperties} [logParams] - Optional logging parameters
@@ -933,7 +933,7 @@ module.exports = function Monday(issue, core, updateIssueBody) {
 
     const existingValue = columnUpdates[column.id];
     const newValue =
-      column.type === "comma" && value !== ""
+      column.type === "multiAppendable" && value !== ""
         ? existingValue
           ? `${existingValue}, ${value}`
           : `${value}`

--- a/.github/scripts/support/monday.js
+++ b/.github/scripts/support/monday.js
@@ -85,8 +85,8 @@ module.exports = function Monday(issue, core, updateIssueBody) {
       type: "comma",
     },
     allAssignees: {
-      id: "multiple_person_mkznz4wx",
-      title: "People",
+      id: "multiple_person_mm0pwfy",
+      title: "Github Assignee",
       type: "comma",
     },
     status: { id: "dup__of_overall_status__1", title: "Status" },

--- a/.github/scripts/support/monday.js
+++ b/.github/scripts/support/monday.js
@@ -65,7 +65,7 @@ module.exports = function Monday(issue, core, updateIssueBody) {
   /** @typedef {object} MondayColumn
    * @property {string} id - The Monday.com column ID
    * @property {string} title - The Monday.com column title. Used for logging, not critical to functionality
-   * @property {"dropdown"} [type] - The type of the column, used for special handling
+   * @property {"dropdown" | "comma"} [type] - The type of the column, used for special handling
    */
   /** @type {Record<string, MondayColumn>} */
   const mondayColumns = {
@@ -73,9 +73,22 @@ module.exports = function Monday(issue, core, updateIssueBody) {
     title: { id: "name", title: "Item" },
     issueNumber: { id: "numeric_mknk2xhh", title: "Issue Number" },
     link: { id: "link", title: "GH Link" },
-    designers: { id: "people", title: "Designer" },
-    developers: { id: "multiple_person_mkt920b0", title: "Developer" },
-    productEngineers: { id: "multiple_person_mkt9pzj9", title: "Verified by" },
+    designers: { id: "people", title: "Designer", type: "comma" },
+    developers: {
+      id: "multiple_person_mkt920b0",
+      title: "Developer",
+      type: "comma",
+    },
+    productEngineers: {
+      id: "multiple_person_mkt9pzj9",
+      title: "Verified by",
+      type: "comma",
+    },
+    allAssignees: {
+      id: "multiple_person_mkznz4wx",
+      title: "People",
+      type: "comma",
+    },
     status: { id: "dup__of_overall_status__1", title: "Status" },
     date: { id: "date6", title: "Milestone" },
     priority: { id: "priority", title: "Priority" },
@@ -484,11 +497,8 @@ module.exports = function Monday(issue, core, updateIssueBody) {
       role = mondayColumns.developers;
     }
 
-    if (columnUpdates[role.id]) {
-      columnUpdates[role.id] += `, ${info.id}`;
-    } else {
-      columnUpdates[role.id] = `${info.id}`;
-    }
+    setColumnValue(role, info.id);
+    setColumnValue(mondayColumns.allAssignees, info.id);
     core.notice(
       `Added assignee "${person.login}" to "${role.title}" column.`,
       logParams,
@@ -840,8 +850,8 @@ module.exports = function Monday(issue, core, updateIssueBody) {
     }
 
     if (assignees.length) {
-      assignees.forEach((person) => addAssignee(person));
       setAssignedStatus();
+      handleAssignees();
     }
 
     if (issueMilestone) {
@@ -901,7 +911,8 @@ module.exports = function Monday(issue, core, updateIssueBody) {
   }
 
   /**
-   * Set a specific column value in columnUpdates
+   * Set a specific column value in columnUpdates.
+   * If `column.type` is `"comma"` and `value` is not empty, the value will be appended via comma-separation to any existing values in the column.
    * @param {MondayColumn} column
    * @param {ColumnValue} value
    * @param {import('@actions/core').AnnotationProperties} [logParams] - Optional logging parameters
@@ -920,7 +931,15 @@ module.exports = function Monday(issue, core, updateIssueBody) {
       return;
     }
 
-    columnUpdates[column.id] = value;
+    const existingValue = columnUpdates[column.id];
+    const newValue =
+      column.type === "comma" && value !== ""
+        ? existingValue
+          ? `${existingValue}, ${value}`
+          : `${value}`
+        : value;
+
+    columnUpdates[column.id] = newValue;
     core.notice(
       value === ""
         ? `Cleared "${column.title}" column.`
@@ -1013,6 +1032,10 @@ module.exports = function Monday(issue, core, updateIssueBody) {
       .forEach((role) => {
         setColumnValue(role, "");
       });
+
+    if (!assignees.length) {
+      setColumnValue(mondayColumns.allAssignees, "");
+    }
   }
 
   /**


### PR DESCRIPTION
**Related Issue:** #13746

## Summary
Syncs all current assignees to **one** new Monday.com column, adding a new column type of `"comma"` and refactoring the `setColumnValue` function to support it.

This allows more functionality/filtering capabilities in Monday.com, as it creates a 1-1 mapping of the current assignee state in GitHub.
