### PR TITLE
ci(chromatic): restore running on force-pushes to PRs

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -5,11 +5,13 @@ on:
     branches: [rc, dev]
   pull_request:
     branches: [rc, dev]
-    types: [labeled]
+    types: [labeled, synchronize]
 
 jobs:
   run-pr:
     if: >
+      github.event_name == 'pull_request' &&
+      github.event.action == 'labeled' &&
       github.event.label.name == 'pr ready for visual snapshots' &&
       !contains(github.event.pull_request.labels.*.name, 'skip visual snapshots')
     runs-on: ubuntu-latest
@@ -53,7 +55,9 @@ jobs:
           chromatic-diff-threshold: ${{ secrets.CHROMATIC_DIFF_THRESHOLD }}
 
   skip:
-    if: contains(github.event.pull_request.labels.*.name, 'skip visual snapshots')
+    if: >
+      github.event_name == 'pull_request' &&
+      contains(github.event.pull_request.labels.*.name, 'skip visual snapshots')
     runs-on: ubuntu-latest
     steps:
       - name: Skip Chromatic


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

https://github.com/Esri/calcite-design-system/pull/14000/ unintentionally stopped the Chromatic workflow from running after PR force pushes.

As a result, PRs labeled `skip visual snapshots` can be left with a stuck pending check (`UI Tests`) because no status ever gets reported (e.g., Renovate dep bump PR).