### PR TITLE
only prevent Escape default when value is non-empty

### DIFF
--- a/packages/components/src/components/filter/filter.e2e.ts
+++ b/packages/components/src/components/filter/filter.e2e.ts
@@ -100,6 +100,49 @@ describe("clear button", () => {
       expect(await filter.getProperty("value")).toBe("");
       expect(await filterIsFocused()).toBe(true);
     });
+
+    it("should prevent default on Escape when value is not empty", async () => {
+      const filter = await page.find("calcite-filter");
+      await filter.callMethod("setFocus");
+      await page.waitForChanges();
+
+      await page.keyboard.type("developer");
+      await page.waitForChanges();
+
+      const wasDefaultPrevented = await page.evaluate(() => {
+        const input = document
+          .querySelector("calcite-filter")
+          .shadowRoot.querySelector("calcite-input")
+          .shadowRoot.querySelector<HTMLInputElement>("input");
+
+        const event = new KeyboardEvent("keydown", { key: "Escape", bubbles: true, composed: true, cancelable: true });
+
+        return !input.dispatchEvent(event);
+      });
+
+      expect(wasDefaultPrevented).toBe(true);
+      expect(await filter.getProperty("value")).toBe("");
+    });
+
+    it("should not prevent default on Escape when value is empty", async () => {
+      const filter = await page.find("calcite-filter");
+      await filter.callMethod("setFocus");
+      await page.waitForChanges();
+
+      const wasDefaultPrevented = await page.evaluate(() => {
+        const input = document
+          .querySelector("calcite-filter")
+          .shadowRoot.querySelector("calcite-input")
+          .shadowRoot.querySelector<HTMLInputElement>("input");
+
+        const event = new KeyboardEvent("keydown", { key: "Escape", bubbles: true, composed: true, cancelable: true });
+
+        return !input.dispatchEvent(event);
+      });
+
+      expect(wasDefaultPrevented).toBe(false);
+      expect(await filter.getProperty("value")).toBe("");
+    });
   });
 });
 

--- a/packages/components/src/components/filter/filter.tsx
+++ b/packages/components/src/components/filter/filter.tsx
@@ -191,8 +191,10 @@ export class Filter extends LitElement {
     }
 
     if (event.key === "Escape") {
-      this.clear();
-      event.preventDefault();
+      if (this.value.length > 0) {
+        this.clear();
+        event.preventDefault();
+      }
     }
 
     if (event.key === "Enter") {


### PR DESCRIPTION
**Related Issue:** #13967 

## Summary
Before: Escape always called preventDefault(), even when filter value was empty.
After: preventDefault() is only called when filter has a non-empty value.

Tests: Added/updated E2E coverage for both cases:
prevents default when value is non-empty
does not prevent default when value is empty