### PR TITLE
feat(dropdown):  add `referenceElement` property

### DIFF
--- a/packages/components/index.html
+++ b/packages/components/index.html
@@ -8,14 +8,30 @@
   </head>
 
   <body>
-    <demo-dom-swapper>
-      <!-- demo snippet start -->
+    <body>
+      <calcite-dropdown width="m">
+        <calcite-button slot="trigger">Select landform</calcite-button>
+        <calcite-dropdown-group group-title="Natural places">
+          <calcite-dropdown-item>Mountain</calcite-dropdown-item>
+          <calcite-dropdown-item>River</calcite-dropdown-item>
+          <calcite-dropdown-item>Waterfall</calcite-dropdown-item>
+          <calcite-dropdown-item>Rainforest</calcite-dropdown-item>
+          <calcite-dropdown-item>Tundra</calcite-dropdown-item>
+          <calcite-dropdown-item>Desert</calcite-dropdown-item>
+        </calcite-dropdown-group>
+      </calcite-dropdown>
 
-      <!-- use this page for quickly setting up your page for a bug fix/repro cases or feature enhancement -->
-      <!-- you can add a demo snippet by running `npx snippet` -->
-
-      <!-- demo snippet end -->
-    </demo-dom-swapper>
-    <demo-options></demo-options>
+      <calcite-button id="test">Select landform</calcite-button>
+      <calcite-dropdown width="m" reference-element="test" type="hover">
+        <calcite-dropdown-group group-title="Natural places">
+          <calcite-dropdown-item>Mountain</calcite-dropdown-item>
+          <calcite-dropdown-item>River</calcite-dropdown-item>
+          <calcite-dropdown-item>Waterfall</calcite-dropdown-item>
+          <calcite-dropdown-item>Rainforest</calcite-dropdown-item>
+          <calcite-dropdown-item>Tundra</calcite-dropdown-item>
+          <calcite-dropdown-item>Desert</calcite-dropdown-item>
+        </calcite-dropdown-group>
+      </calcite-dropdown>
+    </body>
   </body>
 </html>

--- a/packages/components/index.html
+++ b/packages/components/index.html
@@ -8,30 +8,14 @@
   </head>
 
   <body>
-    <body>
-      <calcite-dropdown width="m">
-        <calcite-button slot="trigger">Select landform</calcite-button>
-        <calcite-dropdown-group group-title="Natural places">
-          <calcite-dropdown-item>Mountain</calcite-dropdown-item>
-          <calcite-dropdown-item>River</calcite-dropdown-item>
-          <calcite-dropdown-item>Waterfall</calcite-dropdown-item>
-          <calcite-dropdown-item>Rainforest</calcite-dropdown-item>
-          <calcite-dropdown-item>Tundra</calcite-dropdown-item>
-          <calcite-dropdown-item>Desert</calcite-dropdown-item>
-        </calcite-dropdown-group>
-      </calcite-dropdown>
+    <demo-dom-swapper>
+      <!-- demo snippet start -->
 
-      <calcite-button id="test">Select landform</calcite-button>
-      <calcite-dropdown width="m" reference-element="test" type="hover">
-        <calcite-dropdown-group group-title="Natural places">
-          <calcite-dropdown-item>Mountain</calcite-dropdown-item>
-          <calcite-dropdown-item>River</calcite-dropdown-item>
-          <calcite-dropdown-item>Waterfall</calcite-dropdown-item>
-          <calcite-dropdown-item>Rainforest</calcite-dropdown-item>
-          <calcite-dropdown-item>Tundra</calcite-dropdown-item>
-          <calcite-dropdown-item>Desert</calcite-dropdown-item>
-        </calcite-dropdown-group>
-      </calcite-dropdown>
-    </body>
+      <!-- use this page for quickly setting up your page for a bug fix/repro cases or feature enhancement -->
+      <!-- you can add a demo snippet by running `npx snippet` -->
+
+      <!-- demo snippet end -->
+    </demo-dom-swapper>
+    <demo-options></demo-options>
   </body>
 </html>

--- a/packages/components/src/components/dropdown/dropdown.browser.e2e.tsx
+++ b/packages/components/src/components/dropdown/dropdown.browser.e2e.tsx
@@ -292,3 +292,182 @@ describe("referenceElement keydown", () => {
     expect(el.open).toBe(true);
   });
 });
+
+describe("keyboard navigation", () => {
+  function createReferenceElementKeyboardDropdownHTML(options?: {
+    selectedItemId?: "item-1" | "item-2";
+    includeDisabledAndHiddenItems?: boolean;
+  }): JsxNode {
+    const { selectedItemId, includeDisabledAndHiddenItems } = options || {};
+
+    return (
+      <div>
+        <button id="external-trigger" type="button">
+          Open dropdown
+        </button>
+        <calcite-dropdown reference-element="external-trigger">
+          {includeDisabledAndHiddenItems ? (
+            <calcite-dropdown-group selection-mode="single">
+              <calcite-dropdown-item disabled id="item-1">
+                1
+              </calcite-dropdown-item>
+              <calcite-dropdown-item disabled id="item-1.5">
+                1.5
+              </calcite-dropdown-item>
+              <calcite-dropdown-item id="item-2" selected>
+                2
+              </calcite-dropdown-item>
+              <calcite-dropdown-item hidden id="item-2.5">
+                2.5
+              </calcite-dropdown-item>
+              <calcite-dropdown-item id="item-3">3</calcite-dropdown-item>
+              <calcite-dropdown-item hidden id="item-4">
+                4
+              </calcite-dropdown-item>
+            </calcite-dropdown-group>
+          ) : (
+            <calcite-dropdown-group selection-mode="single">
+              <calcite-dropdown-item id="item-1" selected={selectedItemId === "item-1"}>
+                1
+              </calcite-dropdown-item>
+              <calcite-dropdown-item id="item-2" selected={selectedItemId === "item-2"}>
+                2
+              </calcite-dropdown-item>
+              <calcite-dropdown-item id="item-3">3</calcite-dropdown-item>
+            </calcite-dropdown-group>
+          )}
+        </calcite-dropdown>
+      </div>
+    );
+  }
+
+  function getReferenceElementExpandedState(): string | null {
+    return (getReferenceElementTrigger().element() as HTMLElement | null)?.getAttribute(
+      "aria-expanded",
+    );
+  }
+
+  function getReferenceElementTrigger() {
+    return page.getByRole("button", { name: "Open dropdown" });
+  }
+
+  function getActiveDescendantId(): string | undefined {
+    return (getReferenceElementTrigger().element() as HTMLElement | null)
+      ?.ariaActiveDescendantElement?.id;
+  }
+
+  it("supports navigating through items with arrow keys", async () => {
+    await mount<Dropdown>(() =>
+      createReferenceElementKeyboardDropdownHTML({ selectedItemId: "item-1" }),
+    );
+    const trigger = getReferenceElementTrigger();
+
+    await userEvent.click(trigger);
+    await userEvent.type(trigger, "{Enter}");
+
+    expect(getActiveDescendantId()).toBe("item-1");
+
+    await userEvent.type(trigger, "{ArrowDown}");
+    expect(getActiveDescendantId()).toBe("item-2");
+
+    await userEvent.type(trigger, "{ArrowDown}");
+    expect(getActiveDescendantId()).toBe("item-3");
+
+    await userEvent.type(trigger, "{ArrowDown}");
+    expect(getActiveDescendantId()).toBe("item-1");
+
+    await userEvent.type(trigger, "{ArrowUp}");
+    expect(getActiveDescendantId()).toBe("item-3");
+
+    await userEvent.type(trigger, "{ArrowUp}");
+    expect(getActiveDescendantId()).toBe("item-2");
+
+    await userEvent.type(trigger, "{ArrowUp}");
+    expect(getActiveDescendantId()).toBe("item-1");
+
+    await userEvent.type(trigger, "{ArrowUp}");
+    expect(getActiveDescendantId()).toBe("item-3");
+  });
+
+  it("skips disabled and hidden items when navigating with arrow keys", async () => {
+    await mount<Dropdown>(() =>
+      createReferenceElementKeyboardDropdownHTML({
+        includeDisabledAndHiddenItems: true,
+      }),
+    );
+    const trigger = getReferenceElementTrigger();
+
+    await userEvent.click(trigger);
+    await userEvent.type(trigger, "{Enter}");
+
+    expect(getActiveDescendantId()).toBe("item-2");
+
+    await userEvent.type(trigger, "{ArrowDown}");
+    expect(getActiveDescendantId()).toBe("item-3");
+
+    await userEvent.type(trigger, "{ArrowDown}");
+    expect(getActiveDescendantId()).toBe("item-2");
+
+    await userEvent.type(trigger, "{ArrowUp}");
+    expect(getActiveDescendantId()).toBe("item-3");
+
+    await userEvent.type(trigger, "{ArrowUp}");
+    expect(getActiveDescendantId()).toBe("item-2");
+
+    await userEvent.type(trigger, "{ArrowUp}");
+    expect(getActiveDescendantId()).toBe("item-3");
+  });
+
+  it("should open the dropdown and focus the first item with ArrowDown", async () => {
+    await mount<Dropdown>(() => createReferenceElementKeyboardDropdownHTML());
+    const trigger = getReferenceElementTrigger();
+
+    await userEvent.click(trigger);
+    await userEvent.type(trigger, "{ArrowDown}");
+
+    expect(getReferenceElementExpandedState()).toBe("true");
+    expect(getActiveDescendantId()).toBe("item-1");
+
+    await userEvent.type(trigger, "{ArrowDown}");
+    expect(getActiveDescendantId()).toBe("item-2");
+
+    await userEvent.type(trigger, "{ArrowUp}");
+    expect(getActiveDescendantId()).toBe("item-1");
+  });
+
+  it("should open the dropdown and focus the last item with ArrowUp when no item is selected", async () => {
+    await mount<Dropdown>(() => createReferenceElementKeyboardDropdownHTML());
+    const trigger = getReferenceElementTrigger();
+
+    await userEvent.click(trigger);
+    await userEvent.type(trigger, "{ArrowUp}");
+
+    expect(getReferenceElementExpandedState()).toBe("true");
+    expect(getActiveDescendantId()).toBe("item-3");
+
+    await userEvent.type(trigger, "{ArrowDown}");
+    expect(getActiveDescendantId()).toBe("item-1");
+
+    await userEvent.type(trigger, "{ArrowUp}");
+    expect(getActiveDescendantId()).toBe("item-3");
+  });
+
+  it("should open the dropdown and focus the last item with ArrowUp", async () => {
+    await mount<Dropdown>(() =>
+      createReferenceElementKeyboardDropdownHTML({ selectedItemId: "item-2" }),
+    );
+    const trigger = getReferenceElementTrigger();
+
+    await userEvent.click(trigger);
+    await userEvent.type(trigger, "{ArrowUp}");
+
+    expect(getReferenceElementExpandedState()).toBe("true");
+    expect(getActiveDescendantId()).toBe("item-3");
+
+    await userEvent.type(trigger, "{ArrowUp}");
+    expect(getActiveDescendantId()).toBe("item-2");
+
+    await userEvent.type(trigger, "{ArrowDown}");
+    expect(getActiveDescendantId()).toBe("item-3");
+  });
+});

--- a/packages/components/src/components/dropdown/dropdown.browser.e2e.tsx
+++ b/packages/components/src/components/dropdown/dropdown.browser.e2e.tsx
@@ -1,4 +1,4 @@
-import { h } from "@arcgis/lumina";
+import { Fragment, h } from "@arcgis/lumina";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import { describe, expect, it } from "vitest";
 import { page, userEvent } from "vitest/browser";
@@ -61,7 +61,7 @@ describe("honors hidden attribute", () => {
   hidden(() => mount("calcite-dropdown"));
 });
 
-function createSimpleDropdownHTML(): JsxNode {
+function renderSimpleDropdownHTML(): JsxNode {
   return (
     <calcite-dropdown>
       <calcite-button slot="trigger">Open dropdown</calcite-button>
@@ -76,16 +76,21 @@ function createSimpleDropdownHTML(): JsxNode {
   );
 }
 
-function dispatchKeydown(target: Element, key: string): void {
-  target.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true }));
+async function waitForSettledUpdate(
+  component: Dropdown["manager"]["component"],
+  updateCompletePromise: Promise<unknown>,
+): Promise<void> {
+  if ((await updateCompletePromise) === false) {
+    await component.updateComplete;
+  }
 }
 
 describe("renders", () => {
-  renders(() => mount(createSimpleDropdownHTML), { display: "inline-block" });
+  renders(() => mount(renderSimpleDropdownHTML), { display: "inline-block" });
 });
 
 describe("focusable", () => {
-  focusable(() => mount(createSimpleDropdownHTML), {
+  focusable(() => mount(renderSimpleDropdownHTML), {
     focusTargetSelector: '[slot="trigger"]',
   });
 });
@@ -144,7 +149,7 @@ describe("top layer placement", () => {
 });
 
 describe("hover type", () => {
-  function createHoverDropdownHTML(): JsxNode {
+  function renderHoverDropdownHTML(): JsxNode {
     return (
       <calcite-dropdown type="hover">
         <calcite-action id="trigger" slot="trigger">
@@ -161,7 +166,7 @@ describe("hover type", () => {
   }
 
   it("opens on focusin", async () => {
-    const { el } = await mount<Dropdown>(createHoverDropdownHTML);
+    const { el } = await mount<Dropdown>(renderHoverDropdownHTML);
 
     expect(el.open).toBe(false);
 
@@ -172,7 +177,7 @@ describe("hover type", () => {
   });
 
   it("does not toggle closed on click when type is hover", async () => {
-    const { el } = await mount<Dropdown>(createHoverDropdownHTML);
+    const { el } = await mount<Dropdown>(renderHoverDropdownHTML);
     const trigger = page.getByText("Open dropdown");
 
     expect(el.open).toBe(false);
@@ -189,7 +194,7 @@ describe("hover type", () => {
   it("closes when focus leaves trigger with Tab", async () => {
     const { el } = await mount<Dropdown>(
       <div>
-        {createHoverDropdownHTML()}
+        {renderHoverDropdownHTML()}
         <button id="next-focus-target" type="button">
           Next
         </button>
@@ -210,23 +215,15 @@ describe("hover type", () => {
 });
 
 describe("ariaActiveDescendantElement", () => {
-  function getSlottedTriggerLocator() {
+  function getSlottedTriggerLocator(): ReturnType<typeof page.elementLocator> {
     const internalButton = page.getByRole("button", { name: "Open dropdown" }).element();
     const triggerHost = (internalButton?.getRootNode() as ShadowRoot | null)?.host;
-
-    if (!(triggerHost instanceof HTMLElement)) {
-      throw new Error("Expected slotted calcite-button host");
-    }
 
     return page.elementLocator(triggerHost);
   }
 
-  function getTriggerSlotLocator() {
+  function getTriggerSlotLocator(): ReturnType<typeof page.elementLocator> {
     const slot = (getSlottedTriggerLocator().element() as HTMLElement | null)?.assignedSlot;
-
-    if (!(slot instanceof HTMLSlotElement)) {
-      throw new Error("Expected assigned trigger slot");
-    }
 
     return page.elementLocator(slot);
   }
@@ -237,7 +234,7 @@ describe("ariaActiveDescendantElement", () => {
   }
 
   it("sets ariaActiveDescendantElement on the trigger slot when opened", async () => {
-    await mount<Dropdown>(createSimpleDropdownHTML);
+    await mount<Dropdown>(renderSimpleDropdownHTML);
     const trigger = page.getByText("Open dropdown");
 
     await userEvent.click(trigger);
@@ -246,7 +243,7 @@ describe("ariaActiveDescendantElement", () => {
   });
 
   it("updates ariaActiveDescendantElement on keyboard navigation", async () => {
-    await mount<Dropdown>(createSimpleDropdownHTML);
+    await mount<Dropdown>(renderSimpleDropdownHTML);
     const trigger = page.getByText("Open dropdown");
 
     await userEvent.click(trigger);
@@ -258,7 +255,7 @@ describe("ariaActiveDescendantElement", () => {
   });
 
   it("wraps ariaActiveDescendantElement on ArrowUp navigation", async () => {
-    await mount<Dropdown>(createSimpleDropdownHTML);
+    await mount<Dropdown>(renderSimpleDropdownHTML);
     const trigger = page.getByText("Open dropdown");
 
     await userEvent.click(trigger);
@@ -279,9 +276,9 @@ describe("ariaActiveDescendantElement", () => {
 });
 
 describe("referenceElement keydown", () => {
-  function createReferenceElementDropdownHTML(): JsxNode {
+  function renderReferenceElementDropdownHTML(): JsxNode {
     return (
-      <div>
+      <>
         <button id="external-trigger" type="button">
           Open dropdown
         </button>
@@ -290,24 +287,32 @@ describe("referenceElement keydown", () => {
             <calcite-dropdown-item id="item-1">Dropdown Item Content</calcite-dropdown-item>
           </calcite-dropdown-group>
         </calcite-dropdown>
-      </div>
+      </>
     );
   }
 
-  it("opens when Enter keydown is dispatched on referenceElement", async () => {
-    const { el } = await mount<Dropdown>(createReferenceElementDropdownHTML);
+  it("opens when Enter is pressed on referenceElement", async () => {
+    const { el } = await mount<Dropdown>(renderReferenceElementDropdownHTML);
     const trigger = page.getByRole("button", { name: "Open dropdown" });
+    const dropdownElement = trigger.element()?.nextElementSibling;
+
+    const dropdown = page.elementLocator(dropdownElement).element() as Dropdown;
+    const component = dropdown.manager.component;
 
     expect(el.open).toBe(false);
 
-    dispatchKeydown(trigger.element() as Element, "Enter");
+    const updateComplete = component.updateComplete;
+
+    (trigger.element() as HTMLElement | null)?.focus();
+    await userEvent.keyboard("{Enter}");
+    await waitForSettledUpdate(component, updateComplete);
 
     expect(el.open).toBe(true);
   });
 });
 
 describe("keyboard navigation", () => {
-  function createReferenceElementKeyboardDropdownHTML(options?: {
+  function renderReferenceElementKeyboardDropdownHTML(options?: {
     selectedItemId?: "item-1" | "item-2";
     includeDisabledAndHiddenItems?: boolean;
   }): JsxNode {
@@ -354,31 +359,28 @@ describe("keyboard navigation", () => {
     );
   }
 
-  function getReferenceElementExpandedState(): string | null {
-    return (getReferenceElementTrigger().element() as HTMLElement | null)?.getAttribute(
-      "aria-expanded",
+  function getReferenceElementExpandedState(): string {
+    return (
+      (getReferenceElementTrigger().element() as HTMLElement)?.getAttribute("aria-expanded") ?? ""
     );
   }
 
-  function getReferenceElementTrigger() {
+  function getReferenceElementTrigger(): ReturnType<typeof page.getByRole> {
     return page.getByRole("button", { name: "Open dropdown" });
   }
 
-  function getDropdownLocator() {
+  function getDropdownLocator(): ReturnType<typeof page.elementLocator> {
     const dropdown = getReferenceElementTrigger().element()?.nextElementSibling;
-
-    if (!(dropdown instanceof HTMLElement)) {
-      throw new Error("Expected dropdown next to reference element trigger");
-    }
 
     return page.elementLocator(dropdown);
   }
 
   async function waitForDropdownUpdateComplete(): Promise<void> {
     const dropdown = getDropdownLocator().element() as Dropdown;
+    const component = dropdown.manager.component;
+    const updateComplete = component.updateComplete;
 
-    await dropdown.updateComplete;
-    await dropdown.updateComplete;
+    await waitForSettledUpdate(component, updateComplete);
   }
 
   const defaultItemIds = ["item-1", "item-2", "item-3"];
@@ -393,40 +395,35 @@ describe("keyboard navigation", () => {
     "item-4": "4",
   };
 
-  function getDropdownItemLocator(itemId: string) {
+  function getDropdownItemLocator(itemId: string): ReturnType<typeof page.elementLocator> | null {
     const itemText = dropdownItemTextById[itemId];
-
-    if (!itemText) {
-      return null;
-    }
-
     const itemContent = getDropdownLocator().getByText(itemText, { exact: true }).element();
     const item = itemContent?.closest("calcite-dropdown-item");
-
-    if (!(item instanceof HTMLElement)) {
-      return null;
-    }
 
     return page.elementLocator(item);
   }
 
-  function getActiveItemId(itemIds: string[]): string | undefined {
+  function getActiveItemId(itemIds: string[]): string {
     return itemIds.find((itemId) => {
       const item = getDropdownItemLocator(itemId);
 
-      return (item?.element() as (HTMLElement & { activeDescendant?: boolean }) | null)
-        ?.activeDescendant;
+      if (!item) {
+        throw new Error("Expected dropdown item with id " + itemId);
+      }
+
+      return (item.element() as HTMLElement & { activeDescendant?: boolean }).activeDescendant;
     });
   }
 
   async function pressReferenceElementKey(key: string): Promise<void> {
-    dispatchKeydown(getReferenceElementTrigger().element() as Element, key);
+    (getReferenceElementTrigger().element() as HTMLElement | null)?.focus();
+    await userEvent.keyboard(`{${key}}`);
     await waitForDropdownUpdateComplete();
   }
 
   it("supports navigating through items with arrow keys", async () => {
     await mount<Dropdown>(() =>
-      createReferenceElementKeyboardDropdownHTML({ selectedItemId: "item-1" }),
+      renderReferenceElementKeyboardDropdownHTML({ selectedItemId: "item-1" }),
     );
 
     await pressReferenceElementKey("Enter");
@@ -456,7 +453,7 @@ describe("keyboard navigation", () => {
 
   it("skips disabled and hidden items when navigating with arrow keys", async () => {
     await mount<Dropdown>(() =>
-      createReferenceElementKeyboardDropdownHTML({
+      renderReferenceElementKeyboardDropdownHTML({
         includeDisabledAndHiddenItems: true,
       }),
     );
@@ -481,7 +478,7 @@ describe("keyboard navigation", () => {
   });
 
   it("should open the dropdown and focus the first item with ArrowDown", async () => {
-    await mount<Dropdown>(() => createReferenceElementKeyboardDropdownHTML());
+    await mount<Dropdown>(() => renderReferenceElementKeyboardDropdownHTML());
     await pressReferenceElementKey("ArrowDown");
 
     expect(getReferenceElementExpandedState()).toBe("true");
@@ -495,7 +492,7 @@ describe("keyboard navigation", () => {
   });
 
   it("should open the dropdown and focus the last item with ArrowUp when no item is selected", async () => {
-    await mount<Dropdown>(() => createReferenceElementKeyboardDropdownHTML());
+    await mount<Dropdown>(() => renderReferenceElementKeyboardDropdownHTML());
     await pressReferenceElementKey("ArrowUp");
 
     expect(getReferenceElementExpandedState()).toBe("true");
@@ -510,7 +507,7 @@ describe("keyboard navigation", () => {
 
   it("should open the dropdown and focus the last item with ArrowUp", async () => {
     await mount<Dropdown>(() =>
-      createReferenceElementKeyboardDropdownHTML({ selectedItemId: "item-2" }),
+      renderReferenceElementKeyboardDropdownHTML({ selectedItemId: "item-2" }),
     );
     await pressReferenceElementKey("ArrowUp");
 

--- a/packages/components/src/components/dropdown/dropdown.browser.e2e.tsx
+++ b/packages/components/src/components/dropdown/dropdown.browser.e2e.tsx
@@ -260,3 +260,35 @@ describe("ariaActiveDescendantElement", () => {
     expect(activeDescendantId).toBe("item-2");
   });
 });
+
+describe("referenceElement keydown", () => {
+  function createReferenceElementDropdownHTML(): JsxNode {
+    return (
+      <div>
+        <button id="external-trigger" type="button">
+          Open dropdown
+        </button>
+        <calcite-dropdown reference-element="external-trigger">
+          <calcite-dropdown-group selection-mode="single">
+            <calcite-dropdown-item id="item-1">Dropdown Item Content</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-dropdown>
+      </div>
+    );
+  }
+
+  function dispatchKeydown(target: Element, key: string): void {
+    target.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true }));
+  }
+
+  it("opens when Enter keydown is dispatched on referenceElement", async () => {
+    const { el } = await mount<Dropdown>(createReferenceElementDropdownHTML);
+    const trigger = page.getByRole("button", { name: "Open dropdown" });
+
+    expect(el.open).toBe(false);
+
+    dispatchKeydown(trigger.element() as Element, "Enter");
+
+    expect(el.open).toBe(true);
+  });
+});

--- a/packages/components/src/components/dropdown/dropdown.browser.e2e.tsx
+++ b/packages/components/src/components/dropdown/dropdown.browser.e2e.tsx
@@ -76,6 +76,10 @@ function createSimpleDropdownHTML(): JsxNode {
   );
 }
 
+function dispatchKeydown(target: Element, key: string): void {
+  target.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true }));
+}
+
 describe("renders", () => {
   renders(() => mount(createSimpleDropdownHTML), { display: "inline-block" });
 });
@@ -206,12 +210,25 @@ describe("hover type", () => {
 });
 
 describe("ariaActiveDescendantElement", () => {
-  function getTriggerSlotLocator() {
-    return page.getBySelector("calcite-dropdown slot").first();
+  function getSlottedTriggerLocator() {
+    const internalButton = page.getByRole("button", { name: "Open dropdown" }).element();
+    const triggerHost = (internalButton?.getRootNode() as ShadowRoot | null)?.host;
+
+    if (!(triggerHost instanceof HTMLElement)) {
+      throw new Error("Expected slotted calcite-button host");
+    }
+
+    return page.elementLocator(triggerHost);
   }
 
-  function getSlottedTriggerLocator() {
-    return page.getBySelector("calcite-dropdown [slot=trigger]");
+  function getTriggerSlotLocator() {
+    const slot = (getSlottedTriggerLocator().element() as HTMLElement | null)?.assignedSlot;
+
+    if (!(slot instanceof HTMLSlotElement)) {
+      throw new Error("Expected assigned trigger slot");
+    }
+
+    return page.elementLocator(slot);
   }
 
   function getActiveDescendantId(): string | undefined {
@@ -275,10 +292,6 @@ describe("referenceElement keydown", () => {
         </calcite-dropdown>
       </div>
     );
-  }
-
-  function dispatchKeydown(target: Element, key: string): void {
-    target.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true }));
   }
 
   it("opens when Enter keydown is dispatched on referenceElement", async () => {
@@ -351,42 +364,94 @@ describe("keyboard navigation", () => {
     return page.getByRole("button", { name: "Open dropdown" });
   }
 
-  function getActiveDescendantId(): string | undefined {
-    return (getReferenceElementTrigger().element() as HTMLElement | null)
-      ?.ariaActiveDescendantElement?.id;
+  function getDropdownLocator() {
+    const dropdown = getReferenceElementTrigger().element()?.nextElementSibling;
+
+    if (!(dropdown instanceof HTMLElement)) {
+      throw new Error("Expected dropdown next to reference element trigger");
+    }
+
+    return page.elementLocator(dropdown);
+  }
+
+  async function waitForDropdownUpdateComplete(): Promise<void> {
+    const dropdown = getDropdownLocator().element() as Dropdown;
+
+    await dropdown.updateComplete;
+    await dropdown.updateComplete;
+  }
+
+  const defaultItemIds = ["item-1", "item-2", "item-3"];
+  const disabledAndHiddenItemIds = ["item-1", "item-1.5", "item-2", "item-2.5", "item-3", "item-4"];
+
+  const dropdownItemTextById: Record<string, string> = {
+    "item-1": "1",
+    "item-1.5": "1.5",
+    "item-2": "2",
+    "item-2.5": "2.5",
+    "item-3": "3",
+    "item-4": "4",
+  };
+
+  function getDropdownItemLocator(itemId: string) {
+    const itemText = dropdownItemTextById[itemId];
+
+    if (!itemText) {
+      return null;
+    }
+
+    const itemContent = getDropdownLocator().getByText(itemText, { exact: true }).element();
+    const item = itemContent?.closest("calcite-dropdown-item");
+
+    if (!(item instanceof HTMLElement)) {
+      return null;
+    }
+
+    return page.elementLocator(item);
+  }
+
+  function getActiveItemId(itemIds: string[]): string | undefined {
+    return itemIds.find((itemId) => {
+      const item = getDropdownItemLocator(itemId);
+
+      return (item?.element() as (HTMLElement & { activeDescendant?: boolean }) | null)
+        ?.activeDescendant;
+    });
+  }
+
+  async function pressReferenceElementKey(key: string): Promise<void> {
+    dispatchKeydown(getReferenceElementTrigger().element() as Element, key);
+    await waitForDropdownUpdateComplete();
   }
 
   it("supports navigating through items with arrow keys", async () => {
     await mount<Dropdown>(() =>
       createReferenceElementKeyboardDropdownHTML({ selectedItemId: "item-1" }),
     );
-    const trigger = getReferenceElementTrigger();
 
-    await userEvent.click(trigger);
-    await userEvent.type(trigger, "{Enter}");
+    await pressReferenceElementKey("Enter");
+    expect(getActiveItemId(defaultItemIds)).toBe("item-1");
 
-    expect(getActiveDescendantId()).toBe("item-1");
+    await pressReferenceElementKey("ArrowDown");
+    expect(getActiveItemId(defaultItemIds)).toBe("item-2");
 
-    await userEvent.type(trigger, "{ArrowDown}");
-    expect(getActiveDescendantId()).toBe("item-2");
+    await pressReferenceElementKey("ArrowDown");
+    expect(getActiveItemId(defaultItemIds)).toBe("item-3");
 
-    await userEvent.type(trigger, "{ArrowDown}");
-    expect(getActiveDescendantId()).toBe("item-3");
+    await pressReferenceElementKey("ArrowDown");
+    expect(getActiveItemId(defaultItemIds)).toBe("item-1");
 
-    await userEvent.type(trigger, "{ArrowDown}");
-    expect(getActiveDescendantId()).toBe("item-1");
+    await pressReferenceElementKey("ArrowUp");
+    expect(getActiveItemId(defaultItemIds)).toBe("item-3");
 
-    await userEvent.type(trigger, "{ArrowUp}");
-    expect(getActiveDescendantId()).toBe("item-3");
+    await pressReferenceElementKey("ArrowUp");
+    expect(getActiveItemId(defaultItemIds)).toBe("item-2");
 
-    await userEvent.type(trigger, "{ArrowUp}");
-    expect(getActiveDescendantId()).toBe("item-2");
+    await pressReferenceElementKey("ArrowUp");
+    expect(getActiveItemId(defaultItemIds)).toBe("item-1");
 
-    await userEvent.type(trigger, "{ArrowUp}");
-    expect(getActiveDescendantId()).toBe("item-1");
-
-    await userEvent.type(trigger, "{ArrowUp}");
-    expect(getActiveDescendantId()).toBe("item-3");
+    await pressReferenceElementKey("ArrowUp");
+    expect(getActiveItemId(defaultItemIds)).toBe("item-3");
   });
 
   it("skips disabled and hidden items when navigating with arrow keys", async () => {
@@ -395,79 +460,67 @@ describe("keyboard navigation", () => {
         includeDisabledAndHiddenItems: true,
       }),
     );
-    const trigger = getReferenceElementTrigger();
 
-    await userEvent.click(trigger);
-    await userEvent.type(trigger, "{Enter}");
+    await pressReferenceElementKey("Enter");
+    expect(getActiveItemId(disabledAndHiddenItemIds)).toBe("item-2");
 
-    expect(getActiveDescendantId()).toBe("item-2");
+    await pressReferenceElementKey("ArrowDown");
+    expect(getActiveItemId(disabledAndHiddenItemIds)).toBe("item-3");
 
-    await userEvent.type(trigger, "{ArrowDown}");
-    expect(getActiveDescendantId()).toBe("item-3");
+    await pressReferenceElementKey("ArrowDown");
+    expect(getActiveItemId(disabledAndHiddenItemIds)).toBe("item-2");
 
-    await userEvent.type(trigger, "{ArrowDown}");
-    expect(getActiveDescendantId()).toBe("item-2");
+    await pressReferenceElementKey("ArrowUp");
+    expect(getActiveItemId(disabledAndHiddenItemIds)).toBe("item-3");
 
-    await userEvent.type(trigger, "{ArrowUp}");
-    expect(getActiveDescendantId()).toBe("item-3");
+    await pressReferenceElementKey("ArrowUp");
+    expect(getActiveItemId(disabledAndHiddenItemIds)).toBe("item-2");
 
-    await userEvent.type(trigger, "{ArrowUp}");
-    expect(getActiveDescendantId()).toBe("item-2");
-
-    await userEvent.type(trigger, "{ArrowUp}");
-    expect(getActiveDescendantId()).toBe("item-3");
+    await pressReferenceElementKey("ArrowUp");
+    expect(getActiveItemId(disabledAndHiddenItemIds)).toBe("item-3");
   });
 
   it("should open the dropdown and focus the first item with ArrowDown", async () => {
     await mount<Dropdown>(() => createReferenceElementKeyboardDropdownHTML());
-    const trigger = getReferenceElementTrigger();
-
-    await userEvent.click(trigger);
-    await userEvent.type(trigger, "{ArrowDown}");
+    await pressReferenceElementKey("ArrowDown");
 
     expect(getReferenceElementExpandedState()).toBe("true");
-    expect(getActiveDescendantId()).toBe("item-1");
+    expect(getActiveItemId(defaultItemIds)).toBe("item-1");
 
-    await userEvent.type(trigger, "{ArrowDown}");
-    expect(getActiveDescendantId()).toBe("item-2");
+    await pressReferenceElementKey("ArrowDown");
+    expect(getActiveItemId(defaultItemIds)).toBe("item-2");
 
-    await userEvent.type(trigger, "{ArrowUp}");
-    expect(getActiveDescendantId()).toBe("item-1");
+    await pressReferenceElementKey("ArrowUp");
+    expect(getActiveItemId(defaultItemIds)).toBe("item-1");
   });
 
   it("should open the dropdown and focus the last item with ArrowUp when no item is selected", async () => {
     await mount<Dropdown>(() => createReferenceElementKeyboardDropdownHTML());
-    const trigger = getReferenceElementTrigger();
-
-    await userEvent.click(trigger);
-    await userEvent.type(trigger, "{ArrowUp}");
+    await pressReferenceElementKey("ArrowUp");
 
     expect(getReferenceElementExpandedState()).toBe("true");
-    expect(getActiveDescendantId()).toBe("item-3");
+    expect(getActiveItemId(defaultItemIds)).toBe("item-3");
 
-    await userEvent.type(trigger, "{ArrowDown}");
-    expect(getActiveDescendantId()).toBe("item-1");
+    await pressReferenceElementKey("ArrowDown");
+    expect(getActiveItemId(defaultItemIds)).toBe("item-1");
 
-    await userEvent.type(trigger, "{ArrowUp}");
-    expect(getActiveDescendantId()).toBe("item-3");
+    await pressReferenceElementKey("ArrowUp");
+    expect(getActiveItemId(defaultItemIds)).toBe("item-3");
   });
 
   it("should open the dropdown and focus the last item with ArrowUp", async () => {
     await mount<Dropdown>(() =>
       createReferenceElementKeyboardDropdownHTML({ selectedItemId: "item-2" }),
     );
-    const trigger = getReferenceElementTrigger();
-
-    await userEvent.click(trigger);
-    await userEvent.type(trigger, "{ArrowUp}");
+    await pressReferenceElementKey("ArrowUp");
 
     expect(getReferenceElementExpandedState()).toBe("true");
-    expect(getActiveDescendantId()).toBe("item-3");
+    expect(getActiveItemId(defaultItemIds)).toBe("item-3");
 
-    await userEvent.type(trigger, "{ArrowUp}");
-    expect(getActiveDescendantId()).toBe("item-2");
+    await pressReferenceElementKey("ArrowUp");
+    expect(getActiveItemId(defaultItemIds)).toBe("item-2");
 
-    await userEvent.type(trigger, "{ArrowDown}");
-    expect(getActiveDescendantId()).toBe("item-3");
+    await pressReferenceElementKey("ArrowDown");
+    expect(getActiveItemId(defaultItemIds)).toBe("item-3");
   });
 });

--- a/packages/components/src/components/dropdown/dropdown.e2e.ts
+++ b/packages/components/src/components/dropdown/dropdown.e2e.ts
@@ -27,8 +27,20 @@ const simpleDropdownHTML = html`
   </calcite-dropdown>
 `;
 
+const simpleReferenceElementDropdownHTML = html`
+  <calcite-dropdown reference-element="trigger">
+    <calcite-dropdown-group id="group-1">
+      <calcite-dropdown-item id="item-1"> Dropdown Item Content </calcite-dropdown-item>
+      <calcite-dropdown-item id="item-2" selected> Dropdown Item Content </calcite-dropdown-item>
+      <calcite-dropdown-item id="item-3"> Dropdown Item Content </calcite-dropdown-item>
+    </calcite-dropdown-group>
+  </calcite-dropdown>
+  <calcite-button id="trigger">Open dropdown</calcite-button>
+`;
+
 describe("openClose", () => {
   openClose(simpleDropdownHTML);
+  openClose(simpleReferenceElementDropdownHTML);
 });
 
 const dropdownSelectionModeContent = html`
@@ -1049,6 +1061,7 @@ it("focus is returned to trigger after close", async () => {
 
 describe("accessible", () => {
   accessible(html`${dropdownSelectionModeContent}`);
+  accessible(simpleReferenceElementDropdownHTML);
 });
 
 it("correct role and aria properties are applied based on selection type", async () => {

--- a/packages/components/src/components/dropdown/dropdown.e2e.ts
+++ b/packages/components/src/components/dropdown/dropdown.e2e.ts
@@ -40,6 +40,9 @@ const simpleReferenceElementDropdownHTML = html`
 
 describe("openClose", () => {
   openClose(simpleDropdownHTML);
+});
+
+describe("openClose: reference element", () => {
   openClose(simpleReferenceElementDropdownHTML);
 });
 
@@ -1061,6 +1064,9 @@ it("focus is returned to trigger after close", async () => {
 
 describe("accessible", () => {
   accessible(html`${dropdownSelectionModeContent}`);
+});
+
+describe("accessible reference element", () => {
   accessible(simpleReferenceElementDropdownHTML);
 });
 

--- a/packages/components/src/components/dropdown/dropdown.stories.ts
+++ b/packages/components/src/components/dropdown/dropdown.stories.ts
@@ -540,3 +540,44 @@ export const offsetPlacement = (): string => html`
     </calcite-dropdown-group>
   </calcite-dropdown>
 `;
+
+export const test = (): string =>
+  html`<div style="margin: 50px; padding: 50px">
+    <calcite-button>Non actionable button</calcite-button>
+
+    <calcite-dropdown width="m" type="hover">
+      <calcite-button slot="trigger">Hover</calcite-button>
+      <calcite-dropdown-group group-title="Natural places">
+        <calcite-dropdown-item>Mountain</calcite-dropdown-item>
+        <calcite-dropdown-item>River</calcite-dropdown-item>
+        <calcite-dropdown-item>Waterfall</calcite-dropdown-item>
+        <calcite-dropdown-item>Rainforest</calcite-dropdown-item>
+        <calcite-dropdown-item>Tundra</calcite-dropdown-item>
+        <calcite-dropdown-item>Desert</calcite-dropdown-item>
+      </calcite-dropdown-group>
+    </calcite-dropdown>
+
+    <calcite-button id="hover">Hover: controller</calcite-button>
+    <calcite-dropdown reference-element="hover" width="m" type="hover">
+      <calcite-dropdown-group group-title="Natural places">
+        <calcite-dropdown-item>Mountain</calcite-dropdown-item>
+        <calcite-dropdown-item>River</calcite-dropdown-item>
+        <calcite-dropdown-item>Waterfall</calcite-dropdown-item>
+        <calcite-dropdown-item>Rainforest</calcite-dropdown-item>
+        <calcite-dropdown-item>Tundra</calcite-dropdown-item>
+        <calcite-dropdown-item>Desert</calcite-dropdown-item>
+      </calcite-dropdown-group>
+    </calcite-dropdown>
+
+    <calcite-button id="context">Context: controller</calcite-button>
+    <calcite-dropdown reference-element="context" width="m" type="context">
+      <calcite-dropdown-group group-title="Natural places">
+        <calcite-dropdown-item>Mountain</calcite-dropdown-item>
+        <calcite-dropdown-item>River</calcite-dropdown-item>
+        <calcite-dropdown-item>Waterfall</calcite-dropdown-item>
+        <calcite-dropdown-item>Rainforest</calcite-dropdown-item>
+        <calcite-dropdown-item>Tundra</calcite-dropdown-item>
+        <calcite-dropdown-item>Desert</calcite-dropdown-item>
+      </calcite-dropdown-group>
+    </calcite-dropdown>
+  </div>`;

--- a/packages/components/src/components/dropdown/dropdown.stories.ts
+++ b/packages/components/src/components/dropdown/dropdown.stories.ts
@@ -541,17 +541,16 @@ export const offsetPlacement = (): string => html`
   </calcite-dropdown>
 `;
 
-export const referenceElement = (): string =>
-  html`<div style="margin: 50px; padding: 50px">
-    <calcite-button id="my-dropdown">My Dropdown</calcite-button>
-    <calcite-dropdown reference-element="my-dropdown" open>
-      <calcite-dropdown-group group-title="Natural places">
-        <calcite-dropdown-item>Mountain</calcite-dropdown-item>
-        <calcite-dropdown-item>River</calcite-dropdown-item>
-        <calcite-dropdown-item>Waterfall</calcite-dropdown-item>
-        <calcite-dropdown-item>Rainforest</calcite-dropdown-item>
-        <calcite-dropdown-item>Tundra</calcite-dropdown-item>
-        <calcite-dropdown-item>Desert</calcite-dropdown-item>
-      </calcite-dropdown-group>
-    </calcite-dropdown>
-  </div>`;
+export const referenceElement = (): string => html`
+  <calcite-button id="my-dropdown">My Dropdown</calcite-button>
+  <calcite-dropdown reference-element="my-dropdown" open>
+    <calcite-dropdown-group group-title="Natural places">
+      <calcite-dropdown-item>Mountain</calcite-dropdown-item>
+      <calcite-dropdown-item>River</calcite-dropdown-item>
+      <calcite-dropdown-item>Waterfall</calcite-dropdown-item>
+      <calcite-dropdown-item>Rainforest</calcite-dropdown-item>
+      <calcite-dropdown-item>Tundra</calcite-dropdown-item>
+      <calcite-dropdown-item>Desert</calcite-dropdown-item>
+    </calcite-dropdown-group>
+  </calcite-dropdown>
+`;

--- a/packages/components/src/components/dropdown/dropdown.stories.ts
+++ b/packages/components/src/components/dropdown/dropdown.stories.ts
@@ -541,36 +541,10 @@ export const offsetPlacement = (): string => html`
   </calcite-dropdown>
 `;
 
-export const test = (): string =>
+export const referenceElement = (): string =>
   html`<div style="margin: 50px; padding: 50px">
-    <calcite-button>Non actionable button</calcite-button>
-
-    <calcite-dropdown width="m" type="hover">
-      <calcite-button slot="trigger">Hover</calcite-button>
-      <calcite-dropdown-group group-title="Natural places">
-        <calcite-dropdown-item>Mountain</calcite-dropdown-item>
-        <calcite-dropdown-item>River</calcite-dropdown-item>
-        <calcite-dropdown-item>Waterfall</calcite-dropdown-item>
-        <calcite-dropdown-item>Rainforest</calcite-dropdown-item>
-        <calcite-dropdown-item>Tundra</calcite-dropdown-item>
-        <calcite-dropdown-item>Desert</calcite-dropdown-item>
-      </calcite-dropdown-group>
-    </calcite-dropdown>
-
-    <calcite-button id="hover">Hover: controller</calcite-button>
-    <calcite-dropdown reference-element="hover" width="m" type="hover">
-      <calcite-dropdown-group group-title="Natural places">
-        <calcite-dropdown-item>Mountain</calcite-dropdown-item>
-        <calcite-dropdown-item>River</calcite-dropdown-item>
-        <calcite-dropdown-item>Waterfall</calcite-dropdown-item>
-        <calcite-dropdown-item>Rainforest</calcite-dropdown-item>
-        <calcite-dropdown-item>Tundra</calcite-dropdown-item>
-        <calcite-dropdown-item>Desert</calcite-dropdown-item>
-      </calcite-dropdown-group>
-    </calcite-dropdown>
-
-    <calcite-button id="context">Context: controller</calcite-button>
-    <calcite-dropdown reference-element="context" width="m" type="context">
+    <calcite-button id="my-dropdown">My Dropdown</calcite-button>
+    <calcite-dropdown reference-element="my-dropdown" open>
       <calcite-dropdown-group group-title="Natural places">
         <calcite-dropdown-item>Mountain</calcite-dropdown-item>
         <calcite-dropdown-item>River</calcite-dropdown-item>

--- a/packages/components/src/components/dropdown/dropdown.tsx
+++ b/packages/components/src/components/dropdown/dropdown.tsx
@@ -15,6 +15,7 @@ import {
   hideFloatingUI,
   LogicalPlacement,
   OverlayPositioning,
+  ReferenceElement,
   reposition,
 } from "../../utils/floating-ui";
 import { isActivationKey } from "../../utils/key";
@@ -28,6 +29,12 @@ import type { DropdownGroup } from "../dropdown-group/dropdown-group";
 import { useSetFocus } from "../../controllers/useSetFocus";
 import { useInteractive } from "../../controllers/useInteractive";
 import { useTopLayer } from "../../controllers/useTopLayer";
+import {
+  ReferenceElementComponent,
+  ReferenceElementType,
+  useReferenceElement,
+} from "../../controllers/useReferenceElement";
+import { referenceElementManager } from "../../controllers/useReferenceElement/manager";
 import { CSS, SLOTS } from "./resources";
 import { styles } from "./dropdown.scss";
 
@@ -37,11 +44,13 @@ declare global {
   }
 }
 
+const manager = referenceElementManager({ click: true, hover: true });
+
 /**
  * @slot - A slot for adding `calcite-dropdown-group` elements. Every `calcite-dropdown-item` must have a parent `calcite-dropdown-group`, even if the `groupTitle` property is not set.
- * @slot trigger - A slot for the element that triggers the component.
+ * @slot trigger - [deprecated] Use `referenceElement` property instead. A slot for the element that triggers the component.
  */
-export class Dropdown extends LitElement implements FloatingUIComponent {
+export class Dropdown extends LitElement implements FloatingUIComponent, ReferenceElementComponent {
   //#region Static Members
 
   static override shadowRootOptions = { mode: "open" as const, delegatesFocus: true };
@@ -51,6 +60,12 @@ export class Dropdown extends LitElement implements FloatingUIComponent {
   //#endregion
 
   //#region Private Properties
+
+  get referenceElementType(): ReferenceElementType {
+    return this.referenceElement ? this.type : null;
+  }
+
+  referenceElementController = useReferenceElement({ manager })(this);
 
   private direction = useDirection();
 
@@ -69,8 +84,6 @@ export class Dropdown extends LitElement implements FloatingUIComponent {
   private mutationObserver = createObserver("mutation", () => this.updateItems());
 
   transitionProp = "opacity" as const;
-
-  referenceEl: HTMLDivElement;
 
   private resizeObserver = createObserver("resize", (entries) =>
     this.resizeObserverCallback(entries),
@@ -93,6 +106,8 @@ export class Dropdown extends LitElement implements FloatingUIComponent {
   //#region State Properties
 
   @state() activeDescendantElement?: DropdownItem["el"];
+
+  @state() referenceEl: ReferenceElement;
 
   //#endregion
 
@@ -141,6 +156,19 @@ export class Dropdown extends LitElement implements FloatingUIComponent {
    * Determines the component's placement relative to the container element.
    */
   @property({ reflect: true }) placement: LogicalPlacement = defaultMenuPlacement;
+
+  /**
+   The `referenceElement` is used to position the component according to its `placement` value.
+   *
+   *Setting the value to an `HTMLElement` is preferred so the component does not need to query the DOM.
+   *
+   * However, a string `id` of the reference element can also be used.
+   *
+   *The component should not be placed within its own `referenceElement` to avoid unintended behavior.
+   *
+   * @required
+   */
+  @property() referenceElement: ReferenceElement | string;
 
   /** Specifies the size of the component. */
   @property({ reflect: true }) scale: Scale = "m";
@@ -221,7 +249,10 @@ export class Dropdown extends LitElement implements FloatingUIComponent {
    */
   @method()
   async setFocus(options?: FocusOptions): Promise<void> {
-    return this.focusSetter(() => this.referenceEl, options);
+    return this.focusSetter(
+      () => (this.referenceEl instanceof HTMLElement ? this.referenceEl : this.floatingEl),
+      options,
+    );
   }
 
   //#endregion
@@ -297,6 +328,16 @@ export class Dropdown extends LitElement implements FloatingUIComponent {
     if (changes.has("scale") && (this.hasUpdated || this.scale !== "m")) {
       this.handlePropsChange();
     }
+
+    if (changes.has("referenceElement") && !this.referenceElement && this.open) {
+      this.topLayer.hide();
+    }
+  }
+
+  override updated(changes: PropertyValues<this>): void {
+    if (changes.has("referenceEl") && this.referenceElementType) {
+      connectFloatingUI(this);
+    }
   }
 
   loaded(): void {
@@ -340,7 +381,12 @@ export class Dropdown extends LitElement implements FloatingUIComponent {
   }
 
   private closeCalciteDropdownOnClick(event: MouseEvent): void {
-    if (this.disabled || !this.open || event.composedPath().includes(this.el)) {
+    if (
+      this.referenceElementType ||
+      this.disabled ||
+      !this.open ||
+      event.composedPath().includes(this.el)
+    ) {
       return;
     }
 
@@ -348,7 +394,7 @@ export class Dropdown extends LitElement implements FloatingUIComponent {
   }
 
   private closeCalciteDropdownOnOpenEvent(event: Event): void {
-    if (event.composedPath().includes(this.el)) {
+    if (this.referenceElementType || event.composedPath().includes(this.el)) {
       return;
     }
 
@@ -356,7 +402,7 @@ export class Dropdown extends LitElement implements FloatingUIComponent {
   }
 
   private pointerEnterHandler(): void {
-    if (this.disabled || this.type !== "hover") {
+    if (this.referenceElementType || this.disabled || this.type !== "hover") {
       return;
     }
 
@@ -364,7 +410,7 @@ export class Dropdown extends LitElement implements FloatingUIComponent {
   }
 
   private pointerLeaveHandler(): void {
-    if (this.disabled || this.type !== "hover") {
+    if (this.referenceElementType || this.disabled || this.type !== "hover") {
       return;
     }
 
@@ -438,7 +484,7 @@ export class Dropdown extends LitElement implements FloatingUIComponent {
   private setDropdownWidth(): void {
     const { referenceEl, scrollerEl } = this;
 
-    if (!scrollerEl || !referenceEl) {
+    if (!scrollerEl || !(referenceEl instanceof HTMLElement)) {
       return;
     }
 
@@ -487,8 +533,12 @@ export class Dropdown extends LitElement implements FloatingUIComponent {
   }
 
   private setReferenceEl(el: HTMLDivElement): void {
-    updateRefObserver(this.resizeObserver, this.referenceEl, el);
     this.referenceEl = el;
+
+    if (this.referenceEl instanceof HTMLElement) {
+      updateRefObserver(this.resizeObserver, this.referenceEl, el);
+    }
+
     connectFloatingUI(this);
   }
 
@@ -498,6 +548,10 @@ export class Dropdown extends LitElement implements FloatingUIComponent {
   }
 
   private keyDownHandler(event: KeyboardEvent): void {
+    if (!(this.referenceEl instanceof HTMLElement)) {
+      return;
+    }
+
     if (!event.composedPath().includes(this.referenceEl)) {
       return;
     }
@@ -700,7 +754,9 @@ export class Dropdown extends LitElement implements FloatingUIComponent {
     if (
       relatedTarget &&
       (this.el.contains(relatedTarget) ||
-        (this.referenceEl != null && this.referenceEl.contains(relatedTarget)))
+        (this.referenceEl != null &&
+          this.referenceEl instanceof HTMLElement &&
+          this.referenceEl.contains(relatedTarget)))
     ) {
       return;
     }
@@ -724,22 +780,24 @@ export class Dropdown extends LitElement implements FloatingUIComponent {
     const { open } = this;
     return (
       <this.interactiveContainer disabled={this.disabled}>
-        <div
-          class={CSS.triggerContainer}
-          onClick={this.toggleClickDropdown}
-          onFocusIn={this.openHoverDropdown}
-          onFocusOut={this.closeHoverDropdown}
-          onKeyDown={this.keyDownHandler}
-          ref={this.setReferenceEl}
-        >
-          <slot
-            ariaActiveDescendantElement={this.activeDescendantElement ?? null}
-            ariaControlsElements={this.scrollerEl ? [this.scrollerEl] : undefined}
-            ariaExpanded={open}
-            ariaHasPopup="menu"
-            name={SLOTS.trigger}
-          />
-        </div>
+        {!this.referenceElementType ? (
+          <div
+            class={CSS.triggerContainer}
+            onClick={this.toggleClickDropdown}
+            onFocusIn={this.openHoverDropdown}
+            onFocusOut={this.closeHoverDropdown}
+            onKeyDown={this.keyDownHandler}
+            ref={this.setReferenceEl}
+          >
+            <slot
+              ariaActiveDescendantElement={this.activeDescendantElement ?? null}
+              ariaControlsElements={this.scrollerEl ? [this.scrollerEl] : undefined}
+              ariaExpanded={open}
+              ariaHasPopup="menu"
+              name={SLOTS.trigger}
+            />
+          </div>
+        ) : null}
         <div
           class={{
             [CSS.wrapper]: true,
@@ -752,7 +810,9 @@ export class Dropdown extends LitElement implements FloatingUIComponent {
           ref={this.setFloatingEl}
         >
           <div
-            ariaLabelledByElements={this.referenceEl ? [this.referenceEl] : undefined}
+            ariaLabelledByElements={
+              this.referenceEl instanceof HTMLElement ? [this.referenceEl] : undefined
+            }
             class={{
               [CSS.content]: true,
               [FloatingCSS.animation]: true,

--- a/packages/components/src/components/dropdown/dropdown.tsx
+++ b/packages/components/src/components/dropdown/dropdown.tsx
@@ -93,6 +93,8 @@ export class Dropdown extends LitElement implements FloatingUIComponent, Referen
 
   transitionEl: HTMLDivElement;
 
+  onReferenceElementKeydown = (event: KeyboardEvent): void => this.keyDownHandler(event);
+
   private focusSetter = useSetFocus<this>()(this);
 
   private interactiveContainer = useInteractive(this);

--- a/packages/components/src/components/dropdown/dropdown.tsx
+++ b/packages/components/src/components/dropdown/dropdown.tsx
@@ -61,7 +61,7 @@ export class Dropdown extends LitElement implements FloatingUIComponent, Referen
 
   //#region Private Properties
 
-  get referenceElementType(): ReferenceElementType {
+  get referenceElementType(): ReferenceElementType | nil {
     return this.referenceElement ? this.type : null;
   }
 
@@ -535,11 +535,12 @@ export class Dropdown extends LitElement implements FloatingUIComponent, Referen
   }
 
   private setReferenceEl(el: HTMLDivElement): void {
-    this.referenceEl = el;
+    const previousReferenceEl = this.referenceEl instanceof HTMLElement ? this.referenceEl : null;
+    const nextReferenceEl = el instanceof HTMLElement ? el : null;
 
-    if (this.referenceEl instanceof HTMLElement) {
-      updateRefObserver(this.resizeObserver, this.referenceEl, el);
-    }
+    updateRefObserver(this.resizeObserver, previousReferenceEl, nextReferenceEl);
+
+    this.referenceEl = el;
 
     connectFloatingUI(this);
   }

--- a/packages/components/src/components/dropdown/dropdown.tsx
+++ b/packages/components/src/components/dropdown/dropdown.tsx
@@ -167,10 +167,8 @@ export class Dropdown extends LitElement implements FloatingUIComponent, Referen
    * However, a string `id` of the reference element can also be used.
    *
    *The component should not be placed within its own `referenceElement` to avoid unintended behavior.
-   *
-   * @required
    */
-  @property() referenceElement: ReferenceElement | string;
+  @property() referenceElement: ReferenceElement | string | nil;
 
   /** Specifies the size of the component. */
   @property({ reflect: true }) scale: Scale = "m";

--- a/packages/components/src/components/dropdown/dropdown.tsx
+++ b/packages/components/src/components/dropdown/dropdown.tsx
@@ -2,7 +2,6 @@
 import { PropertyValues } from "lit";
 import { createEvent, h, JsxNode, LitElement, method, property, state } from "@arcgis/lumina";
 import { useDirection } from "@arcgis/lumina/controllers";
-import { nil } from "@arcgis/toolkit/type";
 import { nextFrame } from "../../utils/dom";
 import {
   connectFloatingUI,
@@ -61,7 +60,7 @@ export class Dropdown extends LitElement implements FloatingUIComponent, Referen
 
   //#region Private Properties
 
-  get referenceElementType(): ReferenceElementType | nil {
+  get referenceElementType(): ReferenceElementType | null {
     return this.referenceElement ? this.type : null;
   }
 
@@ -93,7 +92,7 @@ export class Dropdown extends LitElement implements FloatingUIComponent, Referen
 
   transitionEl: HTMLDivElement;
 
-  onReferenceElementKeydown = (event: KeyboardEvent): void => this.keyDownHandler(event);
+  onReferenceElementKeyDown = (event: KeyboardEvent): void => this.keyDownHandler(event);
 
   private focusSetter = useSetFocus<this>()(this);
 
@@ -160,15 +159,15 @@ export class Dropdown extends LitElement implements FloatingUIComponent, Referen
   @property({ reflect: true }) placement: LogicalPlacement = defaultMenuPlacement;
 
   /**
-   The `referenceElement` is used to position the component according to its `placement` value.
+   * The `referenceElement` is used to position the component according to its `placement` value.
    *
-   *Setting the value to an `HTMLElement` is preferred so the component does not need to query the DOM.
+   * Setting the value to an `HTMLElement` is preferred so the component does not need to query the DOM.
    *
    * However, a string `id` of the reference element can also be used.
    *
    *The component should not be placed within its own `referenceElement` to avoid unintended behavior.
    */
-  @property() referenceElement: ReferenceElement | string | nil;
+  @property() referenceElement: ReferenceElement | string | null;
 
   /** Specifies the size of the component. */
   @property({ reflect: true }) scale: Scale = "m";
@@ -549,11 +548,10 @@ export class Dropdown extends LitElement implements FloatingUIComponent, Referen
   }
 
   private keyDownHandler(event: KeyboardEvent): void {
-    if (!(this.referenceEl instanceof HTMLElement)) {
-      return;
-    }
-
-    if (!event.composedPath().includes(this.referenceEl)) {
+    if (
+      !(this.referenceEl instanceof HTMLElement) ||
+      !event.composedPath().includes(this.referenceEl)
+    ) {
       return;
     }
 
@@ -678,7 +676,7 @@ export class Dropdown extends LitElement implements FloatingUIComponent, Referen
     this.updateActiveDescendantElement(activeItem);
   }
 
-  private updateActiveDescendantElement(activeItem: DropdownItem["el"] | nil): void {
+  private updateActiveDescendantElement(activeItem: DropdownItem["el"] | null): void {
     this.items.forEach((item) => {
       item.activeDescendant = item === activeItem;
     });

--- a/packages/components/src/controllers/useReferenceElement.ts
+++ b/packages/components/src/controllers/useReferenceElement.ts
@@ -49,6 +49,13 @@ type InternalProps = {
    * The type of reference element interaction ("click" or "hover").
    */
   referenceElementType: ReferenceElementType | nil;
+
+  /**
+   * Optional keydown handler invoked when a keydown event occurs on this component's reference element.
+   *
+   * Can call `event.preventDefault()` to suppress default manager keydown behavior.
+   */
+  onReferenceElementKeydown?: (event: KeyboardEvent) => void;
 };
 
 /**

--- a/packages/components/src/controllers/useReferenceElement.ts
+++ b/packages/components/src/controllers/useReferenceElement.ts
@@ -51,11 +51,20 @@ type InternalProps = {
   referenceElementType: ReferenceElementType | nil;
 
   /**
-   * Optional keydown handler invoked when a keydown event occurs on this component's reference element.
+   * Keydown handler invoked when a keydown event occurs on this component's reference element.
    *
    * Can call `event.preventDefault()` to suppress default manager keydown behavior.
+   *
+   * @example
+   * ```ts
+   * onReferenceElementKeyDown(event: KeyboardEvent): void {
+   *   if (event.key === "Enter") {
+   *     event.preventDefault();
+   *   }
+   * }
+   * ```
    */
-  onReferenceElementKeydown?: (event: KeyboardEvent) => void;
+  onReferenceElementKeyDown?: (event: KeyboardEvent) => void;
 };
 
 /**

--- a/packages/components/src/controllers/useReferenceElement/manager.browser.spec.tsx
+++ b/packages/components/src/controllers/useReferenceElement/manager.browser.spec.tsx
@@ -6,9 +6,15 @@ import type { ReferenceElement } from "../../utils/floating-ui";
 import { useReferenceElement } from "../useReferenceElement";
 import { referenceElementManager } from "./manager";
 
-afterEach(() => {
+const mountedComponents: HTMLElement[] = [];
+
+afterEach(async () => {
+  mountedComponents.forEach((component) => component.remove());
+  mountedComponents.length = 0;
   vi.restoreAllMocks();
   document.body.querySelectorAll("button[data-testid='ref-el']").forEach((el) => el.remove());
+
+  await afterNextFrame();
 });
 
 describe("referenceElementManager", () => {
@@ -44,6 +50,7 @@ describe("referenceElementManager", () => {
     }
 
     const { component } = await mount(TestComponent);
+    mountedComponents.push(component);
 
     await afterNextFrame();
 
@@ -99,6 +106,7 @@ describe("referenceElementManager", () => {
     }
 
     const { component } = await mount(TestComponent);
+    mountedComponents.push(component);
 
     await afterNextFrame();
 
@@ -142,7 +150,8 @@ describe("referenceElementManager", () => {
       }
     }
 
-    await mount(TestComponent);
+    const { component } = await mount(TestComponent);
+    mountedComponents.push(component);
 
     await afterNextFrame();
 

--- a/packages/components/src/controllers/useReferenceElement/manager.browser.spec.tsx
+++ b/packages/components/src/controllers/useReferenceElement/manager.browser.spec.tsx
@@ -6,15 +6,8 @@ import type { ReferenceElement } from "../../utils/floating-ui";
 import { useReferenceElement } from "../useReferenceElement";
 import { referenceElementManager } from "./manager";
 
-const mountedComponents: HTMLElement[] = [];
-
 afterEach(async () => {
-  mountedComponents.forEach((component) => component.remove());
-  mountedComponents.length = 0;
   vi.restoreAllMocks();
-  document.body.querySelectorAll("button[data-testid='ref-el']").forEach((el) => el.remove());
-
-  await afterNextFrame();
 });
 
 describe("referenceElementManager", () => {
@@ -22,7 +15,6 @@ describe("referenceElementManager", () => {
     const manager = referenceElementManager({ click: true, hover: true });
     const trigger = document.createElement("button");
     trigger.dataset.testid = "ref-el";
-    document.body.append(trigger);
 
     const addListenerSpy = vi.spyOn(window, "addEventListener");
     const removeListenerSpy = vi.spyOn(window, "removeEventListener");
@@ -49,8 +41,8 @@ describe("referenceElementManager", () => {
       }
     }
 
-    const { component } = await mount(TestComponent);
-    mountedComponents.push(component);
+    const { component, container } = await mount(TestComponent);
+    container.append(trigger);
 
     await afterNextFrame();
 
@@ -60,7 +52,7 @@ describe("referenceElementManager", () => {
     expect(clickAddCalls).toHaveLength(1);
     expect(keydownAddCalls).toHaveLength(1);
 
-    component.remove();
+    component.el.remove();
 
     await afterNextFrame();
 
@@ -71,11 +63,10 @@ describe("referenceElementManager", () => {
     expect(keydownRemoveCalls).toHaveLength(1);
   });
 
-  it("invokes onReferenceElementKeydown and honors preventDefault", async () => {
+  it("invokes onReferenceElementKeyDown and honors preventDefault", async () => {
     const manager = referenceElementManager({ click: true });
     const trigger = document.createElement("button");
     trigger.dataset.testid = "ref-el";
-    document.body.append(trigger);
 
     const keydownHandlerSpy = vi.fn((event: KeyboardEvent) => {
       event.preventDefault();
@@ -96,17 +87,13 @@ describe("referenceElementManager", () => {
 
       referenceElementType = "click" as const;
 
-      onReferenceElementKeydown = keydownHandlerSpy;
+      onReferenceElementKeyDown = keydownHandlerSpy;
 
       referenceElementController = useReferenceElement({ manager })(this);
-
-      override render(): JsxNode {
-        return <div>test</div>;
-      }
     }
 
-    const { component } = await mount(TestComponent);
-    mountedComponents.push(component);
+    const { component, container } = await mount(TestComponent);
+    container.append(trigger);
 
     await afterNextFrame();
 
@@ -118,11 +105,10 @@ describe("referenceElementManager", () => {
     expect(component.open).toBe(false);
   });
 
-  it("invokes onReferenceElementKeydown in hover-only mode", async () => {
+  it("invokes onReferenceElementKeyDown in hover-only mode", async () => {
     const manager = referenceElementManager({ hover: true });
     const trigger = document.createElement("button");
     trigger.dataset.testid = "ref-el";
-    document.body.append(trigger);
 
     const keydownHandlerSpy = vi.fn();
 
@@ -141,7 +127,7 @@ describe("referenceElementManager", () => {
 
       referenceElementType = "hover" as const;
 
-      onReferenceElementKeydown = keydownHandlerSpy;
+      onReferenceElementKeyDown = keydownHandlerSpy;
 
       referenceElementController = useReferenceElement({ manager })(this);
 
@@ -150,8 +136,8 @@ describe("referenceElementManager", () => {
       }
     }
 
-    const { component } = await mount(TestComponent);
-    mountedComponents.push(component);
+    const { container } = await mount(TestComponent);
+    container.append(trigger);
 
     await afterNextFrame();
 

--- a/packages/components/src/controllers/useReferenceElement/manager.browser.spec.tsx
+++ b/packages/components/src/controllers/useReferenceElement/manager.browser.spec.tsx
@@ -1,0 +1,155 @@
+import { h, JsxNode, LitElement, property } from "@arcgis/lumina";
+import { mount } from "@arcgis/lumina-compiler/testing";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterNextFrame } from "../../tests/utils/timing";
+import type { ReferenceElement } from "../../utils/floating-ui";
+import { useReferenceElement } from "../useReferenceElement";
+import { referenceElementManager } from "./manager";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  document.body.querySelectorAll("button[data-testid='ref-el']").forEach((el) => el.remove());
+});
+
+describe("referenceElementManager", () => {
+  it("registers a single click and keydown window listener when click and hover are enabled", async () => {
+    const manager = referenceElementManager({ click: true, hover: true });
+    const trigger = document.createElement("button");
+    trigger.dataset.testid = "ref-el";
+    document.body.append(trigger);
+
+    const addListenerSpy = vi.spyOn(window, "addEventListener");
+    const removeListenerSpy = vi.spyOn(window, "removeEventListener");
+
+    class TestComponent extends LitElement {
+      @property() open = false;
+
+      @property() referenceElement: string | ReferenceElement | null = trigger;
+
+      @property() triggerDisabled = false;
+
+      @property() autoClose = false;
+
+      @property() closeOnClick = false;
+
+      @property() referenceEl: ReferenceElement | null = null;
+
+      referenceElementType = "click" as const;
+
+      referenceElementController = useReferenceElement({ manager })(this);
+
+      override render(): JsxNode {
+        return <div>test</div>;
+      }
+    }
+
+    const { component } = await mount(TestComponent);
+
+    await afterNextFrame();
+
+    const clickAddCalls = addListenerSpy.mock.calls.filter(([type]) => type === "click");
+    const keydownAddCalls = addListenerSpy.mock.calls.filter(([type]) => type === "keydown");
+
+    expect(clickAddCalls).toHaveLength(1);
+    expect(keydownAddCalls).toHaveLength(1);
+
+    component.remove();
+
+    await afterNextFrame();
+
+    const clickRemoveCalls = removeListenerSpy.mock.calls.filter(([type]) => type === "click");
+    const keydownRemoveCalls = removeListenerSpy.mock.calls.filter(([type]) => type === "keydown");
+
+    expect(clickRemoveCalls).toHaveLength(1);
+    expect(keydownRemoveCalls).toHaveLength(1);
+  });
+
+  it("invokes onReferenceElementKeydown and honors preventDefault", async () => {
+    const manager = referenceElementManager({ click: true });
+    const trigger = document.createElement("button");
+    trigger.dataset.testid = "ref-el";
+    document.body.append(trigger);
+
+    const keydownHandlerSpy = vi.fn((event: KeyboardEvent) => {
+      event.preventDefault();
+    });
+
+    class TestComponent extends LitElement {
+      @property() open = false;
+
+      @property() referenceElement: string | ReferenceElement | null = trigger;
+
+      @property() triggerDisabled = false;
+
+      @property() autoClose = false;
+
+      @property() closeOnClick = false;
+
+      @property() referenceEl: ReferenceElement | null = null;
+
+      referenceElementType = "click" as const;
+
+      onReferenceElementKeydown = keydownHandlerSpy;
+
+      referenceElementController = useReferenceElement({ manager })(this);
+
+      override render(): JsxNode {
+        return <div>test</div>;
+      }
+    }
+
+    const { component } = await mount(TestComponent);
+
+    await afterNextFrame();
+
+    trigger.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true }),
+    );
+
+    expect(keydownHandlerSpy).toHaveBeenCalledTimes(1);
+    expect(component.open).toBe(false);
+  });
+
+  it("invokes onReferenceElementKeydown in hover-only mode", async () => {
+    const manager = referenceElementManager({ hover: true });
+    const trigger = document.createElement("button");
+    trigger.dataset.testid = "ref-el";
+    document.body.append(trigger);
+
+    const keydownHandlerSpy = vi.fn();
+
+    class TestComponent extends LitElement {
+      @property() open = false;
+
+      @property() referenceElement: string | ReferenceElement | null = trigger;
+
+      @property() triggerDisabled = false;
+
+      @property() autoClose = false;
+
+      @property() closeOnClick = false;
+
+      @property() referenceEl: ReferenceElement | null = null;
+
+      referenceElementType = "hover" as const;
+
+      onReferenceElementKeydown = keydownHandlerSpy;
+
+      referenceElementController = useReferenceElement({ manager })(this);
+
+      override render(): JsxNode {
+        return <div>test</div>;
+      }
+    }
+
+    await mount(TestComponent);
+
+    await afterNextFrame();
+
+    trigger.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true }),
+    );
+
+    expect(keydownHandlerSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/components/src/controllers/useReferenceElement/manager.ts
+++ b/packages/components/src/controllers/useReferenceElement/manager.ts
@@ -78,7 +78,7 @@ export const referenceElementManager = (options: ReferenceElementManagerOptions)
 
   const queryComponents = (
     composedPath: EventTarget[],
-    type: ReferenceElementType,
+    type?: ReferenceElementType,
   ): ReferenceElementComponent[] | undefined => {
     const registeredElement = (composedPath as HTMLElement[]).find((pathEl) => registeredElements.has(pathEl));
 
@@ -88,7 +88,7 @@ export const referenceElementManager = (options: ReferenceElementManagerOptions)
 
     const components = registeredElements.get(registeredElement);
 
-    return components?.filter((component) => component.referenceElementType === type);
+    return type ? components?.filter((component) => component.referenceElementType === type) : components;
   };
 
   const toggleComponents = (event: KeyboardEvent | PointerEvent, type: ReferenceElementType): void => {
@@ -249,6 +249,11 @@ export const referenceElementManager = (options: ReferenceElementManagerOptions)
     }
   };
 
+  const onReferenceElementKeydown = (event: KeyboardEvent): void => {
+    const components = queryComponents(event.composedPath());
+    components?.forEach((component) => component.onReferenceElementKeydown?.(event));
+  };
+
   const closeAllComponents = (): void => {
     Array.from(registeredElements.values())
       .flat()
@@ -333,15 +338,39 @@ export const referenceElementManager = (options: ReferenceElementManagerOptions)
     closeHoveredComponents();
   };
 
-  const addListeners = (): void => {
+  const clickListener = (event: PointerEvent): void => {
     if (options.click) {
-      window.addEventListener("click", clickHandler);
-      window.addEventListener("keydown", keyDownHandler);
+      clickHandler(event);
+    }
+
+    if (options.hover) {
+      hoverClickHandler(event);
+    }
+  };
+
+  const keyDownListener = (event: KeyboardEvent): void => {
+    onReferenceElementKeydown(event);
+
+    if (options.click) {
+      keyDownHandler(event);
+    }
+
+    if (options.hover) {
+      hoverKeyDownHandler(event);
+    }
+  };
+
+  const addListeners = (): void => {
+    if (options.click || options.hover) {
+      window.addEventListener("click", clickListener);
+      window.addEventListener("keydown", keyDownListener);
+    }
+
+    if (options.click) {
       window.addEventListener("pointerdown", pointerDownHandler);
     }
+
     if (options.hover) {
-      window.addEventListener("click", hoverClickHandler);
-      window.addEventListener("keydown", hoverKeyDownHandler);
       window.addEventListener("pointermove", pointerMoveHandler);
       window.addEventListener("focusin", focusInHandler);
       window.addEventListener("blur", blurHandler);
@@ -350,14 +379,16 @@ export const referenceElementManager = (options: ReferenceElementManagerOptions)
   };
 
   const removeListeners = (): void => {
+    if (options.click || options.hover) {
+      window.removeEventListener("click", clickListener);
+      window.removeEventListener("keydown", keyDownListener);
+    }
+
     if (options.click) {
       window.removeEventListener("pointerdown", pointerDownHandler);
-      window.removeEventListener("click", clickHandler);
-      window.removeEventListener("keydown", keyDownHandler);
     }
+
     if (options.hover) {
-      window.removeEventListener("click", hoverClickHandler);
-      window.removeEventListener("keydown", hoverKeyDownHandler);
       window.removeEventListener("pointermove", pointerMoveHandler);
       window.removeEventListener("focusin", focusInHandler);
       window.removeEventListener("blur", blurHandler);

--- a/packages/components/src/controllers/useReferenceElement/manager.ts
+++ b/packages/components/src/controllers/useReferenceElement/manager.ts
@@ -249,9 +249,9 @@ export const referenceElementManager = (options: ReferenceElementManagerOptions)
     }
   };
 
-  const onReferenceElementKeydown = (event: KeyboardEvent): void => {
+  const onReferenceElementKeyDown = (event: KeyboardEvent): void => {
     const components = queryComponents(event.composedPath());
-    components?.forEach((component) => component.onReferenceElementKeydown?.(event));
+    components?.forEach((component) => component.onReferenceElementKeyDown?.(event));
   };
 
   const closeAllComponents = (): void => {
@@ -349,7 +349,7 @@ export const referenceElementManager = (options: ReferenceElementManagerOptions)
   };
 
   const keyDownListener = (event: KeyboardEvent): void => {
-    onReferenceElementKeydown(event);
+    onReferenceElementKeyDown(event);
 
     if (options.click) {
       keyDownHandler(event);


### PR DESCRIPTION
**Related Issue:** #12426

## Summary

This PR expands the useReferenceElement system to support component-level keydown hooks and consolidates manager event listeners, and begins integrating external referenceElement support into calcite-dropdown.

Changes:

Updates referenceElementManager to support querying all components for a reference element and to invoke per-component onReferenceElementKeydown before manager keydown behavior.
Adds browser unit tests for consolidated window listeners and onReferenceElementKeydown/preventDefault behavior.
Integrates referenceElement support into calcite-dropdown (property, controller hookup, story, and E2E coverage).
