### PR TITLE
fix(useSortable): fix DragDetail typings

### DIFF
--- a/packages/components/src/controllers/useSortable.ts
+++ b/packages/components/src/controllers/useSortable.ts
@@ -1,6 +1,6 @@
 import { LitElement } from "@arcgis/lumina";
 import { makeGenericController } from "@arcgis/lumina/controllers";
-import Sortable, { type SortableEvent } from "sortablejs";
+import Sortable from "sortablejs";
 
 const sortableComponentSet = new Set<SortableComponent>();
 
@@ -20,10 +20,12 @@ export interface DragDetail<
   To extends HTMLElement = HTMLElement,
   From extends HTMLElement = HTMLElement,
   Drag extends HTMLElement = HTMLElement,
-> extends Pick<SortableEvent, "newIndex" | "oldIndex"> {
+> {
   toEl: To;
   fromEl: From;
   dragEl: Drag;
+  newIndex: number;
+  oldIndex: number;
 }
 
 export const CSS = {


### PR DESCRIPTION
**Related Issue:** #

## Summary

This PR adjusts the `useSortable` controller’s public `DragDetail` type to avoid relying on `sortablejs`’s `SortableEvent` typings and to explicitly define the index fields used by Calcite’s drag callbacks.

**Changes:**
- Remove the `SortableEvent` type import from `sortablejs`.
- Update `DragDetail` to explicitly include `newIndex`/`oldIndex` as `number` fields rather than inheriting them from `SortableEvent`.

