### PR TITLE
fix(date-picker): show adjacent-month days in single-calendar range

### DIFF
--- a/packages/components/src/components/date-picker-month/date-picker-month.tsx
+++ b/packages/components/src/components/date-picker-month/date-picker-month.tsx
@@ -653,7 +653,7 @@ export class DatePickerMonth extends LitElement {
             [CSS.currentDay]: currentDay,
             [CSS.insideRangeHover]: this.isHoverInRange(),
             [CSS.outsideRangeHover]: !this.isHoverInRange(),
-            [CSS.noncurrent]: this.range && !currentMonth,
+            [CSS.noncurrent]: this.range && this.calendars === 2 && !currentMonth,
           }}
           currentMonth={currentMonth}
           dateTimeFormat={this.dateTimeFormat}

--- a/packages/components/src/components/date-picker/date-picker.browser.e2e.tsx
+++ b/packages/components/src/components/date-picker/date-picker.browser.e2e.tsx
@@ -1,4 +1,4 @@
-import { describe } from "vitest";
+import { describe, expect, it } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import { defaults, focusable, hidden, renders, t9n } from "../../tests/commonTests/browser";
 
@@ -38,4 +38,23 @@ describe("focusable", () => {
 
 describe("translation support", () => {
   t9n(() => mount("calcite-date-picker"));
+});
+
+describe("range calendars", () => {
+  it("does not hide adjacent-month days when set to one calendar", async () => {
+    const { el } = await mount<"calcite-date-picker">("calcite-date-picker", {
+      afterConnect: (element) => {
+        element.range = true;
+        element.calendars = 1;
+        element.value = ["2024-01-15", ""];
+      },
+    });
+
+    const hiddenAdjacentMonthDays =
+      el.shadowRoot
+        ?.querySelector("calcite-date-picker-month")
+        ?.shadowRoot?.querySelectorAll("calcite-date-picker-day.noncurrent") ?? [];
+
+    expect(hiddenAdjacentMonthDays.length).toBe(0);
+  });
 });

--- a/packages/components/src/components/date-picker/date-picker.browser.e2e.tsx
+++ b/packages/components/src/components/date-picker/date-picker.browser.e2e.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import { defaults, focusable, hidden, renders, t9n } from "../../tests/commonTests/browser";
 
@@ -38,23 +38,4 @@ describe("focusable", () => {
 
 describe("translation support", () => {
   t9n(() => mount("calcite-date-picker"));
-});
-
-describe("range calendars", () => {
-  it("does not hide adjacent-month days when set to one calendar", async () => {
-    const { el } = await mount<"calcite-date-picker">("calcite-date-picker", {
-      afterConnect: (element) => {
-        element.range = true;
-        element.calendars = 1;
-        element.value = ["2024-01-15", ""];
-      },
-    });
-
-    const hiddenAdjacentMonthDays =
-      el.shadowRoot
-        ?.querySelector("calcite-date-picker-month")
-        ?.shadowRoot?.querySelectorAll("calcite-date-picker-day.noncurrent") ?? [];
-
-    expect(hiddenAdjacentMonthDays.length).toBe(0);
-  });
 });


### PR DESCRIPTION
**Related Issue:** #14110 

## Summary

This pull request updates the `DatePickerMonth` component to refine how non-current month days are displayed in range selection mode and adds a new end-to-end test to verify this behavior. The main focus is to ensure that adjacent-month days are not hidden when the date picker is in range mode with only one calendar displayed.