### PR TITLE
feat(sort-handle): hide reorder group title when no sibling groups; disable boundary items instead of hiding

### DIFF
--- a/packages/components/src/components/sort-handle/sort-handle.browser.e2e.tsx
+++ b/packages/components/src/components/sort-handle/sort-handle.browser.e2e.tsx
@@ -100,7 +100,7 @@ it("omits the reorder group title when it is the only visible group", async () =
 
   const reorderGroup = el.shadowRoot.querySelector<DropdownGroupLike>(`#${IDS.reorder}`);
 
-  expect(reorderGroup.groupTitle).toBeUndefined();
+  expect(reorderGroup.groupTitle).toBe("");
 });
 
 it("shows the reorder group title when move-to items are present", async () => {

--- a/packages/components/src/components/sort-handle/sort-handle.browser.e2e.tsx
+++ b/packages/components/src/components/sort-handle/sort-handle.browser.e2e.tsx
@@ -11,6 +11,11 @@ import {
   t9n,
 } from "../../tests/commonTests/browser";
 import { IDS } from "./resources";
+import { SortHandle } from "./sort-handle";
+
+type DropdownLike = HTMLElement & { disabled: boolean };
+type DropdownGroupLike = HTMLElement & { groupTitle?: string };
+type DropdownItemLike = HTMLElement & { disabled: boolean };
 
 describe("defaults", () => {
   defaults(
@@ -73,12 +78,14 @@ describe("disabled", () => {
 });
 
 it("renders disabled boundary reorder items instead of hiding them", async () => {
-  const { el } = await mount(<calcite-sort-handle label="test" set-position="1" set-size="4" />);
-  await el.updateComplete;
+  const { el, reRender } = await mount(
+    <calcite-sort-handle label="test" set-position="1" set-size="4" />,
+  );
+  await reRender();
 
   const reorderGroup = el.shadowRoot.querySelector<HTMLElement>(`#${IDS.reorder}`);
   const reorderItems = Array.from(
-    reorderGroup.querySelectorAll<HTMLCalciteDropdownItemElement>("calcite-dropdown-item"),
+    reorderGroup.querySelectorAll<DropdownItemLike>("calcite-dropdown-item"),
   );
 
   expect(reorderItems).toHaveLength(4);
@@ -86,12 +93,12 @@ it("renders disabled boundary reorder items instead of hiding them", async () =>
 });
 
 it("omits the reorder group title when it is the only visible group", async () => {
-  const { el } = await mount(<calcite-sort-handle label="test" set-position="2" set-size="4" />);
-  await el.updateComplete;
-
-  const reorderGroup = el.shadowRoot.querySelector<HTMLCalciteDropdownGroupElement>(
-    `#${IDS.reorder}`,
+  const { el, reRender } = await mount(
+    <calcite-sort-handle label="test" set-position="2" set-size="4" />,
   );
+  await reRender();
+
+  const reorderGroup = el.shadowRoot.querySelector<DropdownGroupLike>(`#${IDS.reorder}`);
 
   expect(reorderGroup.groupTitle).toBeUndefined();
 });
@@ -101,25 +108,29 @@ it("shows the reorder group title when move-to items are present", async () => {
     <calcite-sort-handle label="test" set-position="2" set-size="4" />,
   );
 
-  el.moveToItems = [{ label: "List 2", id: "list2" }];
+  const sortHandle = el as SortHandle;
+
+  sortHandle.moveToItems = [
+    { element: document.createElement("div"), label: "List 2", id: "list2" },
+  ];
   await reRender();
 
-  const reorderGroup = el.shadowRoot.querySelector<HTMLCalciteDropdownGroupElement>(
-    `#${IDS.reorder}`,
-  );
+  const reorderGroup = el.shadowRoot.querySelector<DropdownGroupLike>(`#${IDS.reorder}`);
 
   expect(reorderGroup.groupTitle).toBe("Reorder");
 });
 
 it("keeps single-item sets enabled and renders disabled reorder actions", async () => {
-  const { el } = await mount(<calcite-sort-handle label="test" set-position="1" set-size="1" />);
-  await el.updateComplete;
+  const { el, reRender } = await mount(
+    <calcite-sort-handle label="test" set-position="1" set-size="1" />,
+  );
+  await reRender();
 
-  const dropdown = el.shadowRoot.querySelector<HTMLCalciteDropdownElement>("calcite-dropdown");
+  const dropdown = el.shadowRoot.querySelector<DropdownLike>("calcite-dropdown");
   const reorderItems = Array.from(
     el.shadowRoot
       .querySelector(`#${IDS.reorder}`)
-      .querySelectorAll<HTMLCalciteDropdownItemElement>("calcite-dropdown-item"),
+      .querySelectorAll<DropdownItemLike>("calcite-dropdown-item"),
   );
 
   expect(dropdown.disabled).toBe(false);

--- a/packages/components/src/components/sort-handle/sort-handle.browser.e2e.tsx
+++ b/packages/components/src/components/sort-handle/sort-handle.browser.e2e.tsx
@@ -120,7 +120,7 @@ it("shows the reorder group title when move-to items are present", async () => {
   expect(reorderGroup.groupTitle).toBe("Reorder");
 });
 
-it("keeps single-item sets enabled and renders disabled reorder actions", async () => {
+it("disables single-item sets and renders disabled reorder actions", async () => {
   const { el, reRender } = await mount(
     <calcite-sort-handle label="test" set-position="1" set-size="1" />,
   );
@@ -133,6 +133,24 @@ it("keeps single-item sets enabled and renders disabled reorder actions", async 
       .querySelectorAll<DropdownItemLike>("calcite-dropdown-item"),
   );
 
-  expect(dropdown.disabled).toBe(false);
+  expect(dropdown.disabled).toBe(true);
   expect(reorderItems.map((item) => item.disabled)).toEqual([true, true, true, true]);
+});
+
+it("keeps single-item sets enabled when move-to items are available", async () => {
+  const { el, reRender } = await mount(
+    <calcite-sort-handle label="test" set-position="1" set-size="1" />,
+  );
+
+  const sortHandle = el as SortHandle;
+
+  sortHandle.moveToItems = [
+    { element: document.createElement("div"), label: "List 2", id: "list2" },
+    { element: document.createElement("div"), label: "List 3", id: "list3" },
+  ];
+  await reRender();
+
+  const dropdown = el.shadowRoot.querySelector<DropdownLike>("calcite-dropdown");
+
+  expect(dropdown.disabled).toBe(false);
 });

--- a/packages/components/src/components/sort-handle/sort-handle.browser.e2e.tsx
+++ b/packages/components/src/components/sort-handle/sort-handle.browser.e2e.tsx
@@ -1,6 +1,7 @@
 import { h } from "@arcgis/lumina";
 import { describe, expect, it } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
+import { page } from "vitest/browser";
 import {
   defaults,
   disabled,
@@ -10,12 +11,18 @@ import {
   renders,
   t9n,
 } from "../../tests/commonTests/browser";
-import { IDS } from "./resources";
+import T9nStrings from "./assets/t9n/messages.en.json";
 import { SortHandle } from "./sort-handle";
 
-type DropdownLike = HTMLElement & { disabled: boolean };
-type DropdownGroupLike = HTMLElement & { groupTitle?: string };
-type DropdownItemLike = HTMLElement & { disabled: boolean };
+function getDropdownFromItemText(text: string) {
+  const dropdown = page.getByText(text).element()?.closest("calcite-dropdown");
+
+  if (!dropdown) {
+    throw new Error(`Expected calcite-dropdown for item text: ${text}`);
+  }
+
+  return page.elementLocator(dropdown);
+}
 
 describe("defaults", () => {
   defaults(
@@ -78,29 +85,29 @@ describe("disabled", () => {
 });
 
 it("renders disabled boundary reorder items instead of hiding them", async () => {
-  const { el, reRender } = await mount(
+  const { reRender } = await mount(
     <calcite-sort-handle label="test" set-position="1" set-size="4" />,
   );
   await reRender();
 
-  const reorderGroup = el.shadowRoot.querySelector<HTMLElement>(`#${IDS.reorder}`);
-  const reorderItems = Array.from(
-    reorderGroup.querySelectorAll<DropdownItemLike>("calcite-dropdown-item"),
-  );
+  const firstReorderItem = page.getByText(T9nStrings.moveToTop);
+  const secondReorderItem = page.getByText(T9nStrings.moveUp);
+  const thirdReorderItem = page.getByText(T9nStrings.moveDown);
+  const fourthReorderItem = page.getByText(T9nStrings.moveToBottom);
 
-  expect(reorderItems).toHaveLength(4);
-  expect(reorderItems.map((item) => item.disabled)).toEqual([true, true, false, false]);
+  await expect.element(firstReorderItem).toHaveProperty("disabled", true);
+  await expect.element(secondReorderItem).toHaveProperty("disabled", true);
+  await expect.element(thirdReorderItem).toHaveProperty("disabled", false);
+  await expect.element(fourthReorderItem).toHaveProperty("disabled", false);
 });
 
 it("omits the reorder group title when it is the only visible group", async () => {
-  const { el, reRender } = await mount(
+  const { reRender } = await mount(
     <calcite-sort-handle label="test" set-position="2" set-size="4" />,
   );
   await reRender();
 
-  const reorderGroup = el.shadowRoot.querySelector<DropdownGroupLike>(`#${IDS.reorder}`);
-
-  expect(reorderGroup.groupTitle).toBe("");
+  await expect.element(page.getByText(T9nStrings.reorder)).not.toBeInTheDocument();
 });
 
 it("shows the reorder group title when move-to items are present", async () => {
@@ -115,26 +122,26 @@ it("shows the reorder group title when move-to items are present", async () => {
   ];
   await reRender();
 
-  const reorderGroup = el.shadowRoot.querySelector<DropdownGroupLike>(`#${IDS.reorder}`);
-
-  expect(reorderGroup.groupTitle).toBe("Reorder");
+  await expect.element(page.getByText(T9nStrings.reorder)).toBeInTheDocument();
 });
 
 it("disables single-item sets and renders disabled reorder actions", async () => {
-  const { el, reRender } = await mount(
+  const { reRender } = await mount(
     <calcite-sort-handle label="test" set-position="1" set-size="1" />,
   );
   await reRender();
 
-  const dropdown = el.shadowRoot.querySelector<DropdownLike>("calcite-dropdown");
-  const reorderItems = Array.from(
-    el.shadowRoot
-      .querySelector(`#${IDS.reorder}`)
-      .querySelectorAll<DropdownItemLike>("calcite-dropdown-item"),
-  );
+  const dropdown = getDropdownFromItemText(T9nStrings.moveToTop);
+  const firstReorderItem = page.getByText(T9nStrings.moveToTop);
+  const secondReorderItem = page.getByText(T9nStrings.moveUp);
+  const thirdReorderItem = page.getByText(T9nStrings.moveDown);
+  const fourthReorderItem = page.getByText(T9nStrings.moveToBottom);
 
-  expect(dropdown.disabled).toBe(true);
-  expect(reorderItems.map((item) => item.disabled)).toEqual([true, true, true, true]);
+  await expect.element(dropdown).toHaveProperty("disabled", true);
+  await expect.element(firstReorderItem).toHaveProperty("disabled", true);
+  await expect.element(secondReorderItem).toHaveProperty("disabled", true);
+  await expect.element(thirdReorderItem).toHaveProperty("disabled", true);
+  await expect.element(fourthReorderItem).toHaveProperty("disabled", true);
 });
 
 it("keeps single-item sets enabled when move-to items are available", async () => {
@@ -150,7 +157,7 @@ it("keeps single-item sets enabled when move-to items are available", async () =
   ];
   await reRender();
 
-  const dropdown = el.shadowRoot.querySelector<DropdownLike>("calcite-dropdown");
+  const dropdown = getDropdownFromItemText(T9nStrings.moveToTop);
 
-  expect(dropdown.disabled).toBe(false);
+  await expect.element(dropdown).toHaveProperty("disabled", false);
 });

--- a/packages/components/src/components/sort-handle/sort-handle.browser.e2e.tsx
+++ b/packages/components/src/components/sort-handle/sort-handle.browser.e2e.tsx
@@ -1,5 +1,5 @@
 import { h } from "@arcgis/lumina";
-import { describe } from "vitest";
+import { describe, expect, it } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import {
   defaults,
@@ -10,6 +10,7 @@ import {
   renders,
   t9n,
 } from "../../tests/commonTests/browser";
+import { IDS } from "./resources";
 
 describe("defaults", () => {
   defaults(
@@ -69,4 +70,58 @@ describe("translation support", () => {
 
 describe("disabled", () => {
   disabled(() => mount(<calcite-sort-handle label="test" set-position="4" set-size="10" />));
+});
+
+it("renders disabled boundary reorder items instead of hiding them", async () => {
+  const { el } = await mount(<calcite-sort-handle label="test" set-position="1" set-size="4" />);
+  await el.updateComplete;
+
+  const reorderGroup = el.shadowRoot.querySelector<HTMLElement>(`#${IDS.reorder}`);
+  const reorderItems = Array.from(
+    reorderGroup.querySelectorAll<HTMLCalciteDropdownItemElement>("calcite-dropdown-item"),
+  );
+
+  expect(reorderItems).toHaveLength(4);
+  expect(reorderItems.map((item) => item.disabled)).toEqual([true, true, false, false]);
+});
+
+it("omits the reorder group title when it is the only visible group", async () => {
+  const { el } = await mount(<calcite-sort-handle label="test" set-position="2" set-size="4" />);
+  await el.updateComplete;
+
+  const reorderGroup = el.shadowRoot.querySelector<HTMLCalciteDropdownGroupElement>(
+    `#${IDS.reorder}`,
+  );
+
+  expect(reorderGroup.groupTitle).toBeUndefined();
+});
+
+it("shows the reorder group title when move-to items are present", async () => {
+  const { el, reRender } = await mount(
+    <calcite-sort-handle label="test" set-position="2" set-size="4" />,
+  );
+
+  el.moveToItems = [{ label: "List 2", id: "list2" }];
+  await reRender();
+
+  const reorderGroup = el.shadowRoot.querySelector<HTMLCalciteDropdownGroupElement>(
+    `#${IDS.reorder}`,
+  );
+
+  expect(reorderGroup.groupTitle).toBe("Reorder");
+});
+
+it("keeps single-item sets enabled and renders disabled reorder actions", async () => {
+  const { el } = await mount(<calcite-sort-handle label="test" set-position="1" set-size="1" />);
+  await el.updateComplete;
+
+  const dropdown = el.shadowRoot.querySelector<HTMLCalciteDropdownElement>("calcite-dropdown");
+  const reorderItems = Array.from(
+    el.shadowRoot
+      .querySelector(`#${IDS.reorder}`)
+      .querySelectorAll<HTMLCalciteDropdownItemElement>("calcite-dropdown-item"),
+  );
+
+  expect(dropdown.disabled).toBe(false);
+  expect(reorderItems.map((item) => item.disabled)).toEqual([true, true, true, true]);
 });

--- a/packages/components/src/components/sort-handle/sort-handle.e2e.ts
+++ b/packages/components/src/components/sort-handle/sort-handle.e2e.ts
@@ -137,7 +137,7 @@ it("fires calciteSortHandleAdd event", async () => {
   expect(calciteSortHandleAddSpy.lastEvent.cancelable).toBe(true);
 });
 
-it("is disabled when no items are available, sort is disabled, or set info is invalid", async () => {
+it("is disabled when no items are available, sort is disabled, set info is invalid, or all reorder actions are disabled", async () => {
   const page = await newE2EPage();
   await page.setContent(`<calcite-sort-handle label="test"></calcite-sort-handle>`);
   await skipAnimations(page);
@@ -175,9 +175,13 @@ it("is disabled when no items are available, sort is disabled, or set info is in
   sortHandle.setProperty("moveToItems", []);
   await page.waitForChanges();
 
-  expect(await dropdown.getProperty("disabled")).toBe(false);
+  expect(await dropdown.getProperty("disabled")).toBe(true);
 
   sortHandle.setProperty("moveToItems", moveToItems);
+  await page.waitForChanges();
+
+  expect(await dropdown.getProperty("disabled")).toBe(false);
+
   sortHandle.setProperty("setSize", 2);
   await page.waitForChanges();
 
@@ -252,7 +256,7 @@ it("shows reorder group title when moveTo items are present", async () => {
   expect(await reorderGroup.getProperty("groupTitle")).toBe(T9nStrings.reorder);
 });
 
-it("keeps single-item sets enabled and renders disabled reorder actions", async () => {
+it("disables single-item sets and renders disabled reorder actions", async () => {
   const page = await newE2EPage();
   await page.setContent(`<calcite-sort-handle label="test" set-position="1" set-size="1"></calcite-sort-handle>`);
   await skipAnimations(page);
@@ -260,12 +264,29 @@ it("keeps single-item sets enabled and renders disabled reorder actions", async 
   const dropdown = await page.find("calcite-sort-handle >>> calcite-dropdown");
   const reorderItems = await findAll(page, `calcite-sort-handle >>> #${IDS.reorder} calcite-dropdown-item`);
 
-  expect(await dropdown.getProperty("disabled")).toBe(false);
+  expect(await dropdown.getProperty("disabled")).toBe(true);
   expect(reorderItems).toHaveLength(4);
 
   for (const item of reorderItems) {
     expect(await item.getProperty("disabled")).toBe(true);
   }
+});
+
+it("keeps single-item sets enabled when move-to items are available", async () => {
+  const page = await newE2EPage();
+  await page.setContent(`<calcite-sort-handle label="test" set-position="1" set-size="1"></calcite-sort-handle>`);
+  await skipAnimations(page);
+
+  const sortHandle = await page.find("calcite-sort-handle");
+  sortHandle.setProperty("moveToItems", [
+    { label: "List 2", id: "list2" },
+    { label: "List 3", id: "list3" },
+  ]);
+  await page.waitForChanges();
+
+  const dropdown = await page.find("calcite-sort-handle >>> calcite-dropdown");
+
+  expect(await dropdown.getProperty("disabled")).toBe(false);
 });
 
 it("doesn't render reorder group when sortDisabled is true", async () => {

--- a/packages/components/src/components/sort-handle/sort-handle.e2e.ts
+++ b/packages/components/src/components/sort-handle/sort-handle.e2e.ts
@@ -236,7 +236,7 @@ it("hides reorder group title when it is the only visible group", async () => {
 
   const reorderGroup = await page.find(`calcite-sort-handle >>> #${IDS.reorder}`);
 
-  expect(await reorderGroup.getProperty("groupTitle")).toBeUndefined();
+  expect(await reorderGroup.getProperty("groupTitle")).toBe("");
 });
 
 it("shows reorder group title when moveTo items are present", async () => {

--- a/packages/components/src/components/sort-handle/sort-handle.e2e.ts
+++ b/packages/components/src/components/sort-handle/sort-handle.e2e.ts
@@ -2,11 +2,21 @@
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import { accessible, openClose } from "../../tests/commonTests";
-import { skipAnimations } from "../../tests/utils/puppeteer";
+import { findAll, skipAnimations } from "../../tests/utils/puppeteer";
 import T9nStrings from "./assets/t9n/messages.en.json";
 import { CSS, IDS, REORDER_VALUES, SUBSTITUTIONS } from "./resources";
 import type { AddEventDetail, MoveEventDetail } from "./interfaces";
 import type { ReorderEventDetail } from "./interfaces";
+
+async function openSortHandle(page): Promise<void> {
+  const action = await page.find(`calcite-sort-handle >>> .${CSS.handle}`);
+  await action.callMethod("setFocus");
+
+  const openEventSpy = await page.spyOnEvent("calciteSortHandleOpen");
+  await page.keyboard.press("ArrowDown");
+  await page.waitForChanges();
+  await openEventSpy.next();
+}
 
 describe("accessible", () => {
   accessible(`<calcite-sort-handle label="test" set-position="4" set-size="10"></calcite-sort-handle>`);
@@ -53,13 +63,7 @@ it("fires calciteSortHandleReorder event", async () => {
 
   const calciteSortHandleReorderSpy = await page.spyOnEvent<ReorderEventDetail>("calciteSortHandleReorder");
 
-  const action = await page.find(`calcite-sort-handle >>> .${CSS.handle}`);
-  await action.callMethod("setFocus");
-
-  const openEventSpy = await page.spyOnEvent("calciteSortHandleOpen");
-  await page.keyboard.press("ArrowDown");
-  await page.waitForChanges();
-  await openEventSpy.next();
+  await openSortHandle(page);
   expect(await sortHandle.getProperty("open")).toBe(true);
 
   await page.keyboard.press("Enter");
@@ -133,7 +137,7 @@ it("fires calciteSortHandleAdd event", async () => {
   expect(calciteSortHandleAddSpy.lastEvent.cancelable).toBe(true);
 });
 
-it("is disabled when no moveToItems and sortDisabled, setPosition < 1 or setSize < 2", async () => {
+it("is disabled when no items are available, sort is disabled, or set info is invalid", async () => {
   const page = await newE2EPage();
   await page.setContent(`<calcite-sort-handle label="test"></calcite-sort-handle>`);
   await skipAnimations(page);
@@ -171,7 +175,7 @@ it("is disabled when no moveToItems and sortDisabled, setPosition < 1 or setSize
   sortHandle.setProperty("moveToItems", []);
   await page.waitForChanges();
 
-  expect(await dropdown.getProperty("disabled")).toBe(true);
+  expect(await dropdown.getProperty("disabled")).toBe(false);
 
   sortHandle.setProperty("moveToItems", moveToItems);
   sortHandle.setProperty("setSize", 2);
@@ -189,6 +193,79 @@ it("is disabled when no moveToItems and sortDisabled, setPosition < 1 or setSize
   await page.waitForChanges();
 
   expect(await dropdown.getProperty("disabled")).toBe(false);
+});
+
+it("renders boundary reorder items disabled instead of hiding them", async () => {
+  const page = await newE2EPage();
+  await page.setContent(`<calcite-sort-handle label="test" set-position="1" set-size="4"></calcite-sort-handle>`);
+  await skipAnimations(page);
+
+  const reorderItems = await findAll(page, `calcite-sort-handle >>> #${IDS.reorder} calcite-dropdown-item`);
+
+  expect(reorderItems).toHaveLength(4);
+  expect(await reorderItems[0].getProperty("disabled")).toBe(true);
+  expect(await reorderItems[1].getProperty("disabled")).toBe(true);
+  expect(await reorderItems[2].getProperty("disabled")).toBe(false);
+  expect(await reorderItems[3].getProperty("disabled")).toBe(false);
+});
+
+it("does not emit reorder from disabled boundary items and still allows enabled actions", async () => {
+  const page = await newE2EPage();
+  await page.setContent(`<calcite-sort-handle label="test" set-position="1" set-size="4"></calcite-sort-handle>`);
+  await skipAnimations(page);
+
+  const calciteSortHandleReorderSpy = await page.spyOnEvent<ReorderEventDetail>("calciteSortHandleReorder");
+
+  await openSortHandle(page);
+
+  const reorderItems = await findAll(page, `calcite-sort-handle >>> #${IDS.reorder} calcite-dropdown-item`);
+  await reorderItems[0].click();
+  await page.waitForChanges();
+
+  expect(calciteSortHandleReorderSpy).toHaveReceivedEventTimes(0);
+
+  await reorderItems[2].click();
+  await page.waitForChanges();
+  expect(calciteSortHandleReorderSpy.lastEvent.detail.reorder).toBe(REORDER_VALUES[2]);
+});
+
+it("hides reorder group title when it is the only visible group", async () => {
+  const page = await newE2EPage();
+  await page.setContent(`<calcite-sort-handle label="test" set-position="2" set-size="4"></calcite-sort-handle>`);
+  await page.waitForChanges();
+
+  const reorderGroup = await page.find(`calcite-sort-handle >>> #${IDS.reorder}`);
+
+  expect(await reorderGroup.getProperty("groupTitle")).toBeUndefined();
+});
+
+it("shows reorder group title when moveTo items are present", async () => {
+  const page = await newE2EPage();
+  await page.setContent(`<calcite-sort-handle label="test" set-position="2" set-size="4"></calcite-sort-handle>`);
+
+  const sortHandle = await page.find("calcite-sort-handle");
+  sortHandle.setProperty("moveToItems", [{ label: "List 2", id: "list2" }]);
+  await page.waitForChanges();
+
+  const reorderGroup = await page.find(`calcite-sort-handle >>> #${IDS.reorder}`);
+
+  expect(await reorderGroup.getProperty("groupTitle")).toBe(T9nStrings.reorder);
+});
+
+it("keeps single-item sets enabled and renders disabled reorder actions", async () => {
+  const page = await newE2EPage();
+  await page.setContent(`<calcite-sort-handle label="test" set-position="1" set-size="1"></calcite-sort-handle>`);
+  await skipAnimations(page);
+
+  const dropdown = await page.find("calcite-sort-handle >>> calcite-dropdown");
+  const reorderItems = await findAll(page, `calcite-sort-handle >>> #${IDS.reorder} calcite-dropdown-item`);
+
+  expect(await dropdown.getProperty("disabled")).toBe(false);
+  expect(reorderItems).toHaveLength(4);
+
+  for (const item of reorderItems) {
+    expect(await item.getProperty("disabled")).toBe(true);
+  }
 });
 
 it("doesn't render reorder group when sortDisabled is true", async () => {

--- a/packages/components/src/components/sort-handle/sort-handle.stories.ts
+++ b/packages/components/src/components/sort-handle/sort-handle.stories.ts
@@ -49,27 +49,43 @@ export const positions = (): string => html`
 
 export const withMoveToItems = (): string => html`
   <div style="height:600px; width:600px;">
-    <calcite-sort-handle label="test" set-position="4" set-size="10" open></calcite-sort-handle>
+    <calcite-sort-handle id="move-to-story-handle" label="test" set-position="4" set-size="10"></calcite-sort-handle>
   </div>
   <script>
-    const sortHandle = document.querySelector("calcite-sort-handle");
-    sortHandle.moveToItems = [
-      { element: document.createElement("div"), id: "1", label: "Group 1" },
-      { element: document.createElement("div"), id: "2", label: "Group 2" },
-    ];
+    (async () => {
+      await customElements.whenDefined("calcite-sort-handle");
+
+      const sortHandle = document.querySelector("#move-to-story-handle");
+      await sortHandle.componentOnReady();
+
+      sortHandle.moveToItems = [
+        { element: document.createElement("div"), id: "1", label: "Group 1" },
+        { element: document.createElement("div"), id: "2", label: "Group 2" },
+      ];
+
+      sortHandle.open = true;
+    })();
   </script>
 `;
 
 export const withAddToItems = (): string => html`
   <div style="height:600px; width:600px;">
-    <calcite-sort-handle label="test" set-position="4" set-size="10" open></calcite-sort-handle>
+    <calcite-sort-handle id="add-to-story-handle" label="test" set-position="4" set-size="10"></calcite-sort-handle>
   </div>
   <script>
-    const sortHandle = document.querySelector("calcite-sort-handle");
-    sortHandle.addToItems = [
-      { element: document.createElement("div"), id: "1", label: "Group 1" },
-      { element: document.createElement("div"), id: "2", label: "Group 2" },
-    ];
+    (async () => {
+      await customElements.whenDefined("calcite-sort-handle");
+
+      const sortHandle = document.querySelector("#add-to-story-handle");
+      await sortHandle.componentOnReady();
+
+      sortHandle.addToItems = [
+        { element: document.createElement("div"), id: "1", label: "Group 1" },
+        { element: document.createElement("div"), id: "2", label: "Group 2" },
+      ];
+
+      sortHandle.open = true;
+    })();
   </script>
 `;
 

--- a/packages/components/src/components/sort-handle/sort-handle.tsx
+++ b/packages/components/src/components/sort-handle/sort-handle.tsx
@@ -75,10 +75,10 @@ export class SortHandle extends LitElement {
   get hasAllReorderItemsDisabled(): boolean {
     return (
       this.hasReorderItems &&
-      this.isTopReorderDisabled() &&
-      this.isUpReorderDisabled() &&
-      this.isDownReorderDisabled() &&
-      this.isBottomReorderDisabled()
+      this.isTopReorderDisabled &&
+      this.isUpReorderDisabled &&
+      this.isDownReorderDisabled &&
+      this.isBottomReorderDisabled
     );
   }
 
@@ -89,6 +89,26 @@ export class SortHandle extends LitElement {
       !this.hasAddToItems &&
       this.hasAllReorderItemsDisabled
     );
+  }
+
+  get isTopReorderDisabled(): boolean {
+    const { setPosition } = this;
+
+    return setPosition === 1 || setPosition === 2;
+  }
+
+  get isUpReorderDisabled(): boolean {
+    return this.setPosition === 1;
+  }
+
+  get isDownReorderDisabled(): boolean {
+    return this.setPosition === this.setSize;
+  }
+
+  get isBottomReorderDisabled(): boolean {
+    const { setPosition, setSize } = this;
+
+    return setPosition === setSize || setPosition === setSize - 1;
   }
 
   private interactiveContainer = useInteractive(this);
@@ -301,26 +321,6 @@ export class SortHandle extends LitElement {
     this.calciteSortHandleAdd.emit({ addTo });
   }
 
-  private isTopReorderDisabled(): boolean {
-    const { setPosition } = this;
-
-    return setPosition === 1 || setPosition === 2;
-  }
-
-  private isUpReorderDisabled(): boolean {
-    return this.setPosition === 1;
-  }
-
-  private isDownReorderDisabled(): boolean {
-    return this.setPosition === this.setSize;
-  }
-
-  private isBottomReorderDisabled(): boolean {
-    const { setPosition, setSize } = this;
-
-    return setPosition === setSize || setPosition === setSize - 1;
-  }
-
   //#endregion
 
   //#region Rendering
@@ -468,19 +468,19 @@ export class SortHandle extends LitElement {
   }
 
   private renderTop(): JsxNode {
-    return this.renderDropdownItem(0, this.messages.moveToTop, this.isTopReorderDisabled());
+    return this.renderDropdownItem(0, this.messages.moveToTop, this.isTopReorderDisabled);
   }
 
   private renderUp(): JsxNode {
-    return this.renderDropdownItem(1, this.messages.moveUp, this.isUpReorderDisabled());
+    return this.renderDropdownItem(1, this.messages.moveUp, this.isUpReorderDisabled);
   }
 
   private renderDown(): JsxNode {
-    return this.renderDropdownItem(2, this.messages.moveDown, this.isDownReorderDisabled());
+    return this.renderDropdownItem(2, this.messages.moveDown, this.isDownReorderDisabled);
   }
 
   private renderBottom(): JsxNode {
-    return this.renderDropdownItem(3, this.messages.moveToBottom, this.isBottomReorderDisabled());
+    return this.renderDropdownItem(3, this.messages.moveToBottom, this.isBottomReorderDisabled);
   }
 
   //#endregion

--- a/packages/components/src/components/sort-handle/sort-handle.tsx
+++ b/packages/components/src/components/sort-handle/sort-handle.tsx
@@ -72,6 +72,25 @@ export class SortHandle extends LitElement {
     return !this.hasReorderItems && !this.hasMoveToItems && !this.hasAddToItems;
   }
 
+  get hasAllReorderItemsDisabled(): boolean {
+    return (
+      this.hasReorderItems &&
+      this.isTopReorderDisabled() &&
+      this.isUpReorderDisabled() &&
+      this.isDownReorderDisabled() &&
+      this.isBottomReorderDisabled()
+    );
+  }
+
+  get hasOnlyDisabledReorderItems(): boolean {
+    return (
+      this.hasReorderItems &&
+      !this.hasMoveToItems &&
+      !this.hasAddToItems &&
+      this.hasAllReorderItemsDisabled
+    );
+  }
+
   private interactiveContainer = useInteractive(this);
 
   //#endregion
@@ -282,6 +301,26 @@ export class SortHandle extends LitElement {
     this.calciteSortHandleAdd.emit({ addTo });
   }
 
+  private isTopReorderDisabled(): boolean {
+    const { setPosition } = this;
+
+    return setPosition === 1 || setPosition === 2;
+  }
+
+  private isUpReorderDisabled(): boolean {
+    return this.setPosition === 1;
+  }
+
+  private isDownReorderDisabled(): boolean {
+    return this.setPosition === this.setSize;
+  }
+
+  private isBottomReorderDisabled(): boolean {
+    const { setPosition, setSize } = this;
+
+    return setPosition === setSize || setPosition === setSize - 1;
+  }
+
   //#endregion
 
   //#region Rendering
@@ -290,6 +329,7 @@ export class SortHandle extends LitElement {
     const {
       disabled,
       flipPlacements,
+      hasOnlyDisabledReorderItems,
       open,
       overlayPositioning,
       placement,
@@ -299,7 +339,7 @@ export class SortHandle extends LitElement {
     } = this;
 
     const text = this.getLabel();
-    const isDisabled = disabled || hasNoItems;
+    const isDisabled = disabled || hasNoItems || hasOnlyDisabledReorderItems;
 
     return (
       <this.interactiveContainer disabled={disabled}>
@@ -428,31 +468,19 @@ export class SortHandle extends LitElement {
   }
 
   private renderTop(): JsxNode {
-    const { setPosition } = this;
-
-    return this.renderDropdownItem(
-      0,
-      this.messages.moveToTop,
-      setPosition === 1 || setPosition === 2,
-    );
+    return this.renderDropdownItem(0, this.messages.moveToTop, this.isTopReorderDisabled());
   }
 
   private renderUp(): JsxNode {
-    return this.renderDropdownItem(1, this.messages.moveUp, this.setPosition === 1);
+    return this.renderDropdownItem(1, this.messages.moveUp, this.isUpReorderDisabled());
   }
 
   private renderDown(): JsxNode {
-    return this.renderDropdownItem(2, this.messages.moveDown, this.setPosition === this.setSize);
+    return this.renderDropdownItem(2, this.messages.moveDown, this.isDownReorderDisabled());
   }
 
   private renderBottom(): JsxNode {
-    const { setPosition, setSize } = this;
-
-    return this.renderDropdownItem(
-      3,
-      this.messages.moveToBottom,
-      setPosition === setSize || setPosition === setSize - 1,
-    );
+    return this.renderDropdownItem(3, this.messages.moveToBottom, this.isBottomReorderDisabled());
   }
 
   //#endregion

--- a/packages/components/src/components/sort-handle/sort-handle.tsx
+++ b/packages/components/src/components/sort-handle/sort-handle.tsx
@@ -47,15 +47,29 @@ export class SortHandle extends LitElement {
   }
 
   get hasValidSetInfo(): boolean {
-    return this.hasSetInfo ? this.setPosition > 0 && this.setSize > 1 : true;
+    return this.hasSetInfo
+      ? this.setPosition > 0 && this.setPosition <= this.setSize && this.setSize > 0
+      : true;
   }
 
   get hasReorderItems(): boolean {
     return !this.sortDisabled && this.hasValidSetInfo;
   }
 
+  get hasMoveToItems(): boolean {
+    return this.moveToItems.length > 0;
+  }
+
+  get hasAddToItems(): boolean {
+    return this.addToItems.length > 0;
+  }
+
+  get reorderGroupTitle(): string {
+    return this.hasMoveToItems || this.hasAddToItems ? this.messages.reorder : null;
+  }
+
   get hasNoItems(): boolean {
-    return !this.hasReorderItems && this.moveToItems.length < 1 && this.addToItems.length < 1;
+    return !this.hasReorderItems && !this.hasMoveToItems && !this.hasAddToItems;
   }
 
   private interactiveContainer = useInteractive(this);
@@ -353,7 +367,7 @@ export class SortHandle extends LitElement {
   private renderReorderGroup(): JsxNode {
     return this.hasReorderItems ? (
       <calcite-dropdown-group
-        groupTitle={this.messages.reorder}
+        groupTitle={this.reorderGroupTitle}
         id={IDS.reorder}
         key="reorder"
         scale={this.scale}
@@ -368,9 +382,9 @@ export class SortHandle extends LitElement {
   }
 
   private renderAddToGroup(): JsxNode {
-    const { messages, addToItems, scale } = this;
+    const { messages, addToItems, scale, hasAddToItems } = this;
 
-    return addToItems.length ? (
+    return hasAddToItems ? (
       <calcite-dropdown-group
         groupTitle={messages.addTo}
         id={IDS.add}
@@ -384,9 +398,9 @@ export class SortHandle extends LitElement {
   }
 
   private renderMoveToGroup(): JsxNode {
-    const { messages, moveToItems, scale } = this;
+    const { messages, moveToItems, scale, hasMoveToItems } = this;
 
-    return moveToItems.length ? (
+    return hasMoveToItems ? (
       <calcite-dropdown-group
         groupTitle={messages.moveTo}
         id={IDS.move}
@@ -399,10 +413,11 @@ export class SortHandle extends LitElement {
     ) : null;
   }
 
-  private renderDropdownItem(positionIndex: number, label: string): JsxNode {
+  private renderDropdownItem(positionIndex: number, label: string, disabled = false): JsxNode {
     return (
       <calcite-dropdown-item
         data-value={REORDER_VALUES[positionIndex]}
+        disabled={disabled}
         key={REORDER_VALUES[positionIndex]}
         label={label}
         oncalciteDropdownItemSelect={this.handleReorder}
@@ -412,30 +427,32 @@ export class SortHandle extends LitElement {
     );
   }
 
-  private renderTop(): JsxNode | null {
+  private renderTop(): JsxNode {
     const { setPosition } = this;
 
-    return setPosition !== 1 && setPosition !== 2
-      ? this.renderDropdownItem(0, this.messages.moveToTop)
-      : null;
+    return this.renderDropdownItem(
+      0,
+      this.messages.moveToTop,
+      setPosition === 1 || setPosition === 2,
+    );
   }
 
-  private renderUp(): JsxNode | null {
-    return this.setPosition !== 1 ? this.renderDropdownItem(1, this.messages.moveUp) : null;
+  private renderUp(): JsxNode {
+    return this.renderDropdownItem(1, this.messages.moveUp, this.setPosition === 1);
   }
 
-  private renderDown(): JsxNode | null {
-    return this.setPosition !== this.setSize
-      ? this.renderDropdownItem(2, this.messages.moveDown)
-      : null;
+  private renderDown(): JsxNode {
+    return this.renderDropdownItem(2, this.messages.moveDown, this.setPosition === this.setSize);
   }
 
-  private renderBottom(): JsxNode | null {
+  private renderBottom(): JsxNode {
     const { setPosition, setSize } = this;
 
-    return setPosition !== setSize && setPosition !== setSize - 1
-      ? this.renderDropdownItem(3, this.messages.moveToBottom)
-      : null;
+    return this.renderDropdownItem(
+      3,
+      this.messages.moveToBottom,
+      setPosition === setSize || setPosition === setSize - 1,
+    );
   }
 
   //#endregion

--- a/packages/components/src/components/sort-handle/sort-handle.tsx
+++ b/packages/components/src/components/sort-handle/sort-handle.tsx
@@ -65,7 +65,7 @@ export class SortHandle extends LitElement {
   }
 
   get reorderGroupTitle(): string {
-    return this.hasMoveToItems || this.hasAddToItems ? this.messages.reorder : null;
+    return this.hasMoveToItems || this.hasAddToItems ? this.messages.reorder : "";
   }
 
   get hasNoItems(): boolean {


### PR DESCRIPTION
**Related Issue:** #11451

## Summary
Updates calcite-sort-handle to improve its dropdown UX by (1) conditionally omitting the “Reorder” group label when it would be the only visible group and (2) showing boundary reorder actions as disabled items instead of hiding them, along with corresponding Storybook and E2E test updates.

**Changes:**

- Hide the reorder dropdown-group title when no Move/Add sibling groups are present.
- Render all reorder actions consistently and disable boundary actions (top/up/down/bottom) instead of conditionally not rendering them.
- Update Storybook stories and add/adjust E2E coverage for the new behaviors.