### PR TITLE
refactor(meter): drop inert form-association logic

### DIFF
--- a/packages/components/src/components/meter/meter.tsx
+++ b/packages/components/src/components/meter/meter.tsx
@@ -96,6 +96,8 @@ export class Meter extends LitElement {
    * Specifies the `id` of the component's associated form.
    *
    * When not set, the component is associated with its ancestor form element, if one exists.
+   *
+   * @deprecated since v5.1.0, removal target v6.0.0 - This property has no effect on the component.
    */
   @property({ reflect: true }) form: string;
 
@@ -121,7 +123,11 @@ export class Meter extends LitElement {
   /** Specifies the component's lowest allowed value. */
   @property({ reflect: true }) min = 0;
 
-  /** Specifies the name of the component. Required to pass the component's `value` on form submission. */
+  /**
+   * Specifies the name of the component. Required to pass the component's `value` on form submission.
+   *
+   * @deprecated since v5.1.0, removal target v6.0.0 - This property has no effect on the component.
+   */
   @property({ reflect: true }) name: string;
 
   /** Specifies the Unicode numeral system used by the component for localization. */

--- a/packages/components/src/components/meter/meter.tsx
+++ b/packages/components/src/components/meter/meter.tsx
@@ -21,8 +21,6 @@ declare global {
 export class Meter extends LitElement {
   // #region Static Members
 
-  static formAssociated = true;
-
   static override styles = styles;
 
   // #endregion

--- a/packages/components/src/components/meter/meter.tsx
+++ b/packages/components/src/components/meter/meter.tsx
@@ -97,7 +97,7 @@ export class Meter extends LitElement {
    *
    * When not set, the component is associated with its ancestor form element, if one exists.
    *
-   * @deprecated since v5.1.0, removal target v6.0.0 - This property has no effect on the component.
+   * @deprecated in v5.1.0, removal target v6.0.0 - This property has no effect on the component.
    */
   @property({ reflect: true }) form: string;
 

--- a/packages/components/src/components/meter/meter.tsx
+++ b/packages/components/src/components/meter/meter.tsx
@@ -3,12 +3,6 @@ import { PropertyValues } from "lit";
 import { createRef } from "lit/directives/ref.js";
 import { LitElement, property, h, state, JsxNode } from "@arcgis/lumina";
 import { Appearance, Scale } from "../interfaces";
-import {
-  afterConnectDefaultValueSet,
-  connectForm,
-  disconnectForm,
-  FormComponent,
-} from "../../utils/form";
 import { Locale, NumberingSystem, numberStringFormatter } from "../../utils/locale";
 import { intersects } from "../../utils/dom";
 import { createObserver } from "../../utils/observers";
@@ -24,18 +18,16 @@ declare global {
   }
 }
 
-export class Meter extends LitElement implements FormComponent {
+export class Meter extends LitElement {
   // #region Static Members
+
+  static formAssociated = true;
 
   static override styles = styles;
 
   // #endregion
 
   // #region Private Properties
-
-  defaultValue: Meter["value"];
-
-  formEl: HTMLFormElement;
 
   private highLabelRef = createRef<HTMLDivElement>();
 
@@ -163,13 +155,11 @@ export class Meter extends LitElement implements FormComponent {
   // #region Lifecycle
 
   override connectedCallback(): void {
-    connectForm(this);
     this.resizeObserver?.observe(this.el);
   }
 
   load(): void {
     this.calculateValues();
-    afterConnectDefaultValueSet(this, this.value);
   }
 
   override willUpdate(changes: PropertyValues<this>): void {
@@ -203,7 +193,6 @@ export class Meter extends LitElement implements FormComponent {
   }
 
   override disconnectedCallback(): void {
-    disconnectForm(this);
     this.resizeObserver?.disconnect();
   }
 

--- a/packages/components/src/components/meter/meter.tsx
+++ b/packages/components/src/components/meter/meter.tsx
@@ -126,7 +126,7 @@ export class Meter extends LitElement {
   /**
    * Specifies the name of the component. Required to pass the component's `value` on form submission.
    *
-   * @deprecated since v5.1.0, removal target v6.0.0 - This property has no effect on the component.
+   * @deprecated in v5.1.0, removal target v6.0.0 - This property has no effect on the component.
    */
   @property({ reflect: true }) name: string;
 


### PR DESCRIPTION
**monday.com sync:** #12164338196

**Related Issue:** N/A

## Summary

This came up while working on #8126, where it turned out that `calcite-meter` shouldn’t be form-submittable as it doesn’t match native behavior (see https://codepen.io/jcfranco/pen/emdBqzm).

Luckily, it wasn’t wired up completely (see https://codepen.io/jcfranco/pen/pvENYLQ), so it won’t be a breaking change after removal.

deprecate(meter): deprecate inert `form` and `name` properties