### PR TITLE
fix(input-text): restore focus when it is the first invalid element on form submit

### DIFF
--- a/packages/components/src/controllers/useForm.ts
+++ b/packages/components/src/controllers/useForm.ts
@@ -211,6 +211,21 @@ export const useForm = <T extends FormComponent>(
     function invalidFormHandler(event: Event): void {
       // prevent the browser from showing the native validation popover
       event?.preventDefault();
+
+      const form = event.currentTarget as HTMLFormElement;
+      const formElements = Array.from(form.elements);
+
+      requestAnimationFrame(() => {
+        const invalidEls = formElements.filter((el): el is FormComponent["el"] => el.matches("[status=invalid]"));
+
+        // focus the first invalid element that has a validation message
+        for (const el of invalidEls) {
+          if (el.validationMessage) {
+            el.setFocus();
+            break;
+          }
+        }
+      });
     }
 
     function onFormReset(): void {

--- a/packages/components/src/controllers/useForm.ts
+++ b/packages/components/src/controllers/useForm.ts
@@ -133,6 +133,10 @@ export interface ValidationProps {
   icon: IconName | boolean;
 }
 
+function isFormComponentEl(el: Element): el is FormComponent["el"] {
+  return "form" in el && "name" in el && !!el.form && !!el.name;
+}
+
 function displayValidationMessage(component: FormComponent, { status, message, icon }: ValidationProps): void {
   if ("status" in component) {
     component.status = status;
@@ -171,6 +175,24 @@ function isInputComponent(
   return component && isSupportedType(input.type);
 }
 
+export function focusFirstInvalidFormElement(form: HTMLFormElement): void {
+  const formElements = Array.from(form.elements);
+
+  requestAnimationFrame(() => {
+    const invalidEls = formElements.filter(
+      (el): el is FormComponent["el"] => el.matches("[status=invalid]") && isFormComponentEl(el),
+    );
+
+    // focus the first invalid element that has a validation message
+    for (const el of invalidEls) {
+      if (el.validationMessage) {
+        el.setFocus();
+        break;
+      }
+    }
+  });
+}
+
 interface UseForm {
   /**
    * When true, this component is associated with a form and will have its value submitted when the form is submitted.
@@ -206,22 +228,6 @@ export const useForm = <T extends FormComponent>(
       inputDelegate = document.createElement("input");
       inputDelegate.type = options.inputType;
       // intentionally not appended to the DOM, we just need it for validation
-    }
-
-    function focusFirstInvalidFormElement(form: HTMLFormElement): void {
-      const formElements = Array.from(form.elements);
-
-      requestAnimationFrame(() => {
-        const invalidEls = formElements.filter((el): el is FormComponent["el"] => el.matches("[status=invalid]"));
-
-        // focus the first invalid element that has a validation message
-        for (const el of invalidEls) {
-          if (el.validationMessage) {
-            el.setFocus();
-            break;
-          }
-        }
-      });
     }
 
     function invalidFormHandler(event: Event): void {

--- a/packages/components/src/controllers/useForm.ts
+++ b/packages/components/src/controllers/useForm.ts
@@ -6,7 +6,7 @@ import { kebabToPascal, uncapitalize } from "@arcgis/toolkit/string";
 import type { IconName } from "../components/icon/interfaces";
 import { Status } from "../components/interfaces";
 import { InputComponent, isSupportedType, syncInputDelegate } from "../components/input/common/input";
-import { SetFocusable } from "../utils/dom";
+import { isCalciteFocusable, SetFocusable } from "../utils/dom";
 
 /** Any form <Component> with a `calcite<Component>Input` event needs to be included in this array. */
 export const componentsWithInputEvent = [
@@ -134,7 +134,7 @@ export interface ValidationProps {
 }
 
 function isFormComponentEl(el: Element): el is FormComponent["el"] {
-  return "form" in el && "name" in el && !!el.form && !!el.name;
+  return "form" in el && "name" in el && !!el.form && !!el.name && isCalciteFocusable(el);
 }
 
 function displayValidationMessage(component: FormComponent, { status, message, icon }: ValidationProps): void {

--- a/packages/components/src/controllers/useForm.ts
+++ b/packages/components/src/controllers/useForm.ts
@@ -208,11 +208,7 @@ export const useForm = <T extends FormComponent>(
       // intentionally not appended to the DOM, we just need it for validation
     }
 
-    function invalidFormHandler(event: Event): void {
-      // prevent the browser from showing the native validation popover
-      event?.preventDefault();
-
-      const form = event.currentTarget as HTMLFormElement;
+    function focusFirstInvalidFormElement(form: HTMLFormElement): void {
       const formElements = Array.from(form.elements);
 
       requestAnimationFrame(() => {
@@ -226,6 +222,14 @@ export const useForm = <T extends FormComponent>(
           }
         }
       });
+    }
+
+    function invalidFormHandler(event: Event): void {
+      // prevent the browser from showing the native validation popover
+      event?.preventDefault();
+
+      const form = event.currentTarget as HTMLFormElement;
+      focusFirstInvalidFormElement(form);
     }
 
     function onFormReset(): void {

--- a/packages/components/src/controllers/useForm.ts
+++ b/packages/components/src/controllers/useForm.ts
@@ -133,7 +133,7 @@ export interface ValidationProps {
   icon: IconName | boolean;
 }
 
-function isFormComponentEl(el: Element): el is FormComponent["el"] {
+function isFormComponentEl(el: HTMLElement): el is FormComponent["el"] {
   return "form" in el && "name" in el && !!el.form && !!el.name && isCalciteFocusable(el);
 }
 
@@ -180,7 +180,7 @@ export function focusFirstInvalidFormElement(form: HTMLFormElement): void {
 
   requestAnimationFrame(() => {
     const invalidEls = formElements.filter(
-      (el): el is FormComponent["el"] => el.matches("[status=invalid]") && isFormComponentEl(el),
+      (el): el is FormComponent["el"] => el.matches("[status=invalid]") && isFormComponentEl(el as HTMLElement),
     );
 
     // focus the first invalid element that has a validation message

--- a/packages/components/src/controllers/useForm.ts
+++ b/packages/components/src/controllers/useForm.ts
@@ -134,7 +134,7 @@ export interface ValidationProps {
 }
 
 function isFormComponentEl(el: HTMLElement): el is FormComponent["el"] {
-  return "form" in el && "name" in el && !!el.form && !!el.name && isCalciteFocusable(el);
+  return "form" in el && "name" in el && isCalciteFocusable(el);
 }
 
 function displayValidationMessage(component: FormComponent, { status, message, icon }: ValidationProps): void {

--- a/packages/components/src/controllers/useForm.ts
+++ b/packages/components/src/controllers/useForm.ts
@@ -231,8 +231,12 @@ export const useForm = <T extends FormComponent>(
     }
 
     function invalidFormHandler(event: Event): void {
+      if (event.defaultPrevented) {
+        return;
+      }
+
       // prevent the browser from showing the native validation popover
-      event?.preventDefault();
+      event.preventDefault();
 
       const form = event.currentTarget as HTMLFormElement;
       focusFirstInvalidFormElement(form);

--- a/packages/components/src/tests/commonTests/browser/form-associated.ts
+++ b/packages/components/src/tests/commonTests/browser/form-associated.ts
@@ -351,6 +351,7 @@ export function formAssociated(setup: TestSetup, options: FormAssociatedOptions)
   ): Promise<void> {
     await userEvent.click(submitter);
     expectValidationProps(el, { message, icon: true, status: "invalid" });
+    await expect.element(el).toHaveFocus();
   }
 
   async function assertClearsValidationOnValueChange(

--- a/packages/components/src/utils/form.tsx
+++ b/packages/components/src/utils/form.tsx
@@ -7,7 +7,6 @@ import type { IconName } from "../components/icon/interfaces";
 import { Status } from "../components/interfaces";
 import type { Input } from "../components/input/input";
 import type { RadioButtonGroup } from "../components/radio-button-group/radio-button-group";
-import { focusFirstInvalidFormElement } from "../controllers/useForm";
 import { closestElementCrossShadowBoundary, queryElementRoots } from "./dom";
 
 /** Any form <Component> with a `calcite<Component>Input` event needs to be included in this array. */
@@ -325,7 +324,17 @@ export function submitForm(component: FormOwner): boolean {
   formEl.requestSubmit();
   formEl.removeEventListener("invalid", invalidHandler, true);
 
-  focusFirstInvalidFormElement(formEl);
+  requestAnimationFrame(() => {
+    const invalidEls = formEl.querySelectorAll<Input["el"]>("[status=invalid]");
+
+    // focus the first invalid element that has a validation message
+    for (const el of invalidEls) {
+      if (el?.validationMessage) {
+        el?.setFocus();
+        break;
+      }
+    }
+  });
 
   return true;
 }

--- a/packages/components/src/utils/form.tsx
+++ b/packages/components/src/utils/form.tsx
@@ -7,6 +7,7 @@ import type { IconName } from "../components/icon/interfaces";
 import { Status } from "../components/interfaces";
 import type { Input } from "../components/input/input";
 import type { RadioButtonGroup } from "../components/radio-button-group/radio-button-group";
+import { focusFirstInvalidFormElement } from "../controllers/useForm";
 import { closestElementCrossShadowBoundary, queryElementRoots } from "./dom";
 
 /** Any form <Component> with a `calcite<Component>Input` event needs to be included in this array. */
@@ -324,17 +325,7 @@ export function submitForm(component: FormOwner): boolean {
   formEl.requestSubmit();
   formEl.removeEventListener("invalid", invalidHandler, true);
 
-  requestAnimationFrame(() => {
-    const invalidEls = formEl.querySelectorAll<Input["el"]>("[status=invalid]");
-
-    // focus the first invalid element that has a validation message
-    for (const el of invalidEls) {
-      if (el?.validationMessage) {
-        el?.setFocus();
-        break;
-      }
-    }
-  });
+  focusFirstInvalidFormElement(formEl);
 
   return true;
 }


### PR DESCRIPTION
**Related Issue:** #8126

## Summary

This fixes a regression introduced in #13985 that prevented the component from receiving focus when it is the first invalid element in a form. This would only be noticeable in the rare case where **only** `input-text`s are used in a form where submit is triggered programmatically or through the components themselves.