### PR TITLE
fix(stepper, stepper-item): fix box sizing to prevent scrollbar from being displayed

### DIFF
--- a/packages/components/src/components/stepper-item/stepper-item.scss
+++ b/packages/components/src/components/stepper-item/stepper-item.scss
@@ -113,6 +113,7 @@
 
 :host .stepper-item-content,
 :host .stepper-item-header {
+  box-sizing: border-box;
   padding-block: var(--calcite-internal-stepper-item-spacing-unit-l);
   padding-inline-end: var(--calcite-internal-stepper-item-spacing-unit-m);
   text-align: start;
@@ -437,7 +438,7 @@
 }
 
 :host([layout="horizontal-single"]) .stepper-item-header {
-  @apply border-none box-border
+  @apply border-none
   me-0;
   inline-size: 100%;
   padding-inline: calc(var(--calcite-internal-stepper-action-inline-size) + 0.5rem);

--- a/packages/components/src/components/stepper/stepper.stories.ts
+++ b/packages/components/src/components/stepper/stepper.stories.ts
@@ -370,3 +370,15 @@ export const horizontalContentHeight = (): string =>
     <calcite-stepper-item heading="Add images"></calcite-stepper-item>
     <calcite-stepper-item heading="Review"></calcite-stepper-item>
   </calcite-stepper>`;
+
+export const horizontalBoxSizing = (): string =>
+  html`<calcite-stepper numbered>
+    <calcite-stepper-item heading="Add info" selected>
+      <calcite-notice width="full" open>
+        <div slot="title">Step 1 content</div>
+      </calcite-notice>
+    </calcite-stepper-item>
+    <calcite-stepper-item heading="Add data"> </calcite-stepper-item>
+    <calcite-stepper-item heading="Add images"> </calcite-stepper-item>
+    <calcite-stepper-item heading="Review"> </calcite-stepper-item>
+  </calcite-stepper>`;


### PR DESCRIPTION
**Related Issue:** #12782

## Summary

This PR addresses Issue #12782 by preventing redundant horizontal scrollbars in `calcite-stepper` when a selected `calcite-stepper-item` displays content, by ensuring the item header/content sizing accounts for padding.

**Changes:**
- Apply `box-sizing: border-box` to `.stepper-item-header` and `.stepper-item-content` to avoid width overflow from padding.
- Remove the now-redundant `box-border` utility from the horizontal-single header styling.
- Add a Storybook story to reproduce/guard against the scrollbar regression.