### PR TITLE
refactor(alert, dialog, sheet, tree-item): swap to a unified animation curve

### DIFF
--- a/packages/components/src/styles/shared/_animation.scss
+++ b/packages/components/src/styles/shared/_animation.scss
@@ -7,7 +7,7 @@
 // --calcite-internal-animation-timing-slow
 // --calcite-internal-duration-factor
 
-$easing-function: cubic-bezier(0.215, 0.44, 0.42, 0.88);
+$easing-function: ease-in-out;
 
 @mixin animation-base() {
   --calcite-animation-timing: calc(150ms * var(--calcite-internal-duration-factor));


### PR DESCRIPTION
**Related Issue:** #12669

## Summary
Swap to a unified animation curve.

Right now we have two different sources of truth for the easing curve. Tailwind animation utilities use `ease-in-out`, SCSS transitions use `$easing-function: cubic-bezier(0.215, 0.44, 0.42, 0.88)`.
We need to pick one canonical easing token, and since the `$easing-function` var has been inherited from a fazed out dependency, I'm swapping it with a default to align with the rest of the components. 