### PR TITLE
chore: improve custom mouse commands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -101,6 +101,7 @@
         "typescript-strict-plugin": "2.4.4",
         "vite": "7.3.2",
         "vite-plugin-dts": "4.5.4",
+        "vitest-browser-commands": "0.2.0",
         "yargs": "18.0.0"
       },
       "engines": {
@@ -15422,7 +15423,6 @@
       "integrity": "sha512-Tz23LR9T9jOGVZm2x1EPdXqwA37G/owYMxRwU0E4miurAtFsPMQ1d2Jc2okUaSjZqAFz2oEn3FLXC5a0a+siyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": ">=20.0.0",
         "@types/whatwg-mimetype": "^3.0.2",
@@ -29855,6 +29855,28 @@
         },
         "vite": {
           "optional": false
+        }
+      }
+    },
+    "node_modules/vitest-browser-commands": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/vitest-browser-commands/-/vitest-browser-commands-0.2.0.tgz",
+      "integrity": "sha512-BOPn+s4fm6Wah6aBkFmcmsAJ1GnDStBiPeFILt4ZYcEXxfnzua5FS1gBnXWe12U5YNnVjlhtEtIg4bPjknmdlg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ocavue"
+      },
+      "peerDependencies": {
+        "@vitest/browser-playwright": "^4.0.3",
+        "vitest": "^4.0.3"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "typescript-strict-plugin": "2.4.4",
     "vite": "7.3.2",
     "vite-plugin-dts": "4.5.4",
+    "vitest-browser-commands": "0.2.0",
     "yargs": "18.0.0"
   },
   "license": "SEE LICENSE.md",

--- a/packages/components/src/components/input-number/input-number.browser.e2e.tsx
+++ b/packages/components/src/components/input-number/input-number.browser.e2e.tsx
@@ -1,7 +1,8 @@
 import { h } from "@arcgis/lumina";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { commands, page, userEvent } from "vitest/browser";
+import { page, userEvent } from "vitest/browser";
 import { mount } from "@arcgis/lumina-compiler/testing";
+import { commands } from "../../tests/browser/commands";
 import {
   defaults,
   disabled,

--- a/packages/components/src/components/input/input.browser.e2e.tsx
+++ b/packages/components/src/components/input/input.browser.e2e.tsx
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { h } from "@arcgis/lumina";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { commands, page, userEvent } from "vitest/browser";
+import { page, userEvent } from "vitest/browser";
+import { commands } from "../../tests/browser/commands";
 import {
   defaults,
   disabled,

--- a/packages/components/src/components/sheet/sheet.browser.e2e.tsx
+++ b/packages/components/src/components/sheet/sheet.browser.e2e.tsx
@@ -155,9 +155,8 @@ describe("sheet updateSize public method", () => {
       const initialSize = 320;
       const overrideSize = 400;
 
-      const { sheet, content, resizeHandle, component } = await setupInlineSheet(initialSize);
-      resizeHandle.focus();
-      await userEvent.keyboard("{ArrowRight}");
+      const { sheet, content, component } = await setupInlineSheet(initialSize);
+      await userEvent.keyboard("{Tab}{ArrowRight}");
       expect(getComputedStyle(content).inlineSize).not.toBe(`${initialSize}px`);
 
       await sheet.updateSize({ inline: overrideSize });
@@ -174,14 +173,14 @@ describe("sheet updateSize public method", () => {
       const overrideSize = 400;
 
       const { sheet, content, resizeHandle, component } = await setupInlineSheet(initialSize);
-      await userEvent.click(resizeHandle);
-      const handleRect = resizeHandle.getBoundingClientRect();
 
       expect(getComputedStyle(content).inlineSize).toBe(`${initialSize}px`);
 
+      const handleRect = resizeHandle.getBoundingClientRect();
       const startX = handleRect.left + handleRect.width / 2;
       const startY = handleRect.top + handleRect.height / 2;
 
+      await userEvent.hover(resizeHandle);
       await commands.mouseDown();
       await commands.mouseMove(startX + 10, startY);
       await commands.mouseUp();
@@ -227,10 +226,9 @@ describe("sheet updateSize public method", () => {
       const initialSize = 200;
       const overrideSize = 250;
 
-      const { sheet, content, resizeHandle, component } = await setupBlockSheet(initialSize);
+      const { sheet, content, component } = await setupBlockSheet(initialSize);
 
-      resizeHandle.focus();
-      await userEvent.keyboard("{ArrowDown}");
+      await userEvent.keyboard("{Tab}{ArrowDown}");
       const blockSizeAfterKeyboard = parseFloat(getComputedStyle(content).blockSize);
       expect(blockSizeAfterKeyboard).not.toBe(initialSize);
 
@@ -248,16 +246,16 @@ describe("sheet updateSize public method", () => {
       const overrideSize = 250;
 
       const { sheet, content, resizeHandle, component } = await setupBlockSheet(initialSize);
-      await userEvent.click(resizeHandle);
-      const handleRect = resizeHandle.getBoundingClientRect();
 
       expect(getComputedStyle(content).blockSize).toBe(`${initialSize}px`);
 
+      const handleRect = resizeHandle.getBoundingClientRect();
       const startX = handleRect.left + handleRect.width / 2;
       const startY = handleRect.top + handleRect.height / 2;
 
+      await userEvent.hover(resizeHandle);
       await commands.mouseDown();
-      await commands.mouseMove(startX + 10, startY);
+      await commands.mouseMove(startX, startY + 10);
       await commands.mouseUp();
 
       expect(getComputedStyle(content).blockSize).not.toBe(`${initialSize}px`);

--- a/packages/components/src/components/sheet/sheet.browser.e2e.tsx
+++ b/packages/components/src/components/sheet/sheet.browser.e2e.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { commands, userEvent } from "vitest/browser";
+import { userEvent } from "vitest/browser";
 import { h } from "@arcgis/lumina";
 import { mount } from "@arcgis/lumina-compiler/testing";
+import { commands } from "../../tests/browser/commands";
 import {
   defaults,
   reflects,

--- a/packages/components/src/components/shell-panel/shell-panel.browser.e2e.tsx
+++ b/packages/components/src/components/shell-panel/shell-panel.browser.e2e.tsx
@@ -95,10 +95,9 @@ describe("shell-panel updateSize public method", () => {
       const initialSize = 320;
       const overrideSize = 400;
 
-      const { panel, content, handle, component } = await setupVerticalPanel(initialSize);
+      const { panel, content, component } = await setupVerticalPanel(initialSize);
 
-      handle.focus();
-      await userEvent.keyboard("{ArrowRight}");
+      await userEvent.keyboard("{Tab}{ArrowRight}");
       expect(getComputedStyle(content).inlineSize).not.toBe(initialSize);
 
       await panel.updateSize({ inline: overrideSize });
@@ -115,12 +114,12 @@ describe("shell-panel updateSize public method", () => {
       const overrideSize = 400;
 
       const { panel, content, handle, component } = await setupVerticalPanel(initialSize);
-
-      await userEvent.click(handle);
       const handleRect = handle.getBoundingClientRect();
+
+      await userEvent.hover(handle);
       await commands.mouseDown();
       await commands.mouseMove(
-        handleRect.left + handleRect.width / 2,
+        handleRect.left + handleRect.width / 2 + 10,
         handleRect.top + handleRect.height / 2,
       );
       await commands.mouseUp();
@@ -166,10 +165,9 @@ describe("shell-panel updateSize public method", () => {
       const initialSize = 200;
       const overrideSize = 250;
 
-      const { panel, content, handle, component } = await setupHorizontalPanel(initialSize);
+      const { panel, content, component } = await setupHorizontalPanel(initialSize);
 
-      handle.focus();
-      await userEvent.keyboard("{ArrowDown}");
+      await userEvent.keyboard("{Tab}{ArrowDown}");
       const afterKeyboard = parseFloat(getComputedStyle(content).blockSize);
       expect(afterKeyboard).not.toBe(initialSize);
 
@@ -187,12 +185,12 @@ describe("shell-panel updateSize public method", () => {
       const overrideSize = 250;
 
       const { panel, content, handle, component } = await setupHorizontalPanel(initialSize);
-
-      await userEvent.click(handle);
       const handleRect = handle.getBoundingClientRect();
+
+      await userEvent.hover(handle);
       await commands.mouseMove(
         handleRect.left + handleRect.width / 2,
-        handleRect.top + handleRect.height / 2,
+        handleRect.top + handleRect.height / 2 - 10,
       );
       await commands.mouseDown();
       await commands.mouseUp();

--- a/packages/components/src/components/shell-panel/shell-panel.browser.e2e.tsx
+++ b/packages/components/src/components/shell-panel/shell-panel.browser.e2e.tsx
@@ -1,7 +1,8 @@
 import { h } from "@arcgis/lumina";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import { it, expect, describe } from "vitest";
-import { commands, userEvent } from "vitest/browser";
+import { userEvent } from "vitest/browser";
+import { commands } from "../../tests/browser/commands";
 import { defaults, reflects, hidden, renders, slots, t9n } from "../../tests/commonTests/browser";
 import { mockConsole } from "../../tests/utils/logging";
 import { CSS } from "./resources";

--- a/packages/components/src/components/slider/slider.browser.e2e.tsx
+++ b/packages/components/src/components/slider/slider.browser.e2e.tsx
@@ -1,7 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import { h, JsxNode } from "@arcgis/lumina";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { commands, Locator, page, userEvent } from "vitest/browser";
+import { Locator, page, userEvent } from "vitest/browser";
+import { commands } from "../../tests/browser/commands";
 import {
   defaults,
   disabled,

--- a/packages/components/src/tests/browser/commands.ts
+++ b/packages/components/src/tests/browser/commands.ts
@@ -1,73 +1,7 @@
-import type { Plugin } from "vitest/config";
-import type { BrowserCommand } from "vitest/node";
-import type { Mouse } from "playwright";
+import { mouse } from "vitest-browser-commands/playwright";
 
-declare module "vitest/browser" {
-  interface BrowserCommands {
-    /**
-     * Moves the mouse to the specified coordinates.
-     */
-    mouseMove: (x: number, y: number, options?: Parameters<Mouse["move"]>[2]) => Promise<void>;
-
-    /**
-     * Presses the mouse button down.
-     */
-    mouseDown: (options?: Parameters<Mouse["down"]>[0]) => Promise<void>;
-
-    /**
-     * Releases the mouse button up.
-     */
-    mouseUp: (options?: Parameters<Mouse["up"]>[0]) => Promise<void>;
-  }
-}
-
-const mouseMove: BrowserCommand<[x: number, y: number, options?: Parameters<Mouse["move"]>[2]]> = async (
-  { page, provider },
-  x,
-  y,
-  options,
-) => {
-  if (provider.name === "playwright") {
-    await page.mouse.move(x, y, options);
-    return;
-  }
-
-  throw new Error(`provider ${provider.name} is not supported`);
+export const commands = {
+  mouseMove: mouse.move,
+  mouseDown: mouse.down,
+  mouseUp: mouse.up,
 };
-
-const mouseDown: BrowserCommand<[options?: Parameters<Mouse["down"]>[0]]> = async ({ page, provider }, options) => {
-  if (provider.name === "playwright") {
-    await page.mouse.down(options);
-    return;
-  }
-
-  throw new Error(`provider ${provider.name} is not supported`);
-};
-
-const mouseUp: BrowserCommand<[options?: Parameters<Mouse["up"]>[0]]> = async ({ page, provider }, options) => {
-  if (provider.name === "playwright") {
-    await page.mouse.up(options);
-    return;
-  }
-
-  throw new Error(`provider ${provider.name} is not supported`);
-};
-
-export default function BrowserCommands(): Plugin {
-  return {
-    name: "vitest:custom-commands",
-    config() {
-      return {
-        test: {
-          browser: {
-            commands: {
-              mouseMove,
-              mouseDown,
-              mouseUp,
-            },
-          },
-        },
-      };
-    },
-  };
-}

--- a/packages/components/vite.config.ts
+++ b/packages/components/vite.config.ts
@@ -7,10 +7,10 @@ import { defineConfig } from "vite";
 import { useLumina } from "@arcgis/lumina-compiler";
 import { defaultExclude } from "vitest/config";
 import { playwright } from "@vitest/browser-playwright";
+import { playwrightCommands as customBrowserModeCommandsPlugin } from "vitest-browser-commands";
 import removeTestDataAttr from "./build/transforms/remove-test-data-attributes";
 import { version } from "./package.json";
 import tailwindConfig from "./tailwind.config";
-import customBrowserModeCommands from "./src/tests/browser/commands";
 
 const nonEsmDependencies = ["interactjs"];
 const runBrowserTests = process.env.EXPERIMENTAL_TESTS === "true";
@@ -57,7 +57,7 @@ export default defineConfig({
     noExternal: nonEsmDependencies,
   },
 
-  plugins: [lumina, customBrowserModeCommands()],
+  plugins: [lumina, customBrowserModeCommandsPlugin()],
 
   css: {
     postcss: {


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

This improves custom browser mouse commands by using [`vitest-browser-commands`](https://github.com/ocavue/vitest-browser-commands/) (new dev dependency), which is more robust (e.g., properly maps coordinates used in mouse move operations). 

**Note:** The current `commands` module and its corresponding API was preserved to minimize changes, but we can revisit if needed.