### PR TITLE
fix(switch): remove double focus ring in certain browsers

### DIFF
--- a/packages/components/src/components/switch/switch.scss
+++ b/packages/components/src/components/switch/switch.scss
@@ -64,7 +64,7 @@
 @include includes.disabled();
 
 .container {
-  @apply outline-0;
+  outline: none;
   display: flex;
 }
 


### PR DESCRIPTION
**Related Issue:** #10824

## Summary

This PR addresses Issue #10824 by preventing an extra (browser-default) focus outline from appearing on the Switch in Firefox and Safari, leaving only the component’s intended focus styling.

**Changes:**
- Replace Tailwind `@apply outline-0;` with an explicit `outline: none;` on the switch’s focusable container to suppress the UA outline.

