### PR TITLE
ci(actions): add context to `ready for dev`/`spike complete` comments

### DIFF
--- a/.github/scripts/notifyWhenReadyForDev.js
+++ b/.github/scripts/notifyWhenReadyForDev.js
@@ -2,12 +2,12 @@
 // When the "2 - ready for dev" label is added to an issue:
 // 1. Modifies the labels,
 // 2. Updates the assignees and milestone, and
-// 3. Generates a notification comment tagging the manager(s)
+// 3. Generates a notification comment tagging the planner(s)
 // 4. Emits "SyncActionChanges" event to trigger the Monday.com sync
 //
 // The secret is formatted like so: person1, person2, person3
 //
-// Note the script automatically adds the "@" character in to notify the manager(s)
+// Note the script automatically adds the "@" character in to notify the planner(s)
 const {
   labels: { issueWorkflow },
 } = require("./support/resources");
@@ -25,10 +25,10 @@ module.exports = async ({ github, context }) => {
     issue: { number },
   } = payload;
 
-  const { MANAGERS } = process.env;
+  const { PLANNERS } = process.env;
 
   // Add a "@" character to notify the user
-  const calcite_managers = MANAGERS?.split(",").map((v) => " @" + v.trim());
+  const calcite_planners = PLANNERS?.split(",").map((v) => " @" + v.trim());
 
   const issueProps = {
     owner,
@@ -64,10 +64,10 @@ module.exports = async ({ github, context }) => {
     milestone: null,
   });
 
-  // Add a comment to notify the project manager(s)
+  // Add a comment to notify the planner(s)
   await github.rest.issues.createComment({
     ...issueProps,
-    body: `Development can now begin, as design and/or acceptance criteria for the issue have been defined. cc ${calcite_managers}`,
+    body: `Development can now begin, as design and/or acceptance criteria for the issue have been defined. cc ${calcite_planners}`,
   });
 
   await github.rest.actions.createWorkflowDispatch({

--- a/.github/scripts/notifyWhenReadyForDev.js
+++ b/.github/scripts/notifyWhenReadyForDev.js
@@ -2,12 +2,12 @@
 // When the "2 - ready for dev" label is added to an issue:
 // 1. Modifies the labels,
 // 2. Updates the assignees and milestone, and
-// 3. Generates a notification to the Calcite project manager(s)
+// 3. Generates a notification comment tagging the manager(s)
 // 4. Emits "SyncActionChanges" event to trigger the Monday.com sync
 //
 // The secret is formatted like so: person1, person2, person3
 //
-// Note the script automatically adds the "@" character in to notify the project manager(s)
+// Note the script automatically adds the "@" character in to notify the manager(s)
 const {
   labels: { issueWorkflow },
 } = require("./support/resources");
@@ -67,7 +67,7 @@ module.exports = async ({ github, context }) => {
   // Add a comment to notify the project manager(s)
   await github.rest.issues.createComment({
     ...issueProps,
-    body: `cc ${calcite_managers}`,
+    body: `Development can now begin, as design and/or acceptance criteria for the issue have been defined. cc ${calcite_managers}`,
   });
 
   await github.rest.actions.createWorkflowDispatch({

--- a/.github/scripts/notifyWhenSpikeComplete.js
+++ b/.github/scripts/notifyWhenSpikeComplete.js
@@ -2,12 +2,12 @@
 // When the "spike complete" label is added to an issue:
 // 1. Modifies the labels,
 // 2. Updates the assignees and milestone, and
-// 3. Generates a notification comment tagging the manager(s)
+// 3. Generates a notification comment tagging the planner(s)
 // 4. Emits "SyncActionChanges" event to trigger the Monday.com sync
 //
 // The secret is formatted like so: person1, person2, person3
 //
-// Note the script automatically adds the "@" character in to notify the manager(s)
+// Note the script automatically adds the "@" character in to notify the planner(s)
 const {
   labels: { issueWorkflow, planning },
 } = require("./support/resources");
@@ -22,10 +22,10 @@ module.exports = async ({ github, context }) => {
     issue: { number },
   } = payload;
 
-  const { MANAGERS } = process.env;
+  const { PLANNERS } = process.env;
 
   // Add a "@" character to notify the user
-  const calcite_managers = MANAGERS?.split(",").map((v) => " @" + v.trim());
+  const calcite_planners = PLANNERS?.split(",").map((v) => " @" + v.trim());
 
   const issueProps = {
     owner,
@@ -61,10 +61,10 @@ module.exports = async ({ github, context }) => {
     milestone: null,
   });
 
-  // Add a comment to notify the project manager(s)
+  // Add a comment to notify the planner(s)
   await github.rest.issues.createComment({
     ...issueProps,
-    body: `The spike effort has been completed. cc ${calcite_managers}`,
+    body: `The spike effort has been completed. cc ${calcite_planners}`,
   });
 
   await github.rest.actions.createWorkflowDispatch({

--- a/.github/scripts/notifyWhenSpikeComplete.js
+++ b/.github/scripts/notifyWhenSpikeComplete.js
@@ -2,12 +2,12 @@
 // When the "spike complete" label is added to an issue:
 // 1. Modifies the labels,
 // 2. Updates the assignees and milestone, and
-// 3. Generates a notification to the Calcite project manager(s)
+// 3. Generates a notification comment tagging the manager(s)
 // 4. Emits "SyncActionChanges" event to trigger the Monday.com sync
 //
 // The secret is formatted like so: person1, person2, person3
 //
-// Note the script automatically adds the "@" character in to notify the project manager(s)
+// Note the script automatically adds the "@" character in to notify the manager(s)
 const {
   labels: { issueWorkflow, planning },
 } = require("./support/resources");
@@ -64,7 +64,7 @@ module.exports = async ({ github, context }) => {
   // Add a comment to notify the project manager(s)
   await github.rest.issues.createComment({
     ...issueProps,
-    body: `cc ${calcite_managers}`,
+    body: `The spike effort has been completed. cc ${calcite_managers}`,
   });
 
   await github.rest.actions.createWorkflowDispatch({

--- a/.github/workflows/issue-notifications.yml
+++ b/.github/workflows/issue-notifications.yml
@@ -25,7 +25,7 @@ jobs:
         if: github.event.label.name == 'spike complete'
         uses: actions/github-script@v8
         env:
-          MANAGERS: ${{secrets.CALCITE_MANAGERS}}
+          PLANNERS: ${{secrets.CALCITE_PLANNERS}}
         with:
           script: |
             const action = require('${{ github.workspace }}/.github/scripts/notifyWhenSpikeComplete.js')
@@ -35,7 +35,7 @@ jobs:
         if: github.event.label.name == '2 - ready for dev'
         uses: actions/github-script@v8
         env:
-          MANAGERS: ${{secrets.CALCITE_MANAGERS}}
+          PLANNERS: ${{secrets.CALCITE_PLANNERS}}
         with:
           script: |
             const action = require('${{ github.workspace }}/.github/scripts/notifyWhenReadyForDev.js')


### PR DESCRIPTION
**Related Issue:** #13235

## Summary
Adds context to the notification comments created via the `ready for dev` and `spike complete` workflows. 

> [!warning]
The `CALCITE_MANAGERS` secret will need to be updated to `CALCITE_PLANNERS` in GH settings **immediately** after merge to fulfill the issue requirements.
