### PR TITLE
fix(popover, tooltip): correctly assign aria properties

### DIFF
--- a/packages/components/src/controllers/useReferenceElement.browser.spec.tsx
+++ b/packages/components/src/controllers/useReferenceElement.browser.spec.tsx
@@ -81,7 +81,7 @@ describe("useReferenceElement", () => {
       component.referenceElement = referenceElement;
       await component.updateComplete;
       expect(component.referenceEl).toBeInstanceOf(HTMLElement);
-      expect(component.referenceEl.ariaControlsElements).toContain(component);
+      expect(component.referenceEl.ariaControlsElements).toContain(component.el);
       expect(component.referenceEl.ariaExpanded).toBe("false");
       component.referenceElement = null;
       await component.updateComplete;
@@ -102,7 +102,7 @@ describe("useReferenceElement", () => {
       component.referenceElement = "my-ref";
       await component.updateComplete;
       expect(component.referenceEl).toBeInstanceOf(HTMLElement);
-      expect(component.referenceEl.ariaControlsElements).toContain(component);
+      expect(component.referenceEl.ariaControlsElements).toContain(component.el);
       expect(component.referenceEl.ariaExpanded).toBe("false");
       component.referenceElement = null;
       await component.updateComplete;
@@ -128,7 +128,7 @@ describe("useReferenceElement", () => {
       component.referenceElement = "my-ref-1";
       await component.updateComplete;
 
-      expect(referenceElement1.ariaControlsElements).toContain(component);
+      expect(referenceElement1.ariaControlsElements).toContain(component.el);
       expect(referenceElement1.ariaExpanded).toBe("false");
 
       component.referenceElement = referenceElement2;
@@ -154,7 +154,7 @@ describe("useReferenceElement", () => {
       component.referenceElement = referenceElement;
       await component.updateComplete;
       expect(component.referenceEl).toBeInstanceOf(HTMLElement);
-      expect(component.referenceEl.ariaDescribedByElements).toContain(component);
+      expect(component.referenceEl.ariaDescribedByElements).toContain(component.el);
       component.referenceElement = null;
       await component.updateComplete;
       expect(referenceElement.ariaDescribedByElements).toBeNull();
@@ -173,7 +173,7 @@ describe("useReferenceElement", () => {
       component.referenceElement = "my-ref";
       await component.updateComplete;
       expect(component.referenceEl).toBeInstanceOf(HTMLElement);
-      expect(component.referenceEl.ariaDescribedByElements).toContain(component);
+      expect(component.referenceEl.ariaDescribedByElements).toContain(component.el);
       component.referenceElement = null;
       await component.updateComplete;
       expect(referenceElement.ariaDescribedByElements).toBeNull();

--- a/packages/components/src/controllers/useReferenceElement.browser.spec.tsx
+++ b/packages/components/src/controllers/useReferenceElement.browser.spec.tsx
@@ -138,6 +138,56 @@ describe("useReferenceElement", () => {
       expect(referenceElement1.ariaControlsElements).toBeNull();
       expect(referenceElement1.ariaExpanded).toBeNull();
     });
+
+    it("registers multiple components with same reference element and unregisters independently", async () => {
+      await mount(
+        html`<div>
+          <div id="my-ref">My Reference Element</div>
+          <test-click-component></test-click-component>
+          <test-click-component></test-click-component>
+        </div>`,
+        { dynamicComponents: [TestClickComponent] },
+      );
+
+      const referenceElement = page.getByText("My Reference Element").element() as HTMLElement | null;
+
+      if (!referenceElement) {
+        throw new Error("Expected reference element to be present");
+      }
+
+      const components = Array.from(
+        document.querySelectorAll("test-click-component"),
+      ) as TestClickComponent[];
+
+      if (components.length !== 2) {
+        throw new Error("Expected two test-click-component instances to be present");
+      }
+
+      const [component1, component2] = components;
+
+      component1.referenceElement = referenceElement;
+      component2.referenceElement = referenceElement;
+      await Promise.all([component1.updateComplete, component2.updateComplete]);
+
+      expect(referenceElement.ariaControlsElements).not.toBeNull();
+      expect(referenceElement.ariaControlsElements).toContain(component1.el);
+      expect(referenceElement.ariaControlsElements).toContain(component2.el);
+
+      expect(referenceElement.ariaDescribedByElements).not.toBeNull();
+      expect(referenceElement.ariaDescribedByElements).toContain(component1.el);
+      expect(referenceElement.ariaDescribedByElements).toContain(component2.el);
+
+      component1.referenceElement = null;
+      await component1.updateComplete;
+
+      expect(referenceElement.ariaControlsElements).not.toBeNull();
+      expect(referenceElement.ariaControlsElements).not.toContain(component1.el);
+      expect(referenceElement.ariaControlsElements).toContain(component2.el);
+
+      expect(referenceElement.ariaDescribedByElements).not.toBeNull();
+      expect(referenceElement.ariaDescribedByElements).not.toContain(component1.el);
+      expect(referenceElement.ariaDescribedByElements).toContain(component2.el);
+    });
   });
 
   describe("hover manager", () => {

--- a/packages/components/src/controllers/useReferenceElement.browser.spec.tsx
+++ b/packages/components/src/controllers/useReferenceElement.browser.spec.tsx
@@ -67,6 +67,24 @@ describe("useReferenceElement", () => {
     return { referenceElement, component };
   }
 
+  function getComponentsByText<T extends HTMLElement>(expectedCount: number): T[] {
+    const componentTextEls = page.getByText("Hello world!").elements() as HTMLElement[];
+
+    if (componentTextEls.length !== expectedCount) {
+      throw new Error(`Expected ${expectedCount} test component instances to be present`);
+    }
+
+    return componentTextEls.map((componentTextEl, index) => {
+      const component = (componentTextEl.getRootNode() as ShadowRoot).host as T | null;
+
+      if (!component) {
+        throw new Error(`Expected test component ${index + 1} to be present`);
+      }
+
+      return component;
+    });
+  }
+
   describe("click manager", () => {
     it("register and resolves reference element", async () => {
       await mount(
@@ -149,21 +167,15 @@ describe("useReferenceElement", () => {
         { dynamicComponents: [TestClickComponent] },
       );
 
-      const referenceElement = page.getByText("My Reference Element").element() as HTMLElement | null;
+      const referenceElement = page
+        .getByText("My Reference Element")
+        .element() as HTMLElement | null;
 
       if (!referenceElement) {
         throw new Error("Expected reference element to be present");
       }
 
-      const components = Array.from(
-        document.querySelectorAll("test-click-component"),
-      ) as TestClickComponent[];
-
-      if (components.length !== 2) {
-        throw new Error("Expected two test-click-component instances to be present");
-      }
-
-      const [component1, component2] = components;
+      const [component1, component2] = getComponentsByText<TestClickComponent>(2);
 
       component1.referenceElement = referenceElement;
       component2.referenceElement = referenceElement;
@@ -231,21 +243,15 @@ describe("useReferenceElement", () => {
         { dynamicComponents: [TestHoverComponent] },
       );
 
-      const referenceElement = page.getByText("My Reference Element").element() as HTMLElement | null;
+      const referenceElement = page
+        .getByText("My Reference Element")
+        .element() as HTMLElement | null;
 
       if (!referenceElement) {
         throw new Error("Expected reference element to be present");
       }
 
-      const components = Array.from(
-        document.querySelectorAll("test-hover-component"),
-      ) as TestHoverComponent[];
-
-      if (components.length !== 2) {
-        throw new Error("Expected two test-hover-component instances to be present");
-      }
-
-      const [component1, component2] = components;
+      const [component1, component2] = getComponentsByText<TestHoverComponent>(2);
 
       component1.referenceElement = referenceElement;
       component2.referenceElement = referenceElement;

--- a/packages/components/src/controllers/useReferenceElement.browser.spec.tsx
+++ b/packages/components/src/controllers/useReferenceElement.browser.spec.tsx
@@ -173,20 +173,12 @@ describe("useReferenceElement", () => {
       expect(referenceElement.ariaControlsElements).toContain(component1.el);
       expect(referenceElement.ariaControlsElements).toContain(component2.el);
 
-      expect(referenceElement.ariaDescribedByElements).not.toBeNull();
-      expect(referenceElement.ariaDescribedByElements).toContain(component1.el);
-      expect(referenceElement.ariaDescribedByElements).toContain(component2.el);
-
       component1.referenceElement = null;
       await component1.updateComplete;
 
       expect(referenceElement.ariaControlsElements).not.toBeNull();
       expect(referenceElement.ariaControlsElements).not.toContain(component1.el);
       expect(referenceElement.ariaControlsElements).toContain(component2.el);
-
-      expect(referenceElement.ariaDescribedByElements).not.toBeNull();
-      expect(referenceElement.ariaDescribedByElements).not.toContain(component1.el);
-      expect(referenceElement.ariaDescribedByElements).toContain(component2.el);
     });
   });
 
@@ -227,6 +219,48 @@ describe("useReferenceElement", () => {
       component.referenceElement = null;
       await component.updateComplete;
       expect(referenceElement.ariaDescribedByElements).toBeNull();
+    });
+
+    it("registers multiple hover components with same reference element and unregisters independently", async () => {
+      await mount(
+        html`<div>
+          <div id="my-ref">My Reference Element</div>
+          <test-hover-component></test-hover-component>
+          <test-hover-component></test-hover-component>
+        </div>`,
+        { dynamicComponents: [TestHoverComponent] },
+      );
+
+      const referenceElement = page.getByText("My Reference Element").element() as HTMLElement | null;
+
+      if (!referenceElement) {
+        throw new Error("Expected reference element to be present");
+      }
+
+      const components = Array.from(
+        document.querySelectorAll("test-hover-component"),
+      ) as TestHoverComponent[];
+
+      if (components.length !== 2) {
+        throw new Error("Expected two test-hover-component instances to be present");
+      }
+
+      const [component1, component2] = components;
+
+      component1.referenceElement = referenceElement;
+      component2.referenceElement = referenceElement;
+      await Promise.all([component1.updateComplete, component2.updateComplete]);
+
+      expect(referenceElement.ariaDescribedByElements).not.toBeNull();
+      expect(referenceElement.ariaDescribedByElements).toContain(component1.el);
+      expect(referenceElement.ariaDescribedByElements).toContain(component2.el);
+
+      component1.referenceElement = null;
+      await component1.updateComplete;
+
+      expect(referenceElement.ariaDescribedByElements).not.toBeNull();
+      expect(referenceElement.ariaDescribedByElements).not.toContain(component1.el);
+      expect(referenceElement.ariaDescribedByElements).toContain(component2.el);
     });
   });
 });

--- a/packages/components/src/controllers/useReferenceElement.browser.spec.tsx
+++ b/packages/components/src/controllers/useReferenceElement.browser.spec.tsx
@@ -46,11 +46,7 @@ describe("useReferenceElement", () => {
     referenceElement: HTMLElement;
     component: T;
   } {
-    const referenceElement = page.getByText("My Reference Element").element() as HTMLElement | null;
-
-    if (!referenceElement) {
-      throw new Error("Expected reference element to be present");
-    }
+    const referenceElement = page.getByText("My Reference Element").element() as HTMLElement;
 
     const componentTextEl = page.getByText("Hello world!").element() as HTMLElement | null;
 
@@ -67,7 +63,7 @@ describe("useReferenceElement", () => {
     return { referenceElement, component };
   }
 
-  function getComponentsByText<T extends HTMLElement>(expectedCount: number): T[] {
+  function getComponentElsByText<T extends HTMLElement>(expectedCount: number): T[] {
     const componentTextEls = page.getByText("Hello world!").elements() as HTMLElement[];
 
     if (componentTextEls.length !== expectedCount) {
@@ -83,6 +79,35 @@ describe("useReferenceElement", () => {
 
       return component;
     });
+  }
+
+  type TestReferenceComponent = HTMLElement &
+    Pick<ReferenceElementComponent, "referenceElement"> & {
+      updateComplete: Promise<unknown>;
+      el: HTMLElement;
+    };
+
+  async function assertSharedReferenceElementRegistration<T extends TestReferenceComponent>(
+    getAssociatedElements: (referenceElement: HTMLElement) => readonly Element[] | null,
+  ): Promise<void> {
+    const referenceElement = page.getByText("My Reference Element").element() as HTMLElement;
+
+    const [component1, component2] = getComponentElsByText<T>(2);
+
+    component1.referenceElement = referenceElement;
+    component2.referenceElement = referenceElement;
+    await Promise.all([component1.updateComplete, component2.updateComplete]);
+
+    expect(getAssociatedElements(referenceElement)).not.toBeNull();
+    expect(getAssociatedElements(referenceElement)).toContain(component1.el);
+    expect(getAssociatedElements(referenceElement)).toContain(component2.el);
+
+    component1.referenceElement = null;
+    await component1.updateComplete;
+
+    expect(getAssociatedElements(referenceElement)).not.toBeNull();
+    expect(getAssociatedElements(referenceElement)).not.toContain(component1.el);
+    expect(getAssociatedElements(referenceElement)).toContain(component2.el);
   }
 
   describe("click manager", () => {
@@ -167,30 +192,9 @@ describe("useReferenceElement", () => {
         { dynamicComponents: [TestClickComponent] },
       );
 
-      const referenceElement = page
-        .getByText("My Reference Element")
-        .element() as HTMLElement | null;
-
-      if (!referenceElement) {
-        throw new Error("Expected reference element to be present");
-      }
-
-      const [component1, component2] = getComponentsByText<TestClickComponent>(2);
-
-      component1.referenceElement = referenceElement;
-      component2.referenceElement = referenceElement;
-      await Promise.all([component1.updateComplete, component2.updateComplete]);
-
-      expect(referenceElement.ariaControlsElements).not.toBeNull();
-      expect(referenceElement.ariaControlsElements).toContain(component1.el);
-      expect(referenceElement.ariaControlsElements).toContain(component2.el);
-
-      component1.referenceElement = null;
-      await component1.updateComplete;
-
-      expect(referenceElement.ariaControlsElements).not.toBeNull();
-      expect(referenceElement.ariaControlsElements).not.toContain(component1.el);
-      expect(referenceElement.ariaControlsElements).toContain(component2.el);
+      await assertSharedReferenceElementRegistration<TestClickComponent>(
+        (referenceElement) => referenceElement.ariaControlsElements,
+      );
     });
   });
 
@@ -243,30 +247,9 @@ describe("useReferenceElement", () => {
         { dynamicComponents: [TestHoverComponent] },
       );
 
-      const referenceElement = page
-        .getByText("My Reference Element")
-        .element() as HTMLElement | null;
-
-      if (!referenceElement) {
-        throw new Error("Expected reference element to be present");
-      }
-
-      const [component1, component2] = getComponentsByText<TestHoverComponent>(2);
-
-      component1.referenceElement = referenceElement;
-      component2.referenceElement = referenceElement;
-      await Promise.all([component1.updateComplete, component2.updateComplete]);
-
-      expect(referenceElement.ariaDescribedByElements).not.toBeNull();
-      expect(referenceElement.ariaDescribedByElements).toContain(component1.el);
-      expect(referenceElement.ariaDescribedByElements).toContain(component2.el);
-
-      component1.referenceElement = null;
-      await component1.updateComplete;
-
-      expect(referenceElement.ariaDescribedByElements).not.toBeNull();
-      expect(referenceElement.ariaDescribedByElements).not.toContain(component1.el);
-      expect(referenceElement.ariaDescribedByElements).toContain(component2.el);
+      await assertSharedReferenceElementRegistration<TestHoverComponent>(
+        (referenceElement) => referenceElement.ariaDescribedByElements,
+      );
     });
   });
 });

--- a/packages/components/src/controllers/useReferenceElement/manager.ts
+++ b/packages/components/src/controllers/useReferenceElement/manager.ts
@@ -466,7 +466,7 @@ export const referenceElementManager = (options: ReferenceElementManagerOptions)
     if (options.click && "ariaControlsElements" in referenceEl) {
       const currentElements = referenceEl.ariaControlsElements ?? [];
 
-      if (!currentElements.includes(component)) {
+      if (!currentElements.includes(component.el)) {
         const updatedElements = [...currentElements, component.el];
         referenceEl.ariaControlsElements = updatedElements;
       }
@@ -475,7 +475,7 @@ export const referenceElementManager = (options: ReferenceElementManagerOptions)
     if (options.hover && "ariaDescribedByElements" in referenceEl) {
       const currentElements = referenceEl.ariaDescribedByElements ?? [];
 
-      if (!currentElements.includes(component)) {
+      if (!currentElements.includes(component.el)) {
         const updatedElements = [...currentElements, component.el];
         referenceEl.ariaDescribedByElements = updatedElements;
       }

--- a/packages/components/src/controllers/useReferenceElement/manager.ts
+++ b/packages/components/src/controllers/useReferenceElement/manager.ts
@@ -467,7 +467,7 @@ export const referenceElementManager = (options: ReferenceElementManagerOptions)
       const currentElements = referenceEl.ariaControlsElements ?? [];
 
       if (!currentElements.includes(component)) {
-        const updatedElements = [...currentElements, component];
+        const updatedElements = [...currentElements, component.el];
         referenceEl.ariaControlsElements = updatedElements;
       }
     }
@@ -476,7 +476,7 @@ export const referenceElementManager = (options: ReferenceElementManagerOptions)
       const currentElements = referenceEl.ariaDescribedByElements ?? [];
 
       if (!currentElements.includes(component)) {
-        const updatedElements = [...currentElements, component];
+        const updatedElements = [...currentElements, component.el];
         referenceEl.ariaDescribedByElements = updatedElements;
       }
     }
@@ -530,7 +530,7 @@ export const referenceElementManager = (options: ReferenceElementManagerOptions)
     }
 
     if (options.click && "ariaControlsElements" in referenceEl) {
-      const newElements = referenceEl.ariaControlsElements?.filter((element) => element !== component);
+      const newElements = referenceEl.ariaControlsElements?.filter((element) => element !== component.el);
       referenceEl.ariaControlsElements = newElements?.length > 0 ? newElements : null;
     }
 
@@ -546,7 +546,7 @@ export const referenceElementManager = (options: ReferenceElementManagerOptions)
     }
 
     if (options.hover && "ariaDescribedByElements" in referenceEl) {
-      const newElements = referenceEl.ariaDescribedByElements?.filter((element) => element !== component);
+      const newElements = referenceEl.ariaDescribedByElements?.filter((element) => element !== component.el);
       referenceEl.ariaDescribedByElements = newElements?.length > 0 ? newElements : null;
     }
   };


### PR DESCRIPTION
**Related Issue:** #13242

## Summary

Updates the `useReferenceElement` manager so ARIA element-reflection lists (`ariaControlsElements` / `ariaDescribedByElements`) store host elements, enabling a single `referenceElement` to be associated with multiple popovers/tooltips (Issue #13242).

**Changes:**
- Store `component.el` in `referenceEl.ariaControlsElements` and `referenceEl.ariaDescribedByElements` (instead of the component instance).
- Update existing browser specs to assert against `component.el`.
- Add browser specs covering multiple components sharing the same `referenceElement` and unregistering independently.
