### PR TITLE
ci(chromatic): restore baseline snapshot sync

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -28,6 +28,8 @@ jobs:
           working-dir: packages/components
           storybook-build-dir: docs
           chromatic-diff-threshold: ${{ secrets.CHROMATIC_DIFF_THRESHOLD }}
+
+          # the following are needed when using the pull_request event, see https://www.chromatic.com/docs/github-actions/#recommended-configuration-for-build-events:~:text=If%20you%20decide,the%20checkout%20step%3A
           chromatic-branch: ${{ github.event.pull_request.head.ref || github.ref_name }}
           chromatic-sha: ${{ github.event.pull_request.head.sha || github.ref }}
           chromatic-slug: ${{ github.repository }}

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,4 +1,5 @@
 name: Chromatic
+
 on:
   push:
     branches: [rc, dev]
@@ -18,38 +19,18 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - uses: actions/setup-node@v6
+      - uses: ./.github/actions/chromatic/build-storybook
+
+      - uses: ./.github/actions/chromatic/publish
         with:
-          node-version-file: package.json
-
-      - name: Build storybook
-        env:
-          STORYBOOK_SCREENSHOT_TEST_BUILD: true
-          CHROMATIC_DIFF_THRESHOLD: ${{ secrets.CHROMATIC_DIFF_THRESHOLD }}
-        run: |
-          npm install
-          npm --workspace="packages/design-tokens" run build
-          npm --workspace="packages/tailwind-preset" run build
-          npm --workspace="packages/ui-icons" run build
-          npm --workspace="packages/components" run build-storybook
-
-      - name: Publish to Chromatic
-        uses: chromaui/action@v13
-        with:
-          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          zip: true
-          exitOnceUploaded: true
-          autoAcceptChanges: ${{ github.base_ref || github.ref_name }}
-          workingDir: packages/components
-          storybookBuildDir: docs
-        env:
-          STORYBOOK_SCREENSHOT_TEST_BUILD: true
-          CHROMATIC_DIFF_THRESHOLD: ${{ secrets.CHROMATIC_DIFF_THRESHOLD }}
-
-          # the following are needed when using the pull_request event, see https://www.chromatic.com/docs/github-actions/#recommended-configuration-for-build-events:~:text=If%20you%20decide,the%20checkout%20step%3A
-          CHROMATIC_BRANCH: ${{ github.event.pull_request.head.ref || github.ref_name }}
-          CHROMATIC_SHA: ${{ github.event.pull_request.head.sha || github.ref }}
-          CHROMATIC_SLUG: ${{ github.repository }}
+          project-token: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          auto-accept-changes: ${{ github.base_ref || github.ref_name }}
+          working-dir: packages/components
+          storybook-build-dir: docs
+          chromatic-diff-threshold: ${{ secrets.CHROMATIC_DIFF_THRESHOLD }}
+          chromatic-branch: ${{ github.event.pull_request.head.ref || github.ref_name }}
+          chromatic-sha: ${{ github.event.pull_request.head.sha || github.ref }}
+          chromatic-slug: ${{ github.repository }}
 
   run-push:
     if: github.event_name == 'push'
@@ -59,33 +40,15 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v6
-        with:
-          node-version-file: package.json
+      - uses: ./.github/actions/chromatic/build-storybook
 
-      - name: Build storybook
-        env:
-          STORYBOOK_SCREENSHOT_TEST_BUILD: true
-          CHROMATIC_DIFF_THRESHOLD: ${{ secrets.CHROMATIC_DIFF_THRESHOLD }}
-        run: |
-          npm install
-          npm --workspace="packages/design-tokens" run build
-          npm --workspace="packages/tailwind-preset" run build
-          npm --workspace="packages/ui-icons" run build
-          npm --workspace="packages/components" run build-storybook
-
-      - name: Publish baseline to Chromatic
-        uses: chromaui/action@v13
+      - uses: ./.github/actions/chromatic/publish
         with:
-          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          zip: true
-          exitOnceUploaded: true
-          autoAcceptChanges: ${{ github.ref_name }}
-          workingDir: packages/components
-          storybookBuildDir: docs
-        env:
-          STORYBOOK_SCREENSHOT_TEST_BUILD: true
-          CHROMATIC_DIFF_THRESHOLD: ${{ secrets.CHROMATIC_DIFF_THRESHOLD }}
+          project-token: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          auto-accept-changes: ${{ github.ref_name }}
+          working-dir: packages/components
+          storybook-build-dir: docs
+          chromatic-diff-threshold: ${{ secrets.CHROMATIC_DIFF_THRESHOLD }}
 
   skip:
     if: contains(github.event.pull_request.labels.*.name, 'skip visual snapshots')

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -19,9 +19,9 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - uses: ./.github/actions/chromatic/build-storybook
+      - uses: ./.github/workflows/chromatic/build-storybook
 
-      - uses: ./.github/actions/chromatic/publish
+      - uses: ./.github/workflows/chromatic/publish
         with:
           project-token: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           auto-accept-changes: ${{ github.base_ref || github.ref_name }}
@@ -40,9 +40,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: ./.github/actions/chromatic/build-storybook
+      - uses: ./.github/workflows/chromatic/build-storybook
 
-      - uses: ./.github/actions/chromatic/publish
+      - uses: ./.github/workflows/chromatic/publish
         with:
           project-token: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           auto-accept-changes: ${{ github.ref_name }}

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,13 +1,14 @@
 name: Chromatic
 on:
+  push:
+    branches: [rc, dev]
   pull_request:
     branches: [rc, dev]
-    types: [opened, labeled, synchronize]
+    types: [labeled]
+
 jobs:
-  run:
+  run-pr:
     if: >
-      github.event_name == 'pull_request' &&
-      github.event.action == 'labeled' &&
       github.event.label.name == 'pr ready for visual snapshots' &&
       !contains(github.event.pull_request.labels.*.name, 'skip visual snapshots')
     runs-on: ubuntu-latest
@@ -15,10 +16,12 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
+
       - uses: actions/setup-node@v6
         with:
           node-version-file: package.json
+
       - name: Build storybook
         env:
           STORYBOOK_SCREENSHOT_TEST_BUILD: true
@@ -29,6 +32,7 @@ jobs:
           npm --workspace="packages/tailwind-preset" run build
           npm --workspace="packages/ui-icons" run build
           npm --workspace="packages/components" run build-storybook
+
       - name: Publish to Chromatic
         uses: chromaui/action@v13
         with:
@@ -40,14 +44,51 @@ jobs:
           storybookBuildDir: docs
         env:
           STORYBOOK_SCREENSHOT_TEST_BUILD: true
-          CHROMATIC_BRANCH: ${{ github.event.pull_request.head.ref || github.ref_name }}
           CHROMATIC_DIFF_THRESHOLD: ${{ secrets.CHROMATIC_DIFF_THRESHOLD }}
+
+          # the following are needed when using the pull_request event, see https://www.chromatic.com/docs/github-actions/#recommended-configuration-for-build-events:~:text=If%20you%20decide,the%20checkout%20step%3A
+          CHROMATIC_BRANCH: ${{ github.event.pull_request.head.ref || github.ref_name }}
           CHROMATIC_SHA: ${{ github.event.pull_request.head.sha || github.ref }}
           CHROMATIC_SLUG: ${{ github.repository }}
+
+  run-push:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: package.json
+
+      - name: Build storybook
+        env:
+          STORYBOOK_SCREENSHOT_TEST_BUILD: true
+          CHROMATIC_DIFF_THRESHOLD: ${{ secrets.CHROMATIC_DIFF_THRESHOLD }}
+        run: |
+          npm install
+          npm --workspace="packages/design-tokens" run build
+          npm --workspace="packages/tailwind-preset" run build
+          npm --workspace="packages/ui-icons" run build
+          npm --workspace="packages/components" run build-storybook
+
+      - name: Publish baseline to Chromatic
+        uses: chromaui/action@v13
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          zip: true
+          exitOnceUploaded: true
+          autoAcceptChanges: ${{ github.ref_name }}
+          workingDir: packages/components
+          storybookBuildDir: docs
+        env:
+          STORYBOOK_SCREENSHOT_TEST_BUILD: true
+          CHROMATIC_DIFF_THRESHOLD: ${{ secrets.CHROMATIC_DIFF_THRESHOLD }}
+
   skip:
-    if: >
-      github.event_name == 'pull_request' &&
-      contains(github.event.pull_request.labels.*.name, 'skip visual snapshots')
+    if: contains(github.event.pull_request.labels.*.name, 'skip visual snapshots')
     runs-on: ubuntu-latest
     steps:
       - name: Skip Chromatic
@@ -57,4 +98,4 @@ jobs:
           context: UI Tests
           description: Chromatic run skipped
           state: success
-          sha: ${{ github.event.pull_request.head.sha || github.sha }}
+          sha: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/chromatic/build-storybook/action.yml
+++ b/.github/workflows/chromatic/build-storybook/action.yml
@@ -1,0 +1,19 @@
+name: Build Storybook
+description: Install dependencies and build Storybook output
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@v6
+      with:
+        node-version-file: package.json
+
+    - shell: bash
+      env:
+        STORYBOOK_SCREENSHOT_TEST_BUILD: true
+      run: |
+        npm install
+        npm --workspace="packages/design-tokens" run build
+        npm --workspace="packages/tailwind-preset" run build
+        npm --workspace="packages/ui-icons" run build
+        npm --workspace="packages/components" run build-storybook

--- a/.github/workflows/chromatic/publish/action.yml
+++ b/.github/workflows/chromatic/publish/action.yml
@@ -1,0 +1,38 @@
+name: Publish to Chromatic
+description: Publish a prebuilt Storybook to Chromatic
+
+inputs:
+  project-token:
+    required: true
+  auto-accept-changes:
+    required: false
+  working-dir:
+    required: true
+  storybook-build-dir:
+    required: true
+  chromatic-diff-threshold:
+    required: false
+  chromatic-branch:
+    required: false
+  chromatic-sha:
+    required: false
+  chromatic-slug:
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - uses: chromaui/action@v13
+      with:
+        projectToken: ${{ inputs.project-token }}
+        zip: true
+        exitOnceUploaded: true
+        autoAcceptChanges: ${{ inputs.auto-accept-changes }}
+        workingDir: ${{ inputs.working-dir }}
+        storybookBuildDir: ${{ inputs.storybook-build-dir }}
+      env:
+        STORYBOOK_SCREENSHOT_TEST_BUILD: true
+        CHROMATIC_DIFF_THRESHOLD: ${{ inputs.chromatic-diff-threshold }}
+        CHROMATIC_BRANCH: ${{ inputs.chromatic-branch }}
+        CHROMATIC_SHA: ${{ inputs.chromatic-sha }}
+        CHROMATIC_SLUG: ${{ inputs.chromatic-slug }}


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

This restores updates to the Chromatic snapshot baseline (removed in https://github.com/Esri/calcite-design-system/pull/13606/), which led to hard to read Chromatic builds. 

This also adds composite actions in order to reduce duplication between changes caused by PRs (e.g., `ready for visual snapshots`/`skip visual snapshots`) and commits to `dev` (after PR install).