### PR TITLE
refactor(combobox): wire up `useForm`

### DIFF
--- a/packages/components/src/components/combobox/combobox.browser.e2e.tsx
+++ b/packages/components/src/components/combobox/combobox.browser.e2e.tsx
@@ -8,6 +8,7 @@ import {
   disabled,
   floatingUIOwner,
   focusable,
+  formAssociated,
   hidden,
   internalLabel,
   reflects,
@@ -193,6 +194,25 @@ describe("disabled", () => {
       },
     },
   });
+});
+
+describe("is form-associated", () => {
+  formAssociated(
+    () =>
+      mount(
+        <calcite-combobox selection-mode="single">
+          <calcite-combobox-item heading="One" icon="banana" id="one" value="one" />
+          <calcite-combobox-item heading="Two" icon="beaker" id="two" selected value="two" />
+          <calcite-combobox-item heading="Three" id="three" value="three" />
+        </calcite-combobox>,
+      ),
+    {
+      testValue: "two",
+      submitsOnEnter: true,
+      validation: true,
+      changeValueKeys: ["{Space}", "{Enter}"],
+    },
+  );
 });
 
 describe("top layer placement", () => {

--- a/packages/components/src/components/combobox/combobox.e2e.ts
+++ b/packages/components/src/components/combobox/combobox.e2e.ts
@@ -1,7 +1,7 @@
 // @ts-strict-ignore
 import { E2EElement, E2EPage, EventSpy, newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { beforeEach, describe, expect, it } from "vitest";
-import { accessible, formAssociated, labelable, openClose } from "../../tests/commonTests";
+import { accessible, labelable, openClose } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 import { CSS as ComboboxItemCSS } from "../combobox-item/resources";
 import { CSS as XButtonCSS } from "../functional/XButton";
@@ -1941,17 +1941,6 @@ it("works correctly inside a shadowRoot", async () => {
   expect(await combobox.getProperty("open")).toBeFalsy();
   await input.click();
   expect(await combobox.getProperty("open")).toBe(true);
-});
-
-describe("is form-associated", () => {
-  formAssociated(
-    html`<calcite-combobox selection-mode="single">
-      <calcite-combobox-item id="one" icon="banana" value="one" heading="One"></calcite-combobox-item>
-      <calcite-combobox-item id="two" icon="beaker" value="two" heading="Two" selected></calcite-combobox-item>
-      <calcite-combobox-item id="three" value="three" heading="Three"></calcite-combobox-item>
-    </calcite-combobox>`,
-    { testValue: "two", submitsOnEnter: true, validation: true, changeValueKeys: ["Space", "Enter"] },
-  );
 });
 
 it("should have input--icon class when placeholder-icon is parsed", async () => {

--- a/packages/components/src/components/combobox/combobox.tsx
+++ b/packages/components/src/components/combobox/combobox.tsx
@@ -30,15 +30,6 @@ import {
   OverlayPositioning,
   reposition,
 } from "../../utils/floating-ui";
-import {
-  afterConnectDefaultValueSet,
-  connectForm,
-  disconnectForm,
-  FormComponent,
-  HiddenFormInputSlot,
-  MutableValidityState,
-  submitForm,
-} from "../../utils/form";
 import { guid } from "../../utils/guid";
 import { connectLabel, disconnectLabel, getLabelText, LabelableComponent } from "../../utils/label";
 import { createObserver, updateRefObserver } from "../../utils/observers";
@@ -60,6 +51,7 @@ import { useSetFocus } from "../../controllers/useSetFocus";
 import { useCancelable } from "../../controllers/useCancelable";
 import { useInteractive } from "../../controllers/useInteractive";
 import { useTopLayer } from "../../controllers/useTopLayer";
+import { MutableValidityState, useForm } from "../../controllers/useForm";
 import T9nStrings from "./assets/t9n/messages.en.json";
 import { ComboboxChildElement, GroupData, ItemData, SelectionDisplay } from "./interfaces";
 import { ComboboxItemGroupSelector, ComboboxItemSelector, CSS, IDS, ICONS } from "./resources";
@@ -82,11 +74,10 @@ declare global {
  * @slot - A slot for adding `calcite-combobox-item`s.
  * @slot label-content - A slot for rendering content next to the component's `labelText`.
  */
-export class Combobox
-  extends LitElement
-  implements LabelableComponent, FormComponent, FloatingUIComponent
-{
+export class Combobox extends LitElement implements LabelableComponent, FloatingUIComponent {
   //#region Static Members
+
+  static formAssociated = true;
 
   static override styles = styles;
 
@@ -97,6 +88,10 @@ export class Combobox
   private closeButtonRef = createRef<HTMLButtonElement>();
 
   private direction = useDirection();
+
+  private formSupport = useForm<this>({
+    inputType: "text",
+  })(this);
 
   private selectAllComboboxItemRef = createRef<HTMLCalciteComboboxItemElement>();
 
@@ -601,11 +596,6 @@ export class Combobox
 
   override connectedCallback(): void {
     connectLabel(this);
-    connectForm(this);
-
-    this.internalValueChangeFlag = true;
-    this.value = this.getValue();
-    this.internalValueChangeFlag = false;
     this.mutationObserver?.observe(this.el, { childList: true, subtree: true });
 
     this.setFilteredPlacements();
@@ -614,6 +604,9 @@ export class Combobox
   }
 
   async load(): Promise<void> {
+    this.internalValueChangeFlag = true;
+    this.value = this.getValue();
+    this.internalValueChangeFlag = false;
     this.handleSelectionModeWarning();
   }
 
@@ -652,7 +645,6 @@ export class Combobox
   }
 
   loaded(): void {
-    afterConnectDefaultValueSet(this, this.getValue());
     connectFloatingUI(this);
     this.updateItems();
     this.filterItems(this.filterText, false, false);
@@ -662,7 +654,6 @@ export class Combobox
     this.mutationObserver?.disconnect();
     this.resizeObserver?.disconnect();
     disconnectLabel(this);
-    disconnectForm(this);
     disconnectFloatingUI(this);
   }
 
@@ -945,10 +936,9 @@ export class Combobox
         } else if (this.allowCustomValues && this.filterText) {
           this.addCustomChip(this.filterText, true);
           event.preventDefault();
-        } else if (!event.defaultPrevented) {
-          if (submitForm(this)) {
-            event.preventDefault();
-          }
+        } else if (!event.defaultPrevented && this.formSupport.active) {
+          event.preventDefault();
+          this.formSupport.requestSubmit();
         }
         break;
       case "Delete":
@@ -1988,7 +1978,6 @@ export class Combobox
           {this.renderListBoxOptions()}
         </ul>
         {this.renderFloatingUIContainer()}
-        <HiddenFormInputSlot component={this} />
         {this.validationMessage && this.status === "invalid" ? (
           <Validation
             icon={this.validationIcon}

--- a/packages/components/src/controllers/useForm.ts
+++ b/packages/components/src/controllers/useForm.ts
@@ -90,6 +90,8 @@ export interface FormComponent<T = any>
    * The initial value for this form component.
    *
    * When the form is reset, the value will be set to this property.
+   *
+   * Note: this property will be initialized in the first update cycle, so make sure that the component's value is set before then to ensure defaultValue is properly initialized.
    */
   defaultValue: T;
 
@@ -116,6 +118,8 @@ interface CheckableFormComponent<T = any> extends FormComponent<T> {
    * The initial checked value for this form component.
    *
    * When the form is reset, the checked property will be set to this value.
+   *
+   * Note: this property will be initialized in the first update cycle, so make sure that the component's value is set before then to ensure defaultValue is properly initialized.
    */
   defaultChecked: boolean;
 }

--- a/packages/components/src/controllers/useForm.ts
+++ b/packages/components/src/controllers/useForm.ts
@@ -323,11 +323,10 @@ export const useForm = <T extends FormComponent>(
     function getFormValue(): any {
       if (Array.isArray(component.value)) {
         const formData = new FormData();
-        component.value.forEach((value) => {
-          formData.append(component.name, value);
-        });
+        component.value.forEach((value) => formData.append(component.name, value));
         return formData;
       }
+
       if (isCheckable(component)) {
         if (component.checked) {
           // matches https://html.spec.whatwg.org/multipage/input.html#dom-input-value-default-on

--- a/packages/components/src/controllers/useForm.ts
+++ b/packages/components/src/controllers/useForm.ts
@@ -185,7 +185,7 @@ interface UseForm {
 
 interface UseFormOptions {
   /**
-   * When set, the component will validate and behave as if it were the specified input type (e.g. "email").
+   * When set, the component will validate as if it were the specified input type (e.g. "email").
    */
   inputType?: HTMLInputElement["type"];
 }
@@ -330,7 +330,10 @@ export const useForm = <T extends FormComponent>(
       }
       if (isCheckable(component)) {
         if (component.checked) {
-          return inputDelegate && options.inputType === "checkbox" ? inputDelegate.value : component.value;
+          // matches https://html.spec.whatwg.org/multipage/input.html#dom-input-value-default-on
+          return component.defaultValue === undefined && !defaultValueDirty && component.value === undefined
+            ? "on"
+            : component.value;
         }
 
         return null;


### PR DESCRIPTION
**Related Issue:** #8126

## Summary

This PR refactors `calcite-combobox`' form association logic from the legacy form utilities to the `useForm` controller.

**Note**: the initial value set was moved from `connectedCallback` to `load`, which provides a better hook for initializing state and avoids resetting the value on each connect.