### PR TITLE
chore(CODEOWNERS): auto-request reviews from PEs on SCSS component files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,11 @@
 # The files matching the globs will be assigned to the @usernames that follow
-*                                           # no catch-all code owner to reduce notifications
-.*                                          @jcfranco
-*.json                                      @jcfranco
-CHANGELOG.md                                @isaacbraun @jcfranco @geospatialem
-.github/                                    @isaacbraun @jcfranco @geospatialem
-support/                                    @jcfranco
-/packages/components-react                  @jcfranco
-/packages/eslint-plugin-components          @jcfranco
-/packages/design-tokens                     @matgalla
+*                                            # no catch-all code owner to reduce notifications
+.*                                           @jcfranco
+*.json                                       @jcfranco
+CHANGELOG.md                                 @isaacbraun @jcfranco @geospatialem
+.github/                                     @isaacbraun @jcfranco @geospatialem
+support/                                     @jcfranco
+/packages/components-react                   @jcfranco
+/packages/eslint-plugin-components           @jcfranco
+/packages/design-tokens                      @matgalla
+/packages/components/src/components/*/*.scss @Esri/calcite-pes


### PR DESCRIPTION
**Related Issue:** n/a

## Summary
Auto-assigns the `Esri/calcite-pes` tag PRs including component `scss` files to ensure Design Token doc strings are following the style guide.
