### PR TITLE
refactor(useFormTrigger): tidy up

### DIFF
--- a/packages/components/src/components/action/action.tsx
+++ b/packages/components/src/components/action/action.tsx
@@ -15,7 +15,6 @@ import {
 import { IconName } from "../icon/interfaces";
 import { useT9n } from "../../controllers/useT9n";
 import { useSetFocus } from "../../controllers/useSetFocus";
-import { findAssociatedForm, FormOwner } from "../../utils/form";
 import { useInteractive } from "../../controllers/useInteractive";
 import { useFormTrigger } from "../../controllers/useFormTrigger";
 import T9nStrings from "./assets/t9n/messages.en.json";
@@ -31,7 +30,7 @@ declare global {
 /**
  * @slot - A slot for adding non-interactive content, such as a `calcite-icon`.
  */
-export class Action extends LitElement implements FormOwner {
+export class Action extends LitElement {
   //#region Static Members
 
   static formAssociated = true;
@@ -41,8 +40,6 @@ export class Action extends LitElement implements FormOwner {
   //#endregion
 
   //#region Private Properties
-
-  formEl: HTMLFormElement;
 
   private guid = guid();
 
@@ -209,12 +206,10 @@ export class Action extends LitElement implements FormOwner {
   //#region Lifecycle
 
   override connectedCallback(): void {
-    this.formEl = findAssociatedForm(this);
     this.mutationObserver?.observe(this.el, { childList: true, subtree: true });
   }
 
   override disconnectedCallback(): void {
-    this.formEl = null;
     this.mutationObserver?.disconnect();
   }
 

--- a/packages/components/src/components/button/button.tsx
+++ b/packages/components/src/components/button/button.tsx
@@ -12,7 +12,6 @@ import {
   stringOrBoolean,
 } from "@arcgis/lumina";
 import { useWatchAttributes } from "@arcgis/lumina/controllers";
-import { findAssociatedForm, FormOwner } from "../../utils/form";
 import { connectLabel, disconnectLabel, getLabelText, LabelableComponent } from "../../utils/label";
 import { createObserver, updateRefObserver } from "../../utils/observers";
 import { getIconScale } from "../../utils/component";
@@ -42,7 +41,7 @@ declare global {
  *
  * @slot - A slot for adding text.
  */
-export class Button extends LitElement implements LabelableComponent, FormOwner {
+export class Button extends LitElement implements LabelableComponent {
   //#region Static Members
 
   static formAssociated = true;
@@ -59,8 +58,6 @@ export class Button extends LitElement implements LabelableComponent, FormOwner 
   private childEl?: HTMLElement;
 
   private contentRef = createRef<HTMLSpanElement>();
-
-  formEl: HTMLFormElement;
 
   formTrigger = useFormTrigger({ disabled: () => !!this.href })(this);
 
@@ -207,7 +204,6 @@ export class Button extends LitElement implements LabelableComponent, FormOwner 
   override connectedCallback(): void {
     this.setupTextContentObserver();
     connectLabel(this);
-    this.formEl = findAssociatedForm(this);
   }
 
   async load(): Promise<void> {
@@ -222,7 +218,6 @@ export class Button extends LitElement implements LabelableComponent, FormOwner 
     this.mutationObserver?.disconnect();
     disconnectLabel(this);
     this.resizeObserver?.disconnect();
-    this.formEl = null;
   }
 
   //#endregion

--- a/packages/components/src/controllers/useForm.ts
+++ b/packages/components/src/controllers/useForm.ts
@@ -40,7 +40,7 @@ export type MutableValidityState = Writable<ValidityState>;
  *
  * Allows calling submit/reset methods on the form.
  */
-interface FormOwner extends LitElement {
+export interface FormOwnerComponent extends LitElement {
   /**
    * The ID of the form to associate with the component.
    *
@@ -58,7 +58,7 @@ interface FormOwner extends LitElement {
  */
 export interface FormComponent<T = any>
   extends
-    FormOwner,
+    FormOwnerComponent,
     LitElement,
     SetFocusable,
     // 👇 needed, otherwise types don't come through when using FormComponent | CheckableFormComponent

--- a/packages/components/src/controllers/useFormTrigger.ts
+++ b/packages/components/src/controllers/useFormTrigger.ts
@@ -7,7 +7,7 @@ export interface FormTriggerComponent extends InteractiveComponent {
 
 interface UseFormTriggerOptions {
   /**
-   * When defined, provides a condition to disable form trigger behavior. When `true`, prevents form submit or reset.
+   * A function that returns a boolean indicating whether the form trigger should be disabled. This can be used to conditionally disable the form trigger based on external factors or component state.
    */
   disabled?: () => boolean;
 }
@@ -19,28 +19,25 @@ export const useFormTrigger = (
   options?: UseFormTriggerOptions,
 ): ReturnType<typeof makeGenericController<void, FormTriggerComponent>> =>
   makeGenericController<void, FormTriggerComponent>((component) => {
-    let lastAssociatedForm: HTMLFormElement | null = null;
-
     function submitHandler(event: Event) {
-      if (event.defaultPrevented) {
+      const { form } = component.elementInternals;
+
+      if (event.defaultPrevented || component.disabled || options?.disabled?.() || !form) {
         return;
       }
-      if (component.disabled || options?.disabled?.()) {
-        return;
-      }
+
       if (component.type === "submit") {
-        component.elementInternals.form.requestSubmit();
+        form.requestSubmit();
       } else if (component.type === "reset") {
-        component.elementInternals.form.reset();
+        form.reset();
       }
     }
 
     component.listen("luminaFormAssociatedCallback", ({ detail: [form] }) => {
       if (form) {
-        component.listen("click", submitHandler);
+        component.el.addEventListener("click", submitHandler);
       } else {
-        lastAssociatedForm?.removeEventListener("click", submitHandler);
+        component.el.removeEventListener("click", submitHandler);
       }
-      lastAssociatedForm = form;
     });
   });

--- a/packages/components/src/controllers/useFormTrigger.ts
+++ b/packages/components/src/controllers/useFormTrigger.ts
@@ -1,7 +1,8 @@
 import { makeGenericController } from "@arcgis/lumina/controllers";
 import { InteractiveComponent } from "./useInteractive";
+import { FormOwnerComponent } from "./useForm";
 
-export interface FormTriggerComponent extends InteractiveComponent {
+export interface FormTriggerComponent extends InteractiveComponent, FormOwnerComponent {
   type: HTMLButtonElement["type"];
 }
 


### PR DESCRIPTION
**monday.com sync:** #12164360846

**Related Issue:** N/A

## Summary

* Use `EventTarget#addEventListener` instead of `LitElement#listen`, since the latter binds the listener and prevents `removeEventListener` from working as expected (the same reference must be used)
* Update `disabled` callback doc
* Remove `click` event from the element instead of the form
* Remove references to previous implementation
* Tidy up