### PR TITLE
fix(stepper): only stepper content should expand to available height

### DIFF
--- a/packages/components/src/components/stepper/stepper.browser.e2e.tsx
+++ b/packages/components/src/components/stepper/stepper.browser.e2e.tsx
@@ -1,6 +1,7 @@
 import { h } from "@arcgis/lumina";
 import { describe, expect, it } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
+import { page } from "vitest/browser";
 import { defaults, reflects, hidden, renders, t9n } from "../../tests/commonTests/browser";
 import { CSS as STEPPER_ITEM_CSS } from "../stepper-item/resources";
 
@@ -83,11 +84,11 @@ describe("translation support", () => {
   t9n(() => mount("calcite-stepper"));
 });
 
-describe("layout regressions", () => {
+describe("fixed height sizing", () => {
   it.each(["horizontal", "horizontal-single"] as const)(
     "content row is larger than header row when fixed height is set (%s) (#12786)",
     async (layout) => {
-      const { el, component } = await mount<"calcite-stepper">(
+      await mount<"calcite-stepper">(
         <calcite-stepper layout={layout} style={{ blockSize: "20rem", inlineSize: "40rem" }}>
           <calcite-stepper-item heading="Step 1" selected>
             <div style={{ blockSize: "100%" }}>Step 1 content</div>
@@ -98,19 +99,14 @@ describe("layout regressions", () => {
         </calcite-stepper>,
       );
 
-      await component.updateComplete;
+      const selectedItem = page.getBySelector("calcite-stepper-item[selected]");
+      const header = selectedItem.getBySelector(`.${STEPPER_ITEM_CSS.stepperItemHeader}`);
+      const content = selectedItem.getBySelector(`.${STEPPER_ITEM_CSS.stepperItemContent}`);
 
-      const selectedItem = el.querySelector("calcite-stepper-item[selected]")!;
-      const header = selectedItem.shadowRoot!.querySelector<HTMLElement>(
-        `.${STEPPER_ITEM_CSS.stepperItemHeader}`,
-      )!;
-      const content = selectedItem.shadowRoot!.querySelector<HTMLElement>(
-        `.${STEPPER_ITEM_CSS.stepperItemContent}`,
-      )!;
-      const headerRect = header.getBoundingClientRect();
-      const contentRect = content.getBoundingClientRect();
+      const headerBox = header.element().getBoundingClientRect();
+      const contentBox = content.element().getBoundingClientRect();
 
-      expect(contentRect.height).toBeGreaterThan(headerRect.height);
+      expect(contentBox.height).toBeGreaterThan(headerBox.height);
     },
   );
 });

--- a/packages/components/src/components/stepper/stepper.browser.e2e.tsx
+++ b/packages/components/src/components/stepper/stepper.browser.e2e.tsx
@@ -1,7 +1,8 @@
 import { h } from "@arcgis/lumina";
-import { describe } from "vitest";
+import { describe, expect, it } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import { defaults, reflects, hidden, renders, t9n } from "../../tests/commonTests/browser";
+import { CSS as STEPPER_ITEM_CSS } from "../stepper-item/resources";
 
 describe("defaults", () => {
   defaults(
@@ -80,4 +81,36 @@ describe("renders", () => {
 
 describe("translation support", () => {
   t9n(() => mount("calcite-stepper"));
+});
+
+describe("layout regressions", () => {
+  it.each(["horizontal", "horizontal-single"] as const)(
+    "content row is larger than header row when fixed height is set (%s) (#12786)",
+    async (layout) => {
+      const { el, component } = await mount<"calcite-stepper">(
+        <calcite-stepper layout={layout} style={{ blockSize: "20rem", inlineSize: "40rem" }}>
+          <calcite-stepper-item heading="Step 1" selected>
+            <div style={{ blockSize: "100%" }}>Step 1 content</div>
+          </calcite-stepper-item>
+          <calcite-stepper-item heading="Step 2">
+            <div style={{ blockSize: "100%" }}>Step 2 content</div>
+          </calcite-stepper-item>
+        </calcite-stepper>,
+      );
+
+      await component.updateComplete;
+
+      const selectedItem = el.querySelector("calcite-stepper-item[selected]")!;
+      const header = selectedItem.shadowRoot!.querySelector<HTMLElement>(
+        `.${STEPPER_ITEM_CSS.stepperItemHeader}`,
+      )!;
+      const content = selectedItem.shadowRoot!.querySelector<HTMLElement>(
+        `.${STEPPER_ITEM_CSS.stepperItemContent}`,
+      )!;
+      const headerRect = header.getBoundingClientRect();
+      const contentRect = content.getBoundingClientRect();
+
+      expect(contentRect.height).toBeGreaterThan(headerRect.height);
+    },
+  );
 });

--- a/packages/components/src/components/stepper/stepper.scss
+++ b/packages/components/src/components/stepper/stepper.scss
@@ -70,6 +70,7 @@
       "items"
       "content";
     gap: theme("spacing.2") var(--calcite-stepper-bar-gap, var(--calcite-internal-stepper-item-spacing-unit-s));
+    grid-template-rows: auto 1fr;
   }
 }
 

--- a/packages/components/src/components/stepper/stepper.scss
+++ b/packages/components/src/components/stepper/stepper.scss
@@ -65,7 +65,7 @@
   .container {
     display: grid;
     // grid-templates-columns are dynamically generated
-    // grid-templates-rows are dynamically generated
+    // grid-templates-areas are dynamically generated
     grid-template-areas:
       "items"
       "content";

--- a/packages/components/src/components/stepper/stepper.stories.ts
+++ b/packages/components/src/components/stepper/stepper.stories.ts
@@ -358,7 +358,7 @@ export const verticalLayoutFullWidth = (): string =>
     </calcite-stepper>`;
 
 export const horizontalContentHeight = (): string =>
-  html`<calcite-stepper numbered style=" border: 1px solid red; width: 600px; height: 400px;">
+  html`<calcite-stepper numbered style="border: 1px solid red; width: 600px; height: 400px;">
     <calcite-stepper-item heading="Add info" selected>
       <div style="border: 1px solid green; height: 100%;">
         <calcite-notice width="full" open>
@@ -366,7 +366,7 @@ export const horizontalContentHeight = (): string =>
         </calcite-notice>
       </div>
     </calcite-stepper-item>
-    <calcite-stepper-item heading="Add data"> </calcite-stepper-item>
-    <calcite-stepper-item heading="Add images"> </calcite-stepper-item>
-    <calcite-stepper-item heading="Review"> </calcite-stepper-item>
-  </calcite-stepper> `;
+    <calcite-stepper-item heading="Add data"></calcite-stepper-item>
+    <calcite-stepper-item heading="Add images"></calcite-stepper-item>
+    <calcite-stepper-item heading="Review"></calcite-stepper-item>
+  </calcite-stepper>`;

--- a/packages/components/src/components/stepper/stepper.stories.ts
+++ b/packages/components/src/components/stepper/stepper.stories.ts
@@ -360,10 +360,7 @@ export const verticalLayoutFullWidth = (): string =>
 export const horizontalContentHeight = (): string =>
   html`<calcite-stepper numbered style=" border: 1px solid red; width: 600px; height: 400px;">
     <calcite-stepper-item heading="Add info" selected>
-      <div
-        style="border: 1px solid green;
-        height: 100%;"
-      >
+      <div style="border: 1px solid green; height: 100%;">
         <calcite-notice width="full" open>
           <div slot="title">Step 1 content</div>
         </calcite-notice>

--- a/packages/components/src/components/stepper/stepper.stories.ts
+++ b/packages/components/src/components/stepper/stepper.stories.ts
@@ -361,7 +361,6 @@ export const horizontalContentHeight = (): string =>
   html`<style>
       #stepper {
         border: 1px solid red;
-        height: 100%;
         width: 600px;
         height: 400px;
       }

--- a/packages/components/src/components/stepper/stepper.stories.ts
+++ b/packages/components/src/components/stepper/stepper.stories.ts
@@ -358,34 +358,18 @@ export const verticalLayoutFullWidth = (): string =>
     </calcite-stepper>`;
 
 export const horizontalContentHeight = (): string =>
-  html`<style>
-      #stepper {
-        border: 1px solid red;
-        width: 600px;
-        height: 400px;
-      }
-
-      #stepper-item-1 {
-        border: 1px solid green;
-        height: 100%;
-      }</style
-    ><calcite-stepper numbered id="stepper">
-      <calcite-stepper-item heading="Add info" selected>
-        <div id="stepper-item-1">
-          <calcite-notice width="full" open>
-            <div slot="title">Step 1 content</div>
-          </calcite-notice>
-        </div>
-      </calcite-stepper-item>
-      <calcite-stepper-item heading="Add data"> </calcite-stepper-item>
-      <calcite-stepper-item heading="Add images">
+  html`<calcite-stepper numbered style=" border: 1px solid red; width: 600px; height: 400px;">
+    <calcite-stepper-item heading="Add info" selected>
+      <div
+        style="border: 1px solid green;
+        height: 100%;"
+      >
         <calcite-notice width="full" open>
-          <div slot="title">Step 3 content</div>
+          <div slot="title">Step 1 content</div>
         </calcite-notice>
-      </calcite-stepper-item>
-      <calcite-stepper-item heading="Review">
-        <calcite-notice width="full" open>
-          <div slot="title">Step 4 content</div>
-        </calcite-notice>
-      </calcite-stepper-item>
-    </calcite-stepper> `;
+      </div>
+    </calcite-stepper-item>
+    <calcite-stepper-item heading="Add data"> </calcite-stepper-item>
+    <calcite-stepper-item heading="Add images"> </calcite-stepper-item>
+    <calcite-stepper-item heading="Review"> </calcite-stepper-item>
+  </calcite-stepper> `;

--- a/packages/components/src/components/stepper/stepper.stories.ts
+++ b/packages/components/src/components/stepper/stepper.stories.ts
@@ -356,3 +356,37 @@ export const verticalLayoutFullWidth = (): string =>
       <calcite-stepper-item heading="Rivers" description="The Rivers are calling and I must go" selected></calcite-stepper-item>
       </calcite-stepper-item>
     </calcite-stepper>`;
+
+export const horizontalContentHeight = (): string =>
+  html`<style>
+      #stepper {
+        border: 1px solid red;
+        height: 100%;
+        width: 600px;
+        height: 400px;
+      }
+
+      #stepper-item-1 {
+        border: 1px solid green;
+        height: 100%;
+      }</style
+    ><calcite-stepper numbered id="stepper">
+      <calcite-stepper-item heading="Add info" selected>
+        <div id="stepper-item-1">
+          <calcite-notice width="full" open>
+            <div slot="title">Step 1 content</div>
+          </calcite-notice>
+        </div>
+      </calcite-stepper-item>
+      <calcite-stepper-item heading="Add data"> </calcite-stepper-item>
+      <calcite-stepper-item heading="Add images">
+        <calcite-notice width="full" open>
+          <div slot="title">Step 3 content</div>
+        </calcite-notice>
+      </calcite-stepper-item>
+      <calcite-stepper-item heading="Review">
+        <calcite-notice width="full" open>
+          <div slot="title">Step 4 content</div>
+        </calcite-notice>
+      </calcite-stepper-item>
+    </calcite-stepper> `;


### PR DESCRIPTION
**Related Issue:** #12786

## Summary

This PR addresses #12786 by adjusting the horizontal stepper’s internal grid layout so the header row sizes to its content while the stepper-item content expands to fill the remaining available height.

**Changes:**
- Set the horizontal stepper container grid rows to `auto 1fr` so only content consumes leftover height.
- Add a Storybook story to reproduce/validate horizontal stepper content height behavior.
