### PR TITLE
chore(linting): include `@vitest/eslint-plugin` in all tests

### DIFF
--- a/packages/components/eslint.config.mjs
+++ b/packages/components/eslint.config.mjs
@@ -99,7 +99,7 @@ export default tseslint.config(
   },
 
   {
-    files: ["**/*.{e2e,spec}.ts", "src/tests/**/*"],
+    files: ["**/*.{e2e,spec}.{ts,tsx}", "src/tests/**/*"],
     extends: [vitestPlugin.configs.recommended],
     settings: {
       vitest: {

--- a/packages/components/src/components/combobox/combobox.browser.e2e.tsx
+++ b/packages/components/src/components/combobox/combobox.browser.e2e.tsx
@@ -813,30 +813,6 @@ describe("keyboard interactions", async () => {
     expect(el.selectedItems[0]).toBe(selectedItem2.element());
   });
 
-  it("should delete the first focused chip on Enter key in multi-selection mode", async () => {
-    const { el } = await mount<Combobox>(
-      <calcite-combobox allow-custom-values placeholder="Select a field">
-        <calcite-combobox-item
-          heading="Natural Resources"
-          id="one"
-          selected
-          value="Natural Resources"
-        />
-        <calcite-combobox-item heading="Agriculture" id="two" selected value="agriculture" />
-        <calcite-combobox-item heading="Forestry" id="three" value="forestry" />
-        <calcite-combobox-item heading="Transportation" id="four" value="transportation" />
-      </calcite-combobox>,
-    );
-    const selectedItem1 = page.getBySelector("#one");
-
-    await el.setFocus();
-    await userEvent.keyboard("{ArrowLeft}");
-    await userEvent.keyboard("{Enter}");
-
-    expect(el.selectedItems).toHaveLength(1);
-    expect(el.selectedItems[0]).toBe(selectedItem1.element());
-  });
-
   it("should delete the focused chip on Delete key in multi-selection mode", async () => {
     const { el } = await mount<Combobox>(
       <calcite-combobox allow-custom-values placeholder="Select a field">

--- a/packages/components/src/components/dropdown/dropdown.e2e.ts
+++ b/packages/components/src/components/dropdown/dropdown.e2e.ts
@@ -1523,59 +1523,6 @@ describe("calcite-dropdown", () => {
       ).toBe("item-3");
     });
 
-    it("should open the dropdown and focus the first item with ArrowDown", async () => {
-      const page = await newE2EPage();
-      await page.setContent(html`
-        <calcite-dropdown>
-          <calcite-button slot="trigger">Open</calcite-button>
-          <calcite-dropdown-group selection-mode="single">
-            <calcite-dropdown-item id="item-1">1</calcite-dropdown-item>
-            <calcite-dropdown-item id="item-2" selected>2</calcite-dropdown-item>
-            <calcite-dropdown-item id="item-3">3</calcite-dropdown-item>
-          </calcite-dropdown-group>
-        </calcite-dropdown>
-      `);
-      await skipAnimations(page);
-
-      const dropdown = await page.find("calcite-dropdown");
-      await dropdown.callMethod("setFocus");
-      await page.waitForChanges();
-
-      const openEventSpy = await page.spyOnEvent("calciteDropdownOpen");
-      await page.keyboard.press("ArrowDown");
-      await page.waitForChanges();
-      await openEventSpy.next();
-
-      expect(await dropdown.getProperty("open")).toBe(true);
-      expect(
-        await page.evaluate(
-          () =>
-            document.querySelector("calcite-dropdown").shadowRoot.querySelector("slot[name='trigger']")
-              .ariaActiveDescendantElement?.id,
-        ),
-      ).toBe("item-1");
-
-      await page.keyboard.press("ArrowDown");
-      await page.waitForChanges();
-      expect(
-        await page.evaluate(
-          () =>
-            document.querySelector("calcite-dropdown").shadowRoot.querySelector("slot[name='trigger']")
-              .ariaActiveDescendantElement?.id,
-        ),
-      ).toBe("item-2");
-
-      await page.keyboard.press("ArrowUp");
-      await page.waitForChanges();
-      expect(
-        await page.evaluate(
-          () =>
-            document.querySelector("calcite-dropdown").shadowRoot.querySelector("slot[name='trigger']")
-              .ariaActiveDescendantElement?.id,
-        ),
-      ).toBe("item-1");
-    });
-
     it("should open the dropdown and focus the last item with ArrowUp", async () => {
       const page = await newE2EPage();
       await page.setContent(html`

--- a/packages/components/src/components/time-picker/time-picker.browser.e2e.tsx
+++ b/packages/components/src/components/time-picker/time-picker.browser.e2e.tsx
@@ -116,10 +116,11 @@ describe("l10n", () => {
               .toHaveTextContent(expectedLocalizedSecondSuffix.trim());
           }
 
-          // eslint-disable-next-line vitest/no-conditional-expect -- assertion depends on test config
           await (localeHourFormat === "12"
-            ? expect.element(meridiemEl).toHaveTextContent(expectedLocalizedMeridiem)
-            : expect.element(meridiemEl).not.toBeInTheDocument());
+            ? // eslint-disable-next-line vitest/no-conditional-expect -- assertion depends on test config
+              expect.element(meridiemEl).toHaveTextContent(expectedLocalizedMeridiem)
+            : // eslint-disable-next-line vitest/no-conditional-expect -- assertion depends on test config
+              expect.element(meridiemEl).not.toBeInTheDocument());
         });
       });
 


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Ensures `@vitest/eslint-plugin` rules run in all test files and also fixes some errors reported after this change (e.g., duplicate tests, conditional assertion from helper).