### PR TITLE
ci(release): prefer `dev` when version is greater than release

### DIFF
--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -50,7 +50,7 @@ jobs:
 
           release_version="$(node -p "require('./packages/components/package.json').version")"
 
-          git checkout -b ci/cherry-pick-release-commit origin/dev
+          git checkout -B ci/cherry-pick-release-commit origin/dev
 
           dev_commit="$(git rev-parse HEAD)"
           dev_version="$(node -p "require('./packages/components/package.json').version")"
@@ -63,15 +63,12 @@ jobs:
           )
 
           if ! git cherry-pick --no-commit "$release_commit"; then
-            conflicts="$()"
+            conflicts="$(git diff --name-only --diff-filter=U)"
 
-            if git diff --name-only --diff-filter=U |
+            if echo "$conflicts" |
               grep -qvE 'packages/.*/(CHANGELOG\.md|package\.json)'; then
-              echo "Aborting cherry-pick due to unexpected conflicts."
-              git cherry-pick --abort
-              exit 1
-            else
-              echo "Cherry-pick failed with no detected conflicts. Investigation needed."
+              echo "Aborting cherry-pick due to unexpected conflicts:"
+              echo "$conflicts"
               git cherry-pick --abort
               exit 1
             fi
@@ -81,8 +78,8 @@ jobs:
           git checkout "$kept_commit" -- packages/*/package.json
           git add packages/*/CHANGELOG.md packages/*/package.json
 
-          if git diff --name-only --diff-filter=U then
-            echo "Aborting cherry-pick due to unexpected conflicts.
+          if git diff --name-only --diff-filter=U | grep -q .; then
+            echo "Aborting cherry-pick, as there are still conflicts after auto-resolution."
             git cherry-pick --abort
             exit 1
           fi

--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -65,7 +65,7 @@ jobs:
           if ! git cherry-pick --no-commit "$release_commit"; then
             conflicts="$(git diff --name-only --diff-filter=U)"
 
-            if echo "$conflicts" |
+            if echo [ -n "$conflicts" ] && echo "$conflicts" |
               grep -qvE 'packages/.*/(CHANGELOG\.md|package\.json)'; then
               echo "Aborting cherry-pick due to unexpected conflicts:"
               echo "$conflicts"

--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -52,19 +52,40 @@ jobs:
 
           git checkout -b ci/cherry-pick-release-commit origin/dev
 
+          dev_commit="$(git rev-parse HEAD)"
           dev_version="$(node -p "require('./packages/components/package.json').version")"
-          kept_version=$(
+
+          kept_commit=$(
             node -p "
               const semver=require('semver');
-              semver.gt('$dev_version','$release_version') ? '--ours' : '--theirs'
+              semver.gt('$dev_version','$release_version') ? '$dev_commit' : '$release_commit'
             "
           )
 
-          git cherry-pick --no-commit "$release_commit" || true
+          if ! git cherry-pick --no-commit "$release_commit"; then
+            conflicts="$()"
 
-          git checkout --theirs -- packages/*/CHANGELOG.md
-          git checkout "$kept_version" -- packages/*/package.json
+            if git diff --name-only --diff-filter=U |
+              grep -qvE 'packages/.*/(CHANGELOG\.md|package\.json)'; then
+              echo "Aborting cherry-pick due to unexpected conflicts."
+              git cherry-pick --abort
+              exit 1
+            else
+              echo "Cherry-pick failed with no detected conflicts. Investigation needed."
+              git cherry-pick --abort
+              exit 1
+            fi
+          fi
+
+          git checkout "$release_commit" -- packages/*/CHANGELOG.md
+          git checkout "$kept_commit" -- packages/*/package.json
           git add packages/*/CHANGELOG.md packages/*/package.json
+
+          if git diff --name-only --diff-filter=U then
+            echo "Aborting cherry-pick due to unexpected conflicts.
+            git cherry-pick --abort
+            exit 1
+          fi
 
           git commit -C "$release_commit"
           git push -u origin HEAD

--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -48,22 +48,25 @@ jobs:
           npm run publish:latest
           npm run util:upload-release-assets -- "${{toJSON(steps.release.outputs.paths_released)}}"
 
+          release_version="$(node -p "require('./packages/components/package.json').version")"
+
           git checkout -b ci/cherry-pick-release-commit origin/dev
-          dev_head="$(git rev-parse HEAD)"
 
-          if ! git cherry-pick "$release_commit"; then
-            git checkout --theirs -- packages/*/CHANGELOG.md
-            git checkout --ours -- packages/*/package.json
-            git cherry-pick --continue
-          fi
+          dev_version="$(node -p "require('./packages/components/package.json').version")"
+          kept_version=$(
+            node -p "
+              const semver=require('semver');
+              semver.gt('$dev_version','$release_version') ? '--ours' : '--theirs'
+            "
+          )
 
-          git restore --source="$dev_head" -- packages/*/package.json
-          git add -- packages/*/package.json
+          git cherry-pick --no-commit "$release_commit" || true
 
-          if ! git diff --cached --quiet; then
-            git commit --amend --no-edit
-          fi
+          git checkout --theirs -- packages/*/CHANGELOG.md
+          git checkout "$kept_version" -- packages/*/package.json
+          git add packages/*/CHANGELOG.md packages/*/package.json
 
+          git commit -C "$release_commit"
           git push -u origin HEAD
           gh pr create --fill --head "ci/cherry-pick-release-commit" --base "dev" \
             --label "skip visual snapshots"

--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -65,7 +65,7 @@ jobs:
           if ! git cherry-pick --no-commit "$release_commit"; then
             conflicts="$(git diff --name-only --diff-filter=U)"
 
-            if echo [ -n "$conflicts" ] && echo "$conflicts" |
+            if [ -n "$conflicts" ] && echo "$conflicts" |
               grep -qvE 'packages/.*/(CHANGELOG\.md|package\.json)'; then
               echo "Aborting cherry-pick due to unexpected conflicts:"
               echo "$conflicts"

--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -49,15 +49,19 @@ jobs:
           npm run util:upload-release-assets -- "${{toJSON(steps.release.outputs.paths_released)}}"
 
           git checkout -b ci/cherry-pick-release-commit origin/dev
+          dev_head="$(git rev-parse HEAD)"
 
           if ! git cherry-pick "$release_commit"; then
-            git checkout --theirs \
-              ${{github.workspace}}/packages/*/CHANGELOG.md
-
-            git checkout --theirs \
-              ${{github.workspace}}/packages/*/package.json
-
+            git checkout --theirs -- packages/*/CHANGELOG.md
+            git checkout --ours -- packages/*/package.json
             git cherry-pick --continue
+          fi
+
+          git restore --source="$dev_head" -- packages/*/package.json
+          git add -- packages/*/package.json
+
+          if ! git diff --cached --quiet; then
+            git commit --amend --no-edit
           fi
 
           git push -u origin HEAD


### PR DESCRIPTION
**Related Issue:** N/A

## Summary
Adjusts the cherry-picking to `dev` section of the deploy latest workflow to ensure that the correct package versions are kept in the `package.json` files after release depending on current state.

- Only select version from `dev` when the `dev` version is **greater** than the release version. From our conversation and my testing I think this should only ever be true when a new minor prerelease has gone out before a patch is released.
- Uses the `semver` package to compare. More robust than the minor only comparison I first tried, and should be easy to move to a Node script if we want in the future.
- Instead of cherry-picking and then reverting, cherry-picks without commit, specifically chooses the Changelog/package.json files from the appropriate branches, and then commits.

Resolves build issues described in a prior fix PR: #14008
