### PR TITLE
fix(meter): update border color

### DIFF
--- a/packages/components/src/components/meter/meter.scss
+++ b/packages/components/src/components/meter/meter.scss
@@ -40,7 +40,7 @@
   --calcite-internal-meter-font-size: var(--calcite-font-size--1);
   --calcite-internal-meter-fill-color: var(--calcite-meter-fill-color, var(--calcite-color-brand));
   --calcite-internal-meter-background-color: var(--calcite-meter-background-color, var(--calcite-color-foreground-2));
-  --calcite-internal-meter-border-color: var(--calcite-meter-border-color, var(--calcite-color-border-3));
+  --calcite-internal-meter-border-color: var(--calcite-meter-border-color, var(--calcite-color-border-2));
   --calcite-internal-meter-shadow: var(--calcite-meter-shadow, var(--calcite-shadow-none));
   --calcite-internal-meter-corner-radius: var(--calcite-meter-corner-radius, 9999px);
   --calcite-internal-meter-value-text-color: var(--calcite-meter-value-text-color, var(--calcite-color-text-1));


### PR DESCRIPTION
**Related Issue:** #14166

## Summary
Updates the calcite-meter component’s default border/step-line color token to improve contrast after the v5 color update.

**Changes:**

Change Meter’s default `--calcite-internal-meter-border-color` fallback from `--calcite-color-border-3` to `--calcite-color-border-2`.