### PR TITLE
docs: clarify action-bar position property

### DIFF
--- a/packages/components/src/components/action-bar/action-bar.tsx
+++ b/packages/components/src/components/action-bar/action-bar.tsx
@@ -210,8 +210,8 @@ export class ActionBar extends LitElement {
   /**
    * When `expandDisabled` is `false`, specifies the expand toggle's chevron direction, where:
    *
-   * `"start"` points the expand toggle's chevron away from the start of the component when `expanded` is `false`, and
-   * `"end"` points the expand toggle's chevron away from the end of the component when `expanded` is `false`.
+   * `"start"` positions the expand toggle's chevron away from the start of the component when `expanded` is `false`, and
+   * `"end"` positions the expand toggle's chevron away from the end of the component when `expanded` is `false`.
    *
    * When `expanded` is `true`, the chevron direction is reversed.
    */

--- a/packages/components/src/components/action-bar/action-bar.tsx
+++ b/packages/components/src/components/action-bar/action-bar.tsx
@@ -210,7 +210,7 @@ export class ActionBar extends LitElement {
   /**
    * When `expandDisabled` is `false`, specifies the expand toggle's chevron direction, where:
    *
-   * `"start"` points the expand toggle's chevron away from the start of the component when `expanded` is `false`.
+   * `"start"` points the expand toggle's chevron away from the start of the component when `expanded` is `false`, and
    * `"end"` points the expand toggle's chevron away from the end of the component when `expanded` is `false`.
    *
    * When `expanded` is `true`, the chevron direction is reversed.

--- a/packages/components/src/components/action-bar/action-bar.tsx
+++ b/packages/components/src/components/action-bar/action-bar.tsx
@@ -207,7 +207,14 @@ export class ActionBar extends LitElement {
    */
   @property({ reflect: true }) overlayPositioning: OverlayPositioning = "absolute";
 
-  /** Specifies the position of the component depending on the element's `dir` property. */
+  /**
+   * When `expandDisabled` is `false`, specifies the expand toggle's chevron direction, where:
+   *
+   * `"start"` points the expand toggle's chevron away from the start of the component when `expanded` is `false`.
+   * `"end"` points the expand toggle's chevron away from the end of the component when `expanded` is `false`.
+   *
+   * When `expanded` is `true`, the chevron direction is reversed.
+   */
   @property({ reflect: true }) position: Extract<"start" | "end", Position>;
 
   /** Specifies the size of the expand `calcite-action`. */


### PR DESCRIPTION
**Related Issue:** #9832

## Summary
Clarify `action-bar`'s `position` property and added value descriptions.