### PR TITLE
chore: align prerelease versions after patch cherry picks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32272,7 +32272,7 @@
     },
     "packages/components": {
       "name": "@esri/calcite-components",
-      "version": "5.0.3-next.2",
+      "version": "5.1.0-next.2",
       "license": "SEE LICENSE.md",
       "dependencies": {
         "@arcgis/lumina": ">=5.1.0-next.25 <6.0.0",
@@ -32303,11 +32303,11 @@
     },
     "packages/components-react": {
       "name": "@esri/calcite-components-react",
-      "version": "5.0.3-next.2",
+      "version": "5.1.0-next.2",
       "license": "SEE LICENSE.md",
       "dependencies": {
         "@arcgis/lumina": ">=5.1.0-next.25 <6.0.0",
-        "@esri/calcite-components": "5.0.3-next.2",
+        "@esri/calcite-components": "5.1.0-next.2",
         "@lit/react": "^1.0.8",
         "lit": "^3.3.0"
       },

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/calcite-components-react",
-  "version": "5.0.3-next.2",
+  "version": "5.1.0-next.2",
   "description": "A set of React components that wrap calcite components",
   "homepage": "https://developers.arcgis.com/calcite-design-system/",
   "repository": {
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@arcgis/lumina": ">=5.1.0-next.25 <6.0.0",
-    "@esri/calcite-components": "5.0.3-next.2",
+    "@esri/calcite-components": "5.1.0-next.2",
     "@lit/react": "^1.0.8",
     "lit": "^3.3.0"
   },

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/calcite-components",
-  "version": "5.0.3-next.2",
+  "version": "5.1.0-next.2",
   "description": "Web Components for Esri's Calcite Design System.",
   "homepage": "https://developers.arcgis.com/calcite-design-system/",
   "repository": {


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

This resolves an issue caused by carrying over the `package.json` version from cherry picked patch commits into `dev`.

When a patch release is cherry picked onto `dev`, the version in `package.json` can move backwards relative to existing prereleases. As a result, the next prerelease bump may reuse a version that has already been published, leading to a deployment failure.

### Example

- After `5.0.0` is released  
  - First fix on `dev` ➡️ `5.0.1-next.0`  
  - First feature on `dev` ➡️ `5.1.0-next.0`

- After `5.0.1` is released and cherry picked onto `dev`  
  - First fix on `dev` ➡️ `5.0.2-next.0`  
  - First feature on `dev` ➡️ `5.1.0-next.0` ❌ already published → prerelease deployment fails