### PR TITLE
fix(tree): restore lines containment

### DIFF
--- a/packages/components/src/components/tree-item/tree-item.scss
+++ b/packages/components/src/components/tree-item/tree-item.scss
@@ -165,6 +165,7 @@
   opacity: 0;
   max-block-size: 0;
   overflow: hidden;
+  position: relative;
   transition:
     opacity var(--calcite-internal-animation-timing-slow) animation.$easing-function,
     max-block-size var(--calcite-internal-animation-timing-medium) animation.$easing-function;

--- a/packages/components/src/components/tree/tree.stories.ts
+++ b/packages/components/src/components/tree/tree.stories.ts
@@ -18,7 +18,6 @@ const allScaleTreeBuilder: Decorator = (itemsStory, context): string => {
       .tree-container {
         flex: 1;
         margin-right: 10px;
-        --calcite-color-border-2: chartreuse;
       }
       .container {
         display: flex;
@@ -141,7 +140,7 @@ export const selectionModeNone = (): string => html`${treeItems(true, true)}`;
 selectionModeNone.decorators = [allScaleTreeBuilder];
 selectionModeNone.args = { selectionMode: "none" };
 
-export const linesRTL = (): string => html`<div dir="rtl" style="--calcite-color-border-2: red">${treeItems()}</div>`;
+export const linesRTL = (): string => html`<div dir="rtl">${treeItems()}</div>`;
 linesRTL.decorators = [allScaleTreeBuilder];
 linesRTL.args = { lines: true, selectionMode: "single" };
 
@@ -214,7 +213,6 @@ export const OverflowingSubtree = (): string =>
       <calcite-tree>
         <calcite-tree-item label="test item" expanded id="two">
           Layer 2
-          <calcite-tree slot="children">
             <calcite-tree-item label="test item">
               <span class="title">Layer 2.1</span>
               <calcite-dropdown placement="bottom-trailing">
@@ -245,7 +243,3 @@ export const OverflowingSubtree = (): string =>
         }, 1000);
       });
     </script>`;
-
-export const themedLines = (): string => html`<div style="--calcite-color-border-2: red">${treeItems()}</div>`;
-themedLines.args = { lines: true, selectionMode: "single" };
-themedLines.decorators = [allScaleTreeBuilder];

--- a/packages/components/src/components/tree/tree.stories.ts
+++ b/packages/components/src/components/tree/tree.stories.ts
@@ -45,8 +45,6 @@ export default {
   parameters: {
     chromatic: {
       delay: 1000,
-      diffThreshold: 0,
-      diffIncludeAntiAliasing: true,
     },
   },
 };
@@ -142,7 +140,7 @@ export const selectionModeNone = (): string => html`${treeItems(true, true)}`;
 selectionModeNone.decorators = [allScaleTreeBuilder];
 selectionModeNone.args = { selectionMode: "none" };
 
-export const linesRTL = (): string => html`<div dir="rtl">${treeItems()}</div>`;
+export const linesRTL = (): string => html`<div dir="rtl" style="--calcite-color-border-2: red">${treeItems()}</div>`;
 linesRTL.decorators = [allScaleTreeBuilder];
 linesRTL.args = { lines: true, selectionMode: "single" };
 

--- a/packages/components/src/components/tree/tree.stories.ts
+++ b/packages/components/src/components/tree/tree.stories.ts
@@ -18,6 +18,7 @@ const allScaleTreeBuilder: Decorator = (itemsStory, context): string => {
       .tree-container {
         flex: 1;
         margin-right: 10px;
+        --calcite-color-border-2: chartreuse;
       }
       .container {
         display: flex;

--- a/packages/components/src/components/tree/tree.stories.ts
+++ b/packages/components/src/components/tree/tree.stories.ts
@@ -245,3 +245,7 @@ export const OverflowingSubtree = (): string =>
         }, 1000);
       });
     </script>`;
+
+export const themedLines = (): string => html`<div style="--calcite-color-border-2: red">${treeItems()}</div>`;
+themedLines.args = { lines: true, selectionMode: "single" };
+themedLines.decorators = [allScaleTreeBuilder];

--- a/packages/components/src/components/tree/tree.stories.ts
+++ b/packages/components/src/components/tree/tree.stories.ts
@@ -46,6 +46,7 @@ export default {
     chromatic: {
       delay: 1000,
       diffThreshold: 0,
+      diffIncludeAntiAliasing: true,
     },
   },
 };

--- a/packages/components/src/components/tree/tree.stories.ts
+++ b/packages/components/src/components/tree/tree.stories.ts
@@ -44,7 +44,7 @@ export default {
   title: "Components/Tree",
   parameters: {
     chromatic: {
-      delay: 1000,
+      delay: 5000,
       diffThreshold: 0.015,
     },
   },

--- a/packages/components/src/components/tree/tree.stories.ts
+++ b/packages/components/src/components/tree/tree.stories.ts
@@ -44,8 +44,8 @@ export default {
   title: "Components/Tree",
   parameters: {
     chromatic: {
-      delay: 5000,
-      diffThreshold: 0.015,
+      delay: 1000,
+      diffThreshold: 0,
     },
   },
 };

--- a/packages/components/src/components/tree/tree.stories.ts
+++ b/packages/components/src/components/tree/tree.stories.ts
@@ -45,6 +45,7 @@ export default {
   parameters: {
     chromatic: {
       delay: 1000,
+      diffThreshold: 0.63,
     },
   },
 };

--- a/packages/components/src/components/tree/tree.stories.ts
+++ b/packages/components/src/components/tree/tree.stories.ts
@@ -45,7 +45,7 @@ export default {
   parameters: {
     chromatic: {
       delay: 1000,
-      diffThreshold: 0.04,
+      diffThreshold: 0.015,
     },
   },
 };

--- a/packages/components/src/components/tree/tree.stories.ts
+++ b/packages/components/src/components/tree/tree.stories.ts
@@ -45,7 +45,7 @@ export default {
   parameters: {
     chromatic: {
       delay: 1000,
-      diffThreshold: 0.63,
+      diffThreshold: 0.063,
     },
   },
 };

--- a/packages/components/src/components/tree/tree.stories.ts
+++ b/packages/components/src/components/tree/tree.stories.ts
@@ -45,7 +45,7 @@ export default {
   parameters: {
     chromatic: {
       delay: 1000,
-      diffThreshold: 0.063,
+      diffThreshold: 0.04,
     },
   },
 };

--- a/packages/components/src/components/tree/tree.stories.ts
+++ b/packages/components/src/components/tree/tree.stories.ts
@@ -213,6 +213,7 @@ export const OverflowingSubtree = (): string =>
       <calcite-tree>
         <calcite-tree-item label="test item" expanded id="two">
           Layer 2
+          <calcite-tree slot="children">
             <calcite-tree-item label="test item">
               <span class="title">Layer 2.1</span>
               <calcite-dropdown placement="bottom-trailing">


### PR DESCRIPTION
**Related Issue:** #14187

## Summary

This fixes a regression introduced in https://github.com/Esri/calcite-design-system/pull/13712 that was likely missed due to https://github.com/Esri/calcite-design-system/pull/14000.

**Note**: existing tests provide coverage, so none were added/updated.