### PR TITLE
fix(input-date-picker): calendar is displayed on open in Safari

### DIFF
--- a/packages/components/src/components/input-date-picker/input-date-picker.scss
+++ b/packages/components/src/components/input-date-picker/input-date-picker.scss
@@ -65,8 +65,8 @@
   }
 }
 
-:host([composite-layer]) {
-  transform: translateZ(0);
+:host([composited-layer]) {
+  will-change: transform;
 }
 
 @function get-trailing-text-input-padding($chevron-spacing) {

--- a/packages/components/src/components/input-date-picker/input-date-picker.scss
+++ b/packages/components/src/components/input-date-picker/input-date-picker.scss
@@ -65,6 +65,10 @@
   }
 }
 
+:host([composite-layer]) {
+  transform: translateZ(0);
+}
+
 @function get-trailing-text-input-padding($chevron-spacing) {
   @return calc(var(--calcite-internal-date-picker-toggle-spacing) + $chevron-spacing);
 }

--- a/packages/components/src/components/input-date-picker/input-date-picker.tsx
+++ b/packages/components/src/components/input-date-picker/input-date-picker.tsx
@@ -73,6 +73,7 @@ import type { Input } from "../input/input";
 import { useSetFocus } from "../../controllers/useSetFocus";
 import { useInteractive } from "../../controllers/useInteractive";
 import { useTopLayer } from "../../controllers/useTopLayer";
+import { getUserAgentString } from "../../utils/browser";
 import { styles } from "./input-date-picker.scss";
 import { CSS, ICONS, IDS, POSITION } from "./resources";
 import T9nStrings from "./assets/t9n/messages.en.json";
@@ -195,6 +196,11 @@ export class InputDatePicker
   //#endregion
 
   //#region Public Properties
+
+  /** When `range` is `true`, specifies the number of calendars displayed.
+   * @internal
+   */
+  @property({ reflect: true }) compositeLayer = false;
 
   /** When `range` is `true`, specifies the number of calendars displayed. */
   @property({ type: Number, reflect: true }) calendars: 1 | 2 = 2;
@@ -470,6 +476,10 @@ export class InputDatePicker
   }
 
   async load(): Promise<void> {
+    // Workaround for Safari issue https://github.com/Esri/calcite-design-system/issues/13795
+    // ⚠️ browser-sniffing is not a best practice and should be avoided ⚠️
+    this.compositeLayer = /safari/i.test(getUserAgentString());
+
     this.handleDateTimeFormatChange();
     await this.loadLocaleData();
     this.onMinChanged(this.min);

--- a/packages/components/src/components/input-date-picker/input-date-picker.tsx
+++ b/packages/components/src/components/input-date-picker/input-date-picker.tsx
@@ -197,7 +197,8 @@ export class InputDatePicker
 
   //#region Public Properties
 
-  /** When `range` is `true`, specifies the number of calendars displayed.
+  /** When `true`, the component's content is rendered in its own compositor layer.
+   *  This prop is automatically set to `true` when the component detects it's being rendered in Safari.
    * @internal
    */
   @property({ reflect: true }) compositedLayer = false;
@@ -726,7 +727,7 @@ export class InputDatePicker
   }
 
   private blurHandler(): void {
-    this.open = false;
+    // this.open = false;
   }
 
   private commitValue(): void {

--- a/packages/components/src/components/input-date-picker/input-date-picker.tsx
+++ b/packages/components/src/components/input-date-picker/input-date-picker.tsx
@@ -200,7 +200,7 @@ export class InputDatePicker
   /** When `range` is `true`, specifies the number of calendars displayed.
    * @internal
    */
-  @property({ reflect: true }) compositeLayer = false;
+  @property({ reflect: true }) compositedLayer = false;
 
   /** When `range` is `true`, specifies the number of calendars displayed. */
   @property({ type: Number, reflect: true }) calendars: 1 | 2 = 2;
@@ -478,7 +478,7 @@ export class InputDatePicker
   async load(): Promise<void> {
     // Workaround for Safari issue https://github.com/Esri/calcite-design-system/issues/13795
     // ⚠️ browser-sniffing is not a best practice and should be avoided ⚠️
-    this.compositeLayer = /safari/i.test(getUserAgentString());
+    this.compositedLayer = /safari/i.test(getUserAgentString());
 
     this.handleDateTimeFormatChange();
     await this.loadLocaleData();


### PR DESCRIPTION
**Related Issue:** #13795 

## Summary

Fix calendar display in safari when input-date-picker is open in top-layer.

After analyzing layers in both Chrome(144) & Safari (26.2), date-picker wrapper container (`.calendar-wrapper`) is stacked behind an unkown node in Safari where as in Chrome it is promoted to the front. This workaround solution allows input-date-picker to have it own compositor-layer and promote it

There are other workaround solutions such as enabling `top-layer-disabled` or forcing repaint of input-date-picker as mentioned here https://codepen.io/jcfranco/pen/qENgLLZ?editors=1111. Disabling top-layer requires complex z-index handling from user & forcing repaint is not seamless in terms of UX. 

Related articles: https://web.dev/articles/stick-to-compositor-only-properties-and-manage-layer-count
