### PR TITLE
docs(panel, dialog, flow-item): align content space tokens with style guide

### DIFF
--- a/packages/components/src/components/dialog/dialog.scss
+++ b/packages/components/src/components/dialog/dialog.scss
@@ -11,8 +11,8 @@
  * @prop --calcite-dialog-min-size-y: Specifies the component's minimum height, using `px`, `em`, `rem`, `vh`, or `%`.
  * @prop --calcite-dialog-max-size-y: Specifies the component's maximum height, using `px`, `em`, `rem`, `vh`, or `%`.
  * @prop --calcite-dialog-content-space: Specifies the padding of the component's content.
- * @prop --calcite-dialog-content-top-space: Specifies the padding of the `"content-top"` slot.
- * @prop --calcite-dialog-content-bottom-space: Specifies the padding of the `"content-bottom"` slot.
+ * @prop --calcite-dialog-content-top-space: Specifies the padding of the component's `content-top` slot.
+ * @prop --calcite-dialog-content-bottom-space: Specifies the padding of the component's `content-bottom` slot.
  * @prop --calcite-dialog-footer-space: Specifies the padding of the component's footer.
  * @prop --calcite-dialog-border-color: Specifies the component's border color.
  * @prop --calcite-dialog-offset-x: Specifies the component's horizontal offset.

--- a/packages/components/src/components/flow-item/flow-item.scss
+++ b/packages/components/src/components/flow-item/flow-item.scss
@@ -11,12 +11,12 @@
  * @prop --calcite-flow-description-text-color: Specifies the text color of the component's `description`.
  * @prop --calcite-flow-border-color: Specifies the component's border color.
  * @prop --calcite-flow-background-color: Specifies the component's background color.
- * @prop --calcite-flow-content-top-space: Specifies the padding of the `"content-top"` slot.
- * @prop --calcite-flow-content-bottom-space: Specifies the padding of the `"content-bottom"` slot.
+ * @prop --calcite-flow-content-top-space: Specifies the padding of the component's `content-top` slot.
+ * @prop --calcite-flow-content-bottom-space: Specifies the padding of the component's `content-bottom` slot.
  * @prop --calcite-flow-header-background-color: Specifies the background color of the component's header.
  * @prop --calcite-flow-footer-background-color: Specifies the background color of the component's footer.
  * @prop --calcite-flow-space: Specifies the padding of the component's `unnamed (default)` slot.
- * @prop --calcite-flow-header-content-space: Specifies the padding of the `header-content` slot.
+ * @prop --calcite-flow-header-content-space: Specifies the padding of the component's `header-content` slot.
  * @prop --calcite-flow-footer-space: Specifies the padding of the component's footer.
  * @prop --calcite-action-background-color: Specifies the background color of the component's `closable`, `collapsible`, and `back` `calcite-action`s. Applies to any slotted `calcite-action`s.
  * @prop --calcite-action-background-color-hover: Specifies the background color of the component's `closable`, `collapsible`, and `back` `calcite-action`s when hovered. Applies to any slotted `calcite-action`s.

--- a/packages/components/src/components/panel/panel.scss
+++ b/packages/components/src/components/panel/panel.scss
@@ -9,8 +9,8 @@
  * @prop --calcite-panel-description-text-color: Specifies the text color of the component's `description`.
  * @prop --calcite-panel-border-color: Specifies the component's border color.
  * @prop --calcite-panel-background-color: Specifies the component's background color.
- * @prop --calcite-panel-content-top-space: Specifies the padding of the `"content-top"` slot.
- * @prop --calcite-panel-content-bottom-space: Specifies the padding of the `"content-bottom"` slot.
+ * @prop --calcite-panel-content-top-space: Specifies the padding of the component's `content-top` slot.
+ * @prop --calcite-panel-content-bottom-space: Specifies the padding of the component's `content-bottom` slot.
  * @prop --calcite-panel-header-background-color: Specifies the background color of the component's header.
  * @prop --calcite-panel-header-action-background-color: Specifies the background color of the component's `closable`, `collapsible`, and elements slotted in `header-menu-actions`.
  * @prop --calcite-panel-header-action-background-color-hover: Specifies the background color of the component's `closable`, `collapsible`, and elements slotted in `header-menu-actions` when hovered.
@@ -18,8 +18,8 @@
  * @prop --calcite-panel-header-action-text-color: Specifies the text color of the component's `closable`, `collapsible`, and elements slotted in `header-menu-actions`.
  * @prop --calcite-panel-header-action-text-color-press: Specifies the text color of the component's `closable`, `collapsible`, and elements slotted in `header-menu-actions` when pressed or hovered.
  * @prop --calcite-panel-footer-background-color: Specifies the background color of the component's footer.
- * @prop --calcite-panel-space: Specifies the padding of the component's `"unnamed (default)"` slot.
- * @prop --calcite-panel-header-content-space: Specifies the padding of the `"header-content"` slot.
+ * @prop --calcite-panel-space: Specifies the padding of the component's `unnamed (default)` slot.
+ * @prop --calcite-panel-header-content-space: Specifies the padding of the component's `header-content` slot.
  * @prop --calcite-panel-footer-space: Specifies the padding of the component's footer.
  * @prop --calcite-popover-border-color: Specifies the border color of the component's internally rendered `calcite-popover`, which is rendered within a `calcite-action` menu when slotted `calcite-action`s are present in the `header-actions-end` slot. Applies to any slotted `calcite-popover`s.
  * @prop --calcite-panel-content-space: [Deprecated] Use `--calcite-panel-space` instead. Specifies the padding of the component's content.


### PR DESCRIPTION
**Related Issue:** #10380

## Summary
Aligns the new `--calcite-*-content-top-space` tokens added in #13999 with our documentation style guide.
