### PR TITLE
feat(dropdown, split-button, sort-handle): add additional placement options

### DIFF
--- a/packages/components/src/components/dropdown/dropdown.stories.ts
+++ b/packages/components/src/components/dropdown/dropdown.stories.ts
@@ -1,7 +1,7 @@
 import { DropdownGroup } from "../dropdown-group/dropdown-group";
 import { boolean, modesDarkDefault } from "../../../.storybook/utils";
 import { html } from "../../../support/formatting";
-import { defaultMenuPlacement, menuPlacements } from "../../utils/floating-ui";
+import { defaultMenuPlacement, placements } from "../../utils/floating-ui";
 import { ATTRIBUTES } from "../../../.storybook/resources";
 import { Dropdown } from "./dropdown";
 
@@ -26,7 +26,7 @@ export default {
   },
   argTypes: {
     placement: {
-      options: menuPlacements,
+      options: placements,
       control: { type: "select" },
     },
     scale: {

--- a/packages/components/src/components/dropdown/dropdown.tsx
+++ b/packages/components/src/components/dropdown/dropdown.tsx
@@ -13,7 +13,7 @@ import {
   FloatingCSS,
   FloatingUIComponent,
   hideFloatingUI,
-  MenuPlacement,
+  LogicalPlacement,
   OverlayPositioning,
   reposition,
 } from "../../utils/floating-ui";
@@ -140,7 +140,7 @@ export class Dropdown extends LitElement implements FloatingUIComponent {
   /**
    * Determines the component's placement relative to the container element.
    */
-  @property({ reflect: true }) placement: MenuPlacement = defaultMenuPlacement;
+  @property({ reflect: true }) placement: LogicalPlacement = defaultMenuPlacement;
 
   /** Specifies the size of the component. */
   @property({ reflect: true }) scale: Scale = "m";

--- a/packages/components/src/components/sort-handle/sort-handle.browser.e2e.tsx
+++ b/packages/components/src/components/sort-handle/sort-handle.browser.e2e.tsx
@@ -35,6 +35,10 @@ describe("defaults", () => {
         propertyName: "addToItems",
         defaultValue: [],
       },
+      {
+        propertyName: "placement",
+        defaultValue: "bottom-start",
+      },
     ],
   );
 });
@@ -46,6 +50,10 @@ describe("reflects", () => {
       {
         propertyName: "sortDisabled",
         value: true,
+      },
+      {
+        propertyName: "placement",
+        value: "leading-start",
       },
     ],
   );

--- a/packages/components/src/components/sort-handle/sort-handle.stories.ts
+++ b/packages/components/src/components/sort-handle/sort-handle.stories.ts
@@ -16,6 +16,15 @@ export const closed = (): string => html`
 export const open = (): string =>
   html`<calcite-sort-handle label="test" set-position="4" set-size="10" open></calcite-sort-handle>`;
 
+export const logicalPlacement = (): string =>
+  html`<calcite-sort-handle
+    label="test"
+    placement="leading-start"
+    set-position="4"
+    set-size="10"
+    open
+  ></calcite-sort-handle>`;
+
 export const positions = (): string => html`
   <style>
     .wrapper {

--- a/packages/components/src/components/sort-handle/sort-handle.tsx
+++ b/packages/components/src/components/sort-handle/sort-handle.tsx
@@ -4,7 +4,7 @@ import { LitElement, property, createEvent, h, method, JsxNode } from "@arcgis/l
 import { Scale } from "../interfaces";
 import {
   FlipPlacement,
-  MenuPlacement,
+  LogicalPlacement,
   OverlayPositioning,
   defaultMenuPlacement,
 } from "../../utils/floating-ui";
@@ -104,7 +104,7 @@ export class SortHandle extends LitElement {
   /**
    * Determines where the component will be positioned relative to the container element.
    */
-  @property({ reflect: true }) placement: MenuPlacement = defaultMenuPlacement;
+  @property({ reflect: true }) placement: LogicalPlacement = defaultMenuPlacement;
 
   /** Specifies the size of the component. */
   @property({ reflect: true }) scale: Scale = "m";

--- a/packages/components/src/components/split-button/split-button.stories.ts
+++ b/packages/components/src/components/split-button/split-button.stories.ts
@@ -2,7 +2,7 @@ import { iconNames } from "../../../.storybook/helpers";
 import { boolean, modesDarkDefault } from "../../../.storybook/utils";
 import { html } from "../../../support/formatting";
 import { ATTRIBUTES } from "../../../.storybook/resources";
-import { menuPlacements } from "../../utils/floating-ui";
+import { placements } from "../../utils/floating-ui";
 import { SplitButton } from "./split-button";
 
 const { appearance, kind, scale, width, iconType } = ATTRIBUTES;
@@ -57,7 +57,7 @@ export default {
       control: { type: "select" },
     },
     placement: {
-      options: menuPlacements,
+      options: placements,
       control: { type: "select" },
     },
     primaryIconStart: {

--- a/packages/components/src/components/split-button/split-button.tsx
+++ b/packages/components/src/components/split-button/split-button.tsx
@@ -8,7 +8,7 @@ import {
   JsxNode,
   stringOrBoolean,
 } from "@arcgis/lumina";
-import { FlipPlacement, MenuPlacement, OverlayPositioning } from "../../utils/floating-ui";
+import { FlipPlacement, LogicalPlacement, OverlayPositioning } from "../../utils/floating-ui";
 import { DropdownIconType } from "../button/interfaces";
 import { Appearance, FlipContext, Kind, Scale, Width } from "../interfaces";
 import { IconName } from "../icon/interfaces";
@@ -115,7 +115,7 @@ export class SplitButton extends LitElement {
   /**
    * Determines where the component will be positioned relative to the container element.
    */
-  @property({ reflect: true }) placement: MenuPlacement = "bottom-end";
+  @property({ reflect: true }) placement: LogicalPlacement = "bottom-end";
 
   /** Specifies an icon to display at the end of the primary button. */
   @property({ reflect: true, type: String }) primaryIconEnd: IconName;
@@ -126,7 +126,7 @@ export class SplitButton extends LitElement {
   /** Specifies an icon to display at the start of the primary button. */
   @property({ reflect: true, type: String }) primaryIconStart: IconName;
 
-  /** Speficies an accessible name for the primary button. */
+  /** Specifies an accessible name for the primary button. */
   @property({ reflect: true }) primaryLabel: string;
 
   /** Specifies the text displayed in the primary button. */


### PR DESCRIPTION
**Related Issue:** #4124

## Summary

This PR expands supported/typed `placement` options for floating menu-based components (dropdown, split-button, sort-handle) by switching their `placement` property type from `MenuPlacement` to `LogicalPlacement`, enabling left/right and logical leading/trailing placements as officially accepted values.

**Changes:**
- Update `placement` property typings in `calcite-dropdown`, `calcite-split-button`, and `calcite-sort-handle` to use `LogicalPlacement`.
- Update Storybook stories to use the full `placements` option set from `utils/floating-ui`.
- Add sort-handle Storybook and E2E coverage for logical placement usage and placement reflection/defaults.

