### PR TITLE
ci(actions): rename design estimate labels to use numbers

### DIFF
--- a/.github/scripts/support/monday.js
+++ b/.github/scripts/support/monday.js
@@ -79,7 +79,7 @@ module.exports = function Monday(issue, core, updateIssueBody) {
       type: "multiMutable",
     },
     product: { id: "dropdown_mkwzz3b", title: "Esri Team", type: "multiMutable" },
-    designEstimate: { id: "color_mkrbg2b9", title: "Design Estimate" },
+    designEstimate: { id: "numeric_mkw8yzkt", title: "Design Estimate" },
     devEstimate: { id: "numeric_mkswahrw", title: "Dev Estimate" },
     designIssue: { id: "color_mkswbke0", title: "Design Issue" },
     stalled: { id: "color_mkv79bbx", title: "Stalled" },
@@ -371,21 +371,21 @@ module.exports = function Monday(issue, core, updateIssueBody) {
       designEstimate.small,
       {
         column: mondayColumns.designEstimate,
-        value: "Small",
+        value: 5,
       },
     ],
     [
       designEstimate.medium,
       {
         column: mondayColumns.designEstimate,
-        value: "Medium",
+        value: 13,
       },
     ],
     [
       designEstimate.large,
       {
         column: mondayColumns.designEstimate,
-        value: "Large",
+        value: 21,
       },
     ],
     [

--- a/.github/scripts/support/resources.js
+++ b/.github/scripts/support/resources.js
@@ -63,9 +63,9 @@ const resources = {
       thirtyFour: "estimate - 34",
     },
     designEstimate: {
-      small: "estimate - design - sm",
-      medium: "estimate - design - md",
-      large: "estimate - design - lg",
+      small: "estimate - design - 5",
+      medium: "estimate - design - 13",
+      large: "estimate - design - 21",
     },
     productColor: "006B75",
   },

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,9 +120,9 @@ Estimates are used to determine how much effort needs to go into an issue. The t
 
 ### Design estimates
 
-- `estimate - design - sm`: No more than a few days of design expertise.
-- `estimate - design - md`: One to two weeks of design efforts and collaboration.
-- `estimate - design - lg`: Two to four weeks of design expertise, collaboration, and discussion. Usually requires all hands on deck.
+- `estimate - design - 5`: No more than a few days of design expertise.
+- `estimate - design - 13`: One to two weeks of design efforts and collaboration.
+- `estimate - design - 21`: Two to four weeks of design expertise, collaboration, and discussion. Usually requires all hands on deck.
 
 ### Development estimates
 


### PR DESCRIPTION
**Related Issue:** #13006

## Summary
Renames the Design Estimate labels from size-based (`sm`, `md`, `lg`) to numbers (`5`, `13`, `21`), and changes the
column they are synced to in Monday to a numeric column that already exists.

> [!WARNING]
> The labels will need to be renamed just after this PR is merged.
