### PR TITLE
fix: only initialize `useSortable` if `dragEnabled` is `true`

### DIFF
--- a/packages/components/src/components/block-group/block-group.tsx
+++ b/packages/components/src/components/block-group/block-group.tsx
@@ -179,7 +179,7 @@ export class BlockGroup extends LitElement {
   override connectedCallback(): void {
     this.connectObserver();
     this.updateBlockItemsDebounced();
-    this.setUpSorting();
+    this.sortable.reset();
     this.setParentBlockGroup();
     this.cancelable.add(this.updateBlockItemsDebounced);
   }
@@ -243,7 +243,7 @@ export class BlockGroup extends LitElement {
       }
     });
 
-    this.setUpSorting();
+    this.sortable.reset();
   }
 
   private updateGroupItems(): void {
@@ -302,16 +302,6 @@ export class BlockGroup extends LitElement {
 
   private disconnectObserver(): void {
     this.mutationObserver?.disconnect();
-  }
-
-  private setUpSorting(): void {
-    const { dragEnabled } = this;
-
-    if (!dragEnabled) {
-      return;
-    }
-
-    this.sortable.reset();
   }
 
   onGlobalDragStart(): void {

--- a/packages/components/src/components/list/list.tsx
+++ b/packages/components/src/components/list/list.tsx
@@ -719,11 +719,7 @@ export class List extends LitElement {
   private setUpSorting(): void {
     const { dragEnabled, defaultSlotEl } = this;
 
-    if (!dragEnabled) {
-      return;
-    }
-
-    if (defaultSlotEl) {
+    if (dragEnabled && defaultSlotEl) {
       updateListItemChildren(defaultSlotEl);
     }
 

--- a/packages/components/src/controllers/useSortable.browser.spec.tsx
+++ b/packages/components/src/controllers/useSortable.browser.spec.tsx
@@ -1,0 +1,72 @@
+import { h, JsxNode, LitElement } from "@arcgis/lumina";
+import { mount } from "@arcgis/lumina-compiler/testing";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useSortable } from "./useSortable";
+
+const { createSpy, destroySpy } = vi.hoisted(() => ({
+  createSpy: vi.fn(),
+  destroySpy: vi.fn(),
+}));
+
+vi.mock("sortablejs", () => ({
+  default: {
+    create: createSpy.mockImplementation(() => ({ destroy: destroySpy })),
+  },
+}));
+
+describe("useSortable", () => {
+  class Test extends LitElement {
+    dragEnabled = false;
+    handleSelector = "calcite-sort-handle";
+    sortable = useSortable<this>()(this);
+
+    canPull(): boolean {
+      return true;
+    }
+
+    canPut(): boolean {
+      return true;
+    }
+
+    onGlobalDragStart(): void {}
+    onGlobalDragEnd(): void {}
+    onDragEnd(): void {}
+    onDragStart(): void {}
+    onDragSort(): void {}
+
+    override render(): JsxNode {
+      return <div />;
+    }
+  }
+
+  class DragEnabledTest extends Test {
+    override dragEnabled = true;
+  }
+
+  beforeEach(() => {
+    createSpy.mockClear();
+    destroySpy.mockClear();
+  });
+
+  it("does not create Sortable when dragEnabled is false", async () => {
+    await mount(Test);
+
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  it("creates Sortable when dragEnabled is true", async () => {
+    await mount(DragEnabledTest);
+
+    expect(createSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("destroys Sortable when dragEnabled becomes false and reset runs", async () => {
+    const { component } = await mount(DragEnabledTest);
+
+    component.dragEnabled = false;
+    component.sortable.reset();
+
+    expect(destroySpy).toHaveBeenCalledTimes(1);
+    expect(createSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/components/src/controllers/useSortable.browser.spec.tsx
+++ b/packages/components/src/controllers/useSortable.browser.spec.tsx
@@ -1,4 +1,5 @@
-import { LitElement } from "@arcgis/lumina";
+import { LitElement, property } from "@arcgis/lumina";
+import { html } from "lit";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useSortable } from "./useSortable";
@@ -16,9 +17,11 @@ vi.mock("sortablejs", () => ({
 
 describe("useSortable", () => {
   class Test extends LitElement {
-    dragEnabled = false;
+    static tagName = "sortable-test";
     handleSelector = "calcite-sort-handle";
     sortable = useSortable<this>()(this);
+
+    @property({ type: Boolean }) dragEnabled = false;
 
     canPull(): boolean {
       return true;
@@ -40,10 +43,10 @@ describe("useSortable", () => {
     destroySpy.mockClear();
   });
 
-  const setupDragEnabled = (el: Test["el"]) => {
-    el.dragEnabled = true;
-    el.sortable.reset();
-  };
+  const mountDragEnabled = () =>
+    mount(html`<sortable-test drag-enabled></sortable-test>`, {
+      dynamicComponents: [Test],
+    });
 
   it("does not create Sortable when dragEnabled is false", async () => {
     await mount(Test);
@@ -52,17 +55,13 @@ describe("useSortable", () => {
   });
 
   it("creates Sortable when dragEnabled is true", async () => {
-    await mount(Test, {
-      afterConnect: setupDragEnabled,
-    });
+    await mountDragEnabled();
 
     expect(createSpy).toHaveBeenCalledTimes(1);
   });
 
   it("destroys Sortable when dragEnabled becomes false and reset runs", async () => {
-    const { component } = await mount(Test, {
-      afterConnect: setupDragEnabled,
-    });
+    const { component } = await mountDragEnabled();
 
     component.dragEnabled = false;
     component.sortable.reset();

--- a/packages/components/src/controllers/useSortable.browser.spec.tsx
+++ b/packages/components/src/controllers/useSortable.browser.spec.tsx
@@ -1,4 +1,4 @@
-import { h, JsxNode, LitElement } from "@arcgis/lumina";
+import { LitElement } from "@arcgis/lumina";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useSortable } from "./useSortable";
@@ -33,20 +33,17 @@ describe("useSortable", () => {
     onDragEnd(): void {}
     onDragStart(): void {}
     onDragSort(): void {}
-
-    override render(): JsxNode {
-      return <div />;
-    }
-  }
-
-  class DragEnabledTest extends Test {
-    override dragEnabled = true;
   }
 
   beforeEach(() => {
     createSpy.mockClear();
     destroySpy.mockClear();
   });
+
+  const setupDragEnabled = (el: Test["el"]) => {
+    el.dragEnabled = true;
+    el.sortable.reset();
+  };
 
   it("does not create Sortable when dragEnabled is false", async () => {
     await mount(Test);
@@ -55,13 +52,17 @@ describe("useSortable", () => {
   });
 
   it("creates Sortable when dragEnabled is true", async () => {
-    await mount(DragEnabledTest);
+    await mount(Test, {
+      afterConnect: setupDragEnabled,
+    });
 
     expect(createSpy).toHaveBeenCalledTimes(1);
   });
 
   it("destroys Sortable when dragEnabled becomes false and reset runs", async () => {
-    const { component } = await mount(DragEnabledTest);
+    const { component } = await mount(Test, {
+      afterConnect: setupDragEnabled,
+    });
 
     component.dragEnabled = false;
     component.sortable.reset();

--- a/packages/components/src/controllers/useSortable.ts
+++ b/packages/components/src/controllers/useSortable.ts
@@ -186,12 +186,17 @@ export const useSortable = <T extends SortableComponent>(): ReturnType<
       return component.dragEnabled && globalDragState.active;
     }
 
-    async function setUpSortable(component: SortableComponent): Promise<void> {
+    function setUpSortable(component: SortableComponent): void {
       if (dragActive(component)) {
         return;
       }
 
       tearDownSortable(component);
+
+      if (!component.dragEnabled) {
+        return;
+      }
+
       sortableComponentSet.add(component);
       sortable = createSortable(component);
     }


### PR DESCRIPTION
**Related Issue:** #14259

## Summary

This PR refactors the `useSortable` `setUpSortable` function to always tear down before setting up, and crucially only set it up if the component's `dragEnabled` property is `true`.

Without this change, nested List Item instances and Lists inside Blocks are being initialized as Sortable containers regardless of their `dragEnabled` value, letting Sortable treat them as active drop targets and creating the `parentNode null` crash during drag-over.

Additionally, adds a Browser test for the `useSortable` controller. NOTE: this test is AI generated, I would appreciate a closer review.
