### PR TITLE
ci(actions): never clear the individual role columns

### DIFF
--- a/.github/scripts/support/monday.js
+++ b/.github/scripts/support/monday.js
@@ -1019,19 +1019,13 @@ module.exports = function Monday(issue, core, updateIssueBody) {
 
   /**
    * Handle assignment and removal of assignees. Add all assignees to their respective roles.
-   * If there are no more developers or product engineers assigned, clear those columns.
+   * If there are no more assignees, clears the `allAssignees` column.
    * @returns {void}
    */
   function handleAssignees() {
     assignees.forEach((assignee) => {
       addAssignee(assignee);
     });
-
-    [mondayColumns.developers, mondayColumns.productEngineers]
-      .filter((role) => !(role.id in columnUpdates))
-      .forEach((role) => {
-        setColumnValue(role, "");
-      });
 
     if (!assignees.length) {
       setColumnValue(mondayColumns.allAssignees, "");


### PR DESCRIPTION
**Related Issue:** #14082

## Summary
Removes the snippet that clears the `developers` and `productEngineers` columns when there are no assignees of those roles left. This preserves the historical assignment of the issue in Monday.com while the current assignment is kept track in the `allAssignees` column.
