### PR TITLE
feat(action-group): add `calciteActionGroupChange` for selection tracking

### DIFF
--- a/packages/components/src/components/action-group/action-group.browser.e2e.tsx
+++ b/packages/components/src/components/action-group/action-group.browser.e2e.tsx
@@ -41,6 +41,14 @@ describe("defaults", () => {
         propertyName: "scale",
         defaultValue: "m",
       },
+      {
+        propertyName: "selectionMode",
+        defaultValue: "none",
+      },
+      {
+        propertyName: "selectedActions",
+        defaultValue: [],
+      },
     ],
   );
 });
@@ -131,5 +139,29 @@ describe("actions have no ARIA attributes when selectionMode is 'none'", () => {
 
     expect(action2.getAttribute("aria-checked")).toBeNull();
     expect(action2.getAttribute("role")).toBeNull();
+  });
+});
+
+describe.only("calciteActionGroupChange event", () => {
+  it("fires when selection changes", async () => {
+    const { el } = await mount<"calcite-action-group">(
+      <calcite-action-group selection-mode="single">
+        <calcite-action icon="plus" text="Add" />
+        <calcite-action icon="save" text="Save" />
+      </calcite-action-group>,
+    );
+
+    let changeCount = 0;
+    el.addEventListener("calciteActionGroupChange", () => {
+      changeCount += 1;
+    });
+
+    const [action1, action2] = el.querySelectorAll("calcite-action");
+
+    await userEvent.click(action1);
+    expect(changeCount).toBe(1);
+
+    await userEvent.click(action2);
+    expect(changeCount).toBe(2);
   });
 });

--- a/packages/components/src/components/action-group/action-group.browser.e2e.tsx
+++ b/packages/components/src/components/action-group/action-group.browser.e2e.tsx
@@ -142,7 +142,7 @@ describe("actions have no ARIA attributes when selectionMode is 'none'", () => {
   });
 });
 
-describe("calciteActionGroupChange event", () => {
+describe("selection change event and selectedActions state", () => {
   it("fires when selection changes", async () => {
     const { el } = await mount<"calcite-action-group">(
       <calcite-action-group selection-mode="single">
@@ -163,5 +163,27 @@ describe("calciteActionGroupChange event", () => {
 
     await userEvent.click(action2);
     expect(changeCount).toBe(2);
+  });
+
+  it("tracks active actions based on selection", async () => {
+    const { el } = await mount<"calcite-action-group">(
+      <calcite-action-group selection-mode="single">
+        <calcite-action icon="plus" text="Add" />
+        <calcite-action icon="save" text="Save" />
+      </calcite-action-group>,
+    );
+
+    const [action1, action2] = el.querySelectorAll("calcite-action");
+
+    await userEvent.click(action1);
+    expect(el.selectedActions).toHaveLength(1);
+    expect(el.selectedActions[0]).toBe(action1);
+
+    await userEvent.click(action2);
+    expect(el.selectedActions).toHaveLength(1);
+    expect(el.selectedActions[0]).toBe(action2);
+
+    await userEvent.click(action2);
+    expect(el.selectedActions).toHaveLength(0);
   });
 });

--- a/packages/components/src/components/action-group/action-group.browser.e2e.tsx
+++ b/packages/components/src/components/action-group/action-group.browser.e2e.tsx
@@ -142,7 +142,7 @@ describe("actions have no ARIA attributes when selectionMode is 'none'", () => {
   });
 });
 
-describe.only("calciteActionGroupChange event", () => {
+describe("calciteActionGroupChange event", () => {
   it("fires when selection changes", async () => {
     const { el } = await mount<"calcite-action-group">(
       <calcite-action-group selection-mode="single">

--- a/packages/components/src/components/action-group/action-group.tsx
+++ b/packages/components/src/components/action-group/action-group.tsx
@@ -136,7 +136,11 @@ export class ActionGroup extends LitElement {
    */
   @property({ reflect: true }) topLayerDisabled = false;
 
-  /** Specifies the active actions in the group. */
+  /**
+   * Specifies the active actions in the group.
+   *
+   * @readonly
+   */
   @property() selectedActions: Action["el"][] = [];
 
   //#endregion

--- a/packages/components/src/components/action-group/action-group.tsx
+++ b/packages/components/src/components/action-group/action-group.tsx
@@ -17,6 +17,7 @@ import { FlipPlacement, LogicalPlacement, OverlayPositioning } from "../../utils
 import { slotChangeHasAssignedElement } from "../../utils/dom";
 import { useT9n } from "../../controllers/useT9n";
 import type { Action } from "../action/action";
+import { isAction } from "../action/resources";
 import type { ActionMenu } from "../action-menu/action-menu";
 import { useSetFocus } from "../../controllers/useSetFocus";
 import { SelectionMode } from "../interfaces";
@@ -161,6 +162,12 @@ export class ActionGroup extends LitElement {
   /** Fires when the component's content area is expanded. */
   calciteActionGroupExpand = createEvent({ cancelable: false });
 
+  /** Fires after an action's active state changes. */
+  calciteActionGroupChange = createEvent<{
+    action: Action["el"];
+    active: boolean;
+  }>({ cancelable: false });
+
   //#endregion
 
   //#region Lifecycle
@@ -204,23 +211,21 @@ export class ActionGroup extends LitElement {
 
   private setActiveAction(index: number, active: Action["el"]): void {
     if (this.selectionMode === "multiple") {
-      active.active = !active.active;
-      this.setActionAriaChecked(active, active.active);
+      const nextActive = !active.active;
+      this.updateAction(active, nextActive);
+      this.calciteActionGroupChange.emit({ action: active, active: nextActive });
       return;
     }
     if (this.selectionMode === "single") {
-      this.actions.forEach((action, i) => {
-        action.active = i === index && !action.active;
-        this.setActionAriaChecked(action, action.active);
-      });
+      const nextActive = !active.active;
+      this.actions.forEach((action, i) => this.updateAction(action, i === index && nextActive));
+      this.calciteActionGroupChange.emit({ action: active, active: nextActive });
       return;
     }
     if (this.selectionMode === "single-persist") {
       if (!this.actions[index].active) {
-        this.actions.forEach((action, i) => {
-          action.active = i === index;
-          this.setActionAriaChecked(action, action.active);
-        });
+        this.actions.forEach((action, i) => this.updateAction(action, i === index));
+        this.calciteActionGroupChange.emit({ action: active, active: true });
       }
       return;
     }
@@ -235,8 +240,11 @@ export class ActionGroup extends LitElement {
   }
 
   private handleActionClick(event: MouseEvent): void {
-    const target = event.target as Action["el"];
-    if (!target) {
+    const target = event
+      .composedPath()
+      .find((element): element is Action["el"] => isAction(element as Element));
+
+    if (!target || target.disabled) {
       return;
     }
     const index = this.actions.indexOf(target);
@@ -276,6 +284,11 @@ export class ActionGroup extends LitElement {
         }
       });
     }
+  }
+
+  private updateAction(action: Action["el"], isActive: boolean): void {
+    action.active = isActive;
+    this.setActionAriaChecked(action, isActive);
   }
 
   //#endregion

--- a/packages/components/src/components/action-group/action-group.tsx
+++ b/packages/components/src/components/action-group/action-group.tsx
@@ -203,10 +203,11 @@ export class ActionGroup extends LitElement {
         }
       }
 
-      this.selectedActions =
+      this.updateSelectedActions(
         this.selectionMode === "none"
           ? []
-          : (this.actions?.filter((action) => action.active) ?? []);
+          : (this.actions?.filter((action) => action.active) ?? []),
+      );
     }
 
     if (changes.has("expanded")) {
@@ -231,21 +232,21 @@ export class ActionGroup extends LitElement {
     if (this.selectionMode === "multiple") {
       const nextActive = !active.active;
       this.updateAction(active, nextActive);
-      this.selectedActions = this.actions.filter((action) => action.active);
+      this.updateSelectedActions(this.actions.filter((action) => action.active));
       this.calciteActionGroupChange.emit();
       return;
     }
     if (this.selectionMode === "single") {
       const nextActive = !active.active;
       this.actions.forEach((action, i) => this.updateAction(action, i === index && nextActive));
-      this.selectedActions = this.actions.filter((action) => action.active);
+      this.updateSelectedActions(this.actions.filter((action) => action.active));
       this.calciteActionGroupChange.emit();
       return;
     }
     if (this.selectionMode === "single-persist") {
       if (!this.actions[index].active) {
         this.actions.forEach((action, i) => this.updateAction(action, i === index));
-        this.selectedActions = [active];
+        this.updateSelectedActions([active]);
         this.calciteActionGroupChange.emit();
       }
       return;
@@ -310,6 +311,19 @@ export class ActionGroup extends LitElement {
   private updateAction(action: Action["el"], isActive: boolean): void {
     action.active = isActive;
     this.setActionAriaChecked(action, isActive);
+  }
+
+  private updateSelectedActions(nextSelected: Action["el"][]): void {
+    const currentSelected = this.selectedActions;
+
+    if (currentSelected.length === nextSelected.length) {
+      const matches = currentSelected.every((action, index) => action === nextSelected[index]);
+      if (matches) {
+        return;
+      }
+    }
+
+    this.selectedActions = nextSelected;
   }
 
   //#endregion

--- a/packages/components/src/components/action-group/action-group.tsx
+++ b/packages/components/src/components/action-group/action-group.tsx
@@ -136,6 +136,9 @@ export class ActionGroup extends LitElement {
    */
   @property({ reflect: true }) topLayerDisabled = false;
 
+  /** Specifies the active actions in the group. */
+  @property() selectedActions: Action["el"][] = [];
+
   //#endregion
 
   //#region Public Methods
@@ -163,10 +166,7 @@ export class ActionGroup extends LitElement {
   calciteActionGroupExpand = createEvent({ cancelable: false });
 
   /** Fires after an action's active state changes. */
-  calciteActionGroupChange = createEvent<{
-    action: Action["el"];
-    active: boolean;
-  }>({ cancelable: false });
+  calciteActionGroupChange = createEvent({ cancelable: false });
 
   //#endregion
 
@@ -189,6 +189,20 @@ export class ActionGroup extends LitElement {
       } else if (this.selectionMode === "none") {
         this.clearActionAriaAttributes();
       }
+
+      if (this.selectionMode === "single" || this.selectionMode === "single-persist") {
+        const selected = this.actions?.filter((action) => action.active) ?? [];
+        if (selected.length > 1) {
+          this.actions.forEach((action) =>
+            this.updateAction(action, action === selected[selected.length - 1]),
+          );
+        }
+      }
+
+      this.selectedActions =
+        this.selectionMode === "none"
+          ? []
+          : (this.actions?.filter((action) => action.active) ?? []);
     }
 
     if (changes.has("expanded")) {
@@ -213,19 +227,22 @@ export class ActionGroup extends LitElement {
     if (this.selectionMode === "multiple") {
       const nextActive = !active.active;
       this.updateAction(active, nextActive);
-      this.calciteActionGroupChange.emit({ action: active, active: nextActive });
+      this.selectedActions = this.actions.filter((action) => action.active);
+      this.calciteActionGroupChange.emit();
       return;
     }
     if (this.selectionMode === "single") {
       const nextActive = !active.active;
       this.actions.forEach((action, i) => this.updateAction(action, i === index && nextActive));
-      this.calciteActionGroupChange.emit({ action: active, active: nextActive });
+      this.selectedActions = this.actions.filter((action) => action.active);
+      this.calciteActionGroupChange.emit();
       return;
     }
     if (this.selectionMode === "single-persist") {
       if (!this.actions[index].active) {
         this.actions.forEach((action, i) => this.updateAction(action, i === index));
-        this.calciteActionGroupChange.emit({ action: active, active: true });
+        this.selectedActions = [active];
+        this.calciteActionGroupChange.emit();
       }
       return;
     }


### PR DESCRIPTION
**Related Issue:** [#13962](https://github.com/Esri/calcite-design-system/issues/13962)

## Summary
Adds a custom change event `calciteActionGroupChange` to ensure correct active timing for consistent selection behavior.