### PR TITLE
docs: deprecate --calcite-stepper-bar-inactive-fill-color and --calcite-stepper-bar-active-fill-color

### DIFF
--- a/packages/components/src/components/stepper/stepper.scss
+++ b/packages/components/src/components/stepper/stepper.scss
@@ -4,8 +4,8 @@
  * These properties can be overridden using the component's tag as selector.
  *
  * @prop --calcite-stepper-bar-gap: Specifies the space between the component's `calcite-stepper-item`s.
- * @prop --calcite-stepper-bar-inactive-fill-color: Specifies the `calcite-stepper-item`s' bar fill color of the component's `calcite-stepper-item`s.
- * @prop --calcite-stepper-bar-active-fill-color: Specifies the `calcite-stepper-item`s' bar fill color of the component's active `calcite-stepper-item`s.
+ * @prop --calcite-stepper-bar-inactive-fill-color: [Deprecated] Use `--calcite-stepper-bar-fill-color`. Specifies the `calcite-stepper-item`s' bar fill color of the component's `calcite-stepper-item`s.
+ * @prop --calcite-stepper-bar-active-fill-color: [Deprecated] Use `--calcite-stepper-bar-selected-fill-color`. Specifies the `calcite-stepper-item`s' bar fill color of the component's active `calcite-stepper-item`s.
  * @prop --calcite-stepper-bar-complete-fill-color: When `calcite-stepper-item`s are `complete`, specifies the component's `calcite-stepper-item`s' bar fill color.
  * @prop --calcite-stepper-bar-error-fill-color: When `calcite-stepper-item`s contain an `error`, specifies the component's `calcite-stepper-item`s' bar fill color.
  */


### PR DESCRIPTION
**Related Issue:** #13720 

## Summary

deprecate --calcite-stepper-bar-inactive-fill-color and --calcite-stepper-bar-active-fill-color because they're not functional and alternatives already exist.