### PR TITLE
refactor(button): drop unnecessary server check

### DIFF
--- a/packages/components/src/components/button/button.tsx
+++ b/packages/components/src/components/button/button.tsx
@@ -1,5 +1,4 @@
 // @ts-strict-ignore
-import { isServer } from "lit";
 import { createRef } from "lit/directives/ref.js";
 import { literal } from "lit/static-html.js";
 import {
@@ -207,9 +206,7 @@ export class Button extends LitElement implements LabelableComponent, FormOwner 
   }
 
   async load(): Promise<void> {
-    if (!isServer) {
-      this.updateHasContent();
-    }
+    this.updateHasContent();
   }
 
   loaded(): void {


### PR DESCRIPTION
**monday.com sync:** #12164340693

**Related Issue:** N/A

## Summary

Lumina [skips `connectedCallback`, `load` and `loaded`](https://webgis.esri.com/references/lumina/ssr#skipped-lifecycles) hooks, so the load-time server environment check is not needed.