### PR TITLE
refactor(autocomplete): wire up `useForm`

### DIFF
--- a/packages/components/src/components/autocomplete/autocomplete.browser.e2e.tsx
+++ b/packages/components/src/components/autocomplete/autocomplete.browser.e2e.tsx
@@ -148,7 +148,7 @@ describe("defaults", () => {
           tooLong: false,
           tooShort: false,
           typeMismatch: false,
-          valid: false,
+          valid: true,
           valueMissing: false,
         },
       },

--- a/packages/components/src/components/autocomplete/autocomplete.browser.e2e.tsx
+++ b/packages/components/src/components/autocomplete/autocomplete.browser.e2e.tsx
@@ -15,6 +15,7 @@ import {
   t9n,
   disabled,
   topLayer,
+  formAssociated,
 } from "../../tests/commonTests/browser";
 import { defaultMenuPlacement } from "../../utils/floating-ui";
 import { mockConsole } from "../../tests/utils/logging";
@@ -273,6 +274,13 @@ describe("floating-ui", () => {
     floatingUIOwner(() => mount(renderAutocomplete), "open", {
       shadowSelector: `.${CSS.floatingUIContainer}`,
     });
+  });
+});
+
+describe("is form-associated", () => {
+  formAssociated(() => mount(renderAutocomplete), {
+    testValue: "two",
+    submitsOnEnter: true,
   });
 });
 

--- a/packages/components/src/components/autocomplete/autocomplete.browser.e2e.tsx
+++ b/packages/components/src/components/autocomplete/autocomplete.browser.e2e.tsx
@@ -299,7 +299,7 @@ describe("disabled", () => {
 describe("keyboard selection", () => {
   it("toggles active item selection on Enter and emits calciteAutocompleteItemSelect", async () => {
     const { el, reRender } = await mount<Autocomplete>(renderAutocomplete);
-    const firstItem = el.querySelector("calcite-autocomplete-item");
+    const firstItem = el.querySelector("calcite-autocomplete-item")!;
     const itemSelectSpy = vi.fn();
 
     el.addEventListener("calciteAutocompleteItemSelect", itemSelectSpy);

--- a/packages/components/src/components/autocomplete/autocomplete.e2e.ts
+++ b/packages/components/src/components/autocomplete/autocomplete.e2e.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { E2EPage, newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
-import { accessible, formAssociated, labelable, openClose, themed } from "../../tests/commonTests";
+import { accessible, labelable, openClose, themed } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 import { Input } from "../input/input";
 import { findAll, isElementFocused, skipAnimations } from "../../tests/utils/puppeteer";
@@ -228,13 +228,6 @@ describe("labelable", () => {
 
 describe("openClose", () => {
   openClose(simpleHTML);
-});
-
-describe("is form-associated", () => {
-  formAssociated(simpleHTML, {
-    testValue: "two",
-    submitsOnEnter: true,
-  });
 });
 
 it("should set screen reader list attribute 'aria-live' to 'polite'", async () => {

--- a/packages/components/src/components/autocomplete/autocomplete.tsx
+++ b/packages/components/src/components/autocomplete/autocomplete.tsx
@@ -72,6 +72,8 @@ export class Autocomplete
 {
   //#region Static Members
 
+  static formAssociated = true;
+
   static override styles = styles;
 
   //#endregion

--- a/packages/components/src/components/autocomplete/autocomplete.tsx
+++ b/packages/components/src/components/autocomplete/autocomplete.tsx
@@ -46,7 +46,7 @@ import { useSetFocus } from "../../controllers/useSetFocus";
 import { useInteractive } from "../../controllers/useInteractive";
 import { toggleOpenClose } from "../../utils/openCloseComponent";
 import { useTopLayer } from "../../controllers/useTopLayer";
-import { MutableValidityState, useForm } from "../../controllers/useForm";
+import { useForm } from "../../controllers/useForm";
 import { styles } from "./autocomplete.scss";
 import T9nStrings from "./assets/t9n/messages.en.json";
 import { CSS, IDS, SLOTS } from "./resources";
@@ -317,19 +317,7 @@ export class Autocomplete
    * @readonly
    * @mdn [ValidityState](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState)
    */
-  @property() validity: MutableValidityState = {
-    valid: false,
-    badInput: false,
-    customError: false,
-    patternMismatch: false,
-    rangeOverflow: false,
-    rangeUnderflow: false,
-    stepMismatch: false,
-    tooLong: false,
-    tooShort: false,
-    typeMismatch: false,
-    valueMissing: false,
-  };
+  @property() validity: ValidityState;
 
   /** Specifies the selected `autocomplete-item`. When the component resides in a form, the `value` is submitted with the form. */
   @property() value = "";

--- a/packages/components/src/components/autocomplete/autocomplete.tsx
+++ b/packages/components/src/components/autocomplete/autocomplete.tsx
@@ -31,15 +31,6 @@ import { Alignment, Scale, Status } from "../interfaces";
 import { IconName } from "../icon/interfaces";
 import { connectLabel, disconnectLabel, LabelableComponent, getLabelText } from "../../utils/label";
 import { TextualInputComponent } from "../input/common/input";
-import {
-  afterConnectDefaultValueSet,
-  FormComponent,
-  HiddenFormInputSlot,
-  MutableValidityState,
-  connectForm,
-  disconnectForm,
-  submitForm,
-} from "../../utils/form";
 import { slotChangeHasAssignedElement } from "../../utils/dom";
 import { guid } from "../../utils/guid";
 import { useT9n } from "../../controllers/useT9n";
@@ -55,6 +46,7 @@ import { useSetFocus } from "../../controllers/useSetFocus";
 import { useInteractive } from "../../controllers/useInteractive";
 import { toggleOpenClose } from "../../utils/openCloseComponent";
 import { useTopLayer } from "../../controllers/useTopLayer";
+import { MutableValidityState, useForm } from "../../controllers/useForm";
 import { styles } from "./autocomplete.scss";
 import T9nStrings from "./assets/t9n/messages.en.json";
 import { CSS, IDS, SLOTS } from "./resources";
@@ -76,7 +68,7 @@ declare global {
  */
 export class Autocomplete
   extends LitElement
-  implements FloatingUIComponent, FormComponent, LabelableComponent, TextualInputComponent
+  implements FloatingUIComponent, LabelableComponent, TextualInputComponent
 {
   //#region Static Members
 
@@ -95,15 +87,15 @@ export class Autocomplete
 
   defaultValue: Autocomplete["value"];
 
-  defaultInputValue: Autocomplete["inputValue"];
-
   private direction = useDirection();
 
   floatingEl: HTMLDivElement;
 
   floatingLayout?: FloatingLayout;
 
-  formEl: HTMLFormElement;
+  private formSupport = useForm<this>({
+    inputType: "text",
+  })(this);
 
   private inputId = IDS.input(this.guid);
 
@@ -448,8 +440,6 @@ export class Autocomplete
       subtree: true,
     });
     connectLabel(this);
-    connectForm(this);
-    this.defaultInputValue = this.inputValue || "";
     this.getAllItemsDebounced();
     connectFloatingUI(this);
     this.cancelable.add(this.getAllItemsDebounced);
@@ -503,8 +493,6 @@ export class Autocomplete
   }
 
   loaded(): void {
-    afterConnectDefaultValueSet(this, this.value || "");
-    this.defaultInputValue = this.inputValue || "";
     connectFloatingUI(this);
   }
 
@@ -512,7 +500,6 @@ export class Autocomplete
     this.mutationObserver?.disconnect();
     this.resizeObserver?.disconnect();
     disconnectLabel(this);
-    disconnectForm(this);
     disconnectFloatingUI(this);
   }
 
@@ -572,10 +559,6 @@ export class Autocomplete
 
   onLabelClick(): void {
     this.setFocus();
-  }
-
-  onFormReset(): void {
-    this.inputValue = this.defaultInputValue;
   }
 
   onBeforeOpen(): void {
@@ -691,10 +674,9 @@ export class Autocomplete
           activeItem.toggleSelection();
           this.open = false;
           event.preventDefault();
-        } else if (!event.defaultPrevented) {
-          if (submitForm(this)) {
-            event.preventDefault();
-          }
+        } else if (!event.defaultPrevented && this.formSupport.active) {
+          event.preventDefault();
+          this.formSupport.requestSubmit();
         }
         break;
       case "ArrowDown":
@@ -859,7 +841,6 @@ export class Autocomplete
             </div>
           </div>
         </div>
-        <HiddenFormInputSlot component={this} />
         {this.validationMessage && this.status === "invalid" ? (
           <Validation
             icon={this.validationIcon}

--- a/packages/components/src/tests/commonTests/browser/defaults.ts
+++ b/packages/components/src/tests/commonTests/browser/defaults.ts
@@ -52,7 +52,21 @@ export function defaults<
     "%s",
     async (propertyName, defaultValue) => {
       const { el } = await setup();
-      expect(el[propertyName]).toEqual(defaultValue);
+      const propValue = el[propertyName];
+
+      if (propertyName === "validity") {
+        expectValidityEqual(propValue, defaultValue);
+        return;
+      }
+
+      expect(propValue).toEqual(defaultValue);
     },
   );
+}
+
+function expectValidityEqual(actual: ValidityState, expected: ValidityState) {
+  const validityKeys = Object.keys(ValidityState.prototype) as (keyof ValidityState)[];
+  const validitySnapshot = Object.fromEntries(validityKeys.map((key) => [key, actual[key]]));
+
+  expect(validitySnapshot).toEqual(expected);
 }


### PR DESCRIPTION
**Related Issue:** #8126 

## Summary

This PR refactors `autocomplete`'s form association logic from the legacy form utilities to the `useForm` controller.

### Notes

* `validity` is now managed by the controller
  * default value is no longer needed
  * updated `defaults` test to reflect correct state (`valid` is true on initialization)
* updated `defaults` to handle `validity` props
* test type tidy up