### PR TITLE
fix(filter): do not cancel `Escape` when value is empty

### DIFF
--- a/packages/components/src/components/filter/filter.browser.e2e.tsx
+++ b/packages/components/src/components/filter/filter.browser.e2e.tsx
@@ -1,4 +1,5 @@
-import { describe } from "vitest";
+import { describe, expect, it } from "vitest";
+import { userEvent } from "vitest/browser";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import {
   cancelable,
@@ -75,4 +76,42 @@ describe("translation support", () => {
 
 describe("disabled", () => {
   disabled(() => mount("calcite-filter"));
+});
+
+describe("clear", () => {
+  it("should clear the value and prevent default on Escape only when value is not empty", async () => {
+    const { el } = await mount("calcite-filter");
+    el.items = [{ foo: "bar" }];
+
+    const input = el.shadowRoot
+      .querySelector("calcite-input")
+      .shadowRoot.querySelector<HTMLInputElement>("input");
+    const escapeDefaultPrevented: boolean[] = [];
+
+    el.addEventListener("keydown", (event) => {
+      if (event.key === "Escape") {
+        escapeDefaultPrevented.push(event.defaultPrevented);
+      }
+    });
+
+    await userEvent.click(input);
+
+    expect(el.value).toBe("");
+    await userEvent.keyboard("{Escape}");
+    expect(escapeDefaultPrevented[0]).toBe(false);
+    expect(el.value).toBe("");
+
+    await userEvent.click(input);
+    await userEvent.type(input, "something");
+
+    expect(el.value).toBe("something");
+
+    await userEvent.keyboard("{Escape}");
+    expect(escapeDefaultPrevented[1]).toBe(true);
+    expect(el.value).toBe("");
+
+    await userEvent.keyboard("{Escape}");
+    expect(escapeDefaultPrevented[2]).toBe(false);
+    expect(el.value).toBe("");
+  });
 });

--- a/packages/components/src/components/filter/filter.tsx
+++ b/packages/components/src/components/filter/filter.tsx
@@ -191,8 +191,10 @@ export class Filter extends LitElement {
     }
 
     if (event.key === "Escape") {
-      this.clear();
-      event.preventDefault();
+      if (this.value.length > 0) {
+        this.clear();
+        event.preventDefault();
+      }
     }
 
     if (event.key === "Enter") {


### PR DESCRIPTION
**Related Issue:** #13967 

## Summary
Before: Escape always called preventDefault(), even when filter value was empty.
After: preventDefault() is only called when filter has a non-empty value.

The test confirms [calcite-filter] only prevents Escape by default when it has a non-empty value (to clear it), but does not prevent Escape when already empty.