### PR TITLE
docs(dialog): specify that `modal` must be `true` for `outsideCloseDisabled` to work

### DIFF
--- a/packages/components/src/components/dialog/dialog.tsx
+++ b/packages/components/src/components/dialog/dialog.tsx
@@ -245,7 +245,7 @@ export class Dialog extends LitElement implements OpenCloseComponentWithEl {
     }
   }
 
-  /** When `true`, disables the closing of the component when clicked outside. */
+  /** When `true` and `modal` is `true`, disables the closing of the component when clicked outside. */
   @property({ reflect: true }) outsideCloseDisabled = false;
 
   /**


### PR DESCRIPTION
**Related Issue:** #14252

## Summary
Updates the `outsideClickDisabled` doc to specify that `modal` must be `true` for it to work. Better clarifies the story that Dialog does not automatically close on outside clicks unless `modal` is `true`.
