### PR TITLE
refactor(time-picker): remove unnecessary whitespace handling

### DIFF
--- a/packages/components/src/components/time-picker/time-picker.browser.e2e.tsx
+++ b/packages/components/src/components/time-picker/time-picker.browser.e2e.tsx
@@ -111,9 +111,7 @@ describe("l10n", () => {
             // Esri i18n prefers this character be removed for short time formats, which is the only format currently that time-picker supports.
             // We're leaving this conditional check here in case a new locale is added in the future that might need to test the second suffix.
             // eslint-disable-next-line vitest/no-conditional-expect -- assertion depends on test config
-            await expect
-              .element(secondSuffixEl)
-              .toHaveTextContent(expectedLocalizedSecondSuffix.trim());
+            await expect.element(secondSuffixEl).toHaveTextContent(expectedLocalizedSecondSuffix);
           }
 
           await (localeHourFormat === "12"
@@ -185,9 +183,7 @@ describe("l10n", () => {
             // Esri i18n prefers this character be removed for short time formats, which is the only format currently that time-picker supports.
             // We're leaving this conditional check here in case a new locale is added in the future that might need to test the second suffix.
             // eslint-disable-next-line vitest/no-conditional-expect -- assertion depends on test config
-            await expect
-              .element(secondSuffixEl)
-              .toHaveTextContent(expectedLocalizedSecondSuffix.trim());
+            await expect.element(secondSuffixEl).toHaveTextContent(expectedLocalizedSecondSuffix);
           }
 
           await expect.element(meridiemEl).toHaveTextContent(expectedLocalizedMeridiem);

--- a/packages/components/src/components/time-picker/time-picker.browser.e2e.tsx
+++ b/packages/components/src/components/time-picker/time-picker.browser.e2e.tsx
@@ -111,7 +111,9 @@ describe("l10n", () => {
             // Esri i18n prefers this character be removed for short time formats, which is the only format currently that time-picker supports.
             // We're leaving this conditional check here in case a new locale is added in the future that might need to test the second suffix.
             // eslint-disable-next-line vitest/no-conditional-expect -- assertion depends on test config
-            await expect.element(secondSuffixEl).toHaveTextContent(expectedLocalizedSecondSuffix);
+            await expect
+              .element(secondSuffixEl)
+              .toHaveTextContent(expectedLocalizedSecondSuffix, { normalizeWhitespace: false });
           }
 
           await (localeHourFormat === "12"
@@ -183,7 +185,9 @@ describe("l10n", () => {
             // Esri i18n prefers this character be removed for short time formats, which is the only format currently that time-picker supports.
             // We're leaving this conditional check here in case a new locale is added in the future that might need to test the second suffix.
             // eslint-disable-next-line vitest/no-conditional-expect -- assertion depends on test config
-            await expect.element(secondSuffixEl).toHaveTextContent(expectedLocalizedSecondSuffix);
+            await expect
+              .element(secondSuffixEl)
+              .toHaveTextContent(expectedLocalizedSecondSuffix, { normalizeWhitespace: false });
           }
 
           await expect.element(meridiemEl).toHaveTextContent(expectedLocalizedMeridiem);

--- a/packages/components/src/components/time-picker/time-picker.tsx
+++ b/packages/components/src/components/time-picker/time-picker.tsx
@@ -596,7 +596,7 @@ export class TimePicker extends LitElement implements TimeComponent {
         )}
         {showSecondSuffix && (
           <span class={{ [CSS.delimiter]: true, [CSS.secondSuffix]: true }}>
-            {localizedSecondSuffix.trim()}
+            {localizedSecondSuffix}
           </span>
         )}
         {showMeridiem && (


### PR DESCRIPTION
**monday.com sync:** #12164338171

**Related Issue:** N/A

## Summary

Whitespace handling is no longer needed thanks to https://github.com/Esri/calcite-design-system/pull/13372/. 🎉