### PR TITLE
fix(sheet, shell-panel): fix mouse resizing when direction is changed dynamically

### DIFF
--- a/packages/components/src/components/sheet/sheet.browser.e2e.tsx
+++ b/packages/components/src/components/sheet/sheet.browser.e2e.tsx
@@ -1,19 +1,21 @@
-import { describe, it, expect } from "vitest";
-import { userEvent } from "vitest/browser";
+import { describe, expect, it } from "vitest";
 import { h } from "@arcgis/lumina";
+import { userEvent } from "vitest/browser";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import { commands } from "../../tests/browser/commands";
 import {
   defaults,
-  reflects,
-  hidden,
-  renders,
   focusable,
-  topLayer,
+  hidden,
   openClose,
+  reflects,
+  renders,
+  topLayer,
 } from "../../tests/commonTests/browser";
 import { mockConsole } from "../../tests/utils/logging";
+import { Dir } from "../interfaces";
 import { CSS } from "./resources";
+import { Sheet } from "./sheet";
 
 mockConsole();
 
@@ -130,51 +132,104 @@ describe("renders", () => {
 describe("sheet updateSize public method", () => {
   mockConsole();
 
-  describe("inline (position inline-start)", () => {
-    async function setupInlineSheet(initialSize: number) {
-      const { el, component } = await mount<"calcite-shell">(
-        <calcite-shell>
-          <calcite-sheet embedded open position="inline-start" resizable>
-            <calcite-panel>Content</calcite-panel>
-          </calcite-sheet>
-        </calcite-shell>,
-      );
+  type Axis = "inline" | "block";
+  type TestCase = {
+    axis: Axis;
+    dir: Dir;
+    changeDirAfterMount: boolean;
+  };
 
-      const sheet = el.querySelector("calcite-sheet")!;
-      const content = sheet.shadowRoot!.querySelector<HTMLElement>(`.${CSS.content}`)!;
-      const resizeHandle = sheet.shadowRoot!.querySelector<HTMLElement>(`.${CSS.resizeHandle}`)!;
+  const testCases: TestCase[] = [
+    { axis: "inline", dir: "ltr", changeDirAfterMount: true },
+    { axis: "inline", dir: "ltr", changeDirAfterMount: false },
+    { axis: "inline", dir: "rtl", changeDirAfterMount: true },
+    { axis: "inline", dir: "rtl", changeDirAfterMount: false },
+    { axis: "block", dir: "ltr", changeDirAfterMount: true },
+    { axis: "block", dir: "ltr", changeDirAfterMount: false },
+    { axis: "block", dir: "rtl", changeDirAfterMount: true },
+    { axis: "block", dir: "rtl", changeDirAfterMount: false },
+  ] as const;
 
-      sheet.style.setProperty("--calcite-sheet-width", `${initialSize}px`);
+  async function setUpSheet({ axis, dir, changeDirAfterMount }: TestCase) {
+    const position = axis === "inline" ? "inline-start" : "block-start";
+    const sizeProp = axis === "inline" ? "inlineSize" : "blockSize";
+    const keyboardKey = axis === "inline" ? "{ArrowRight}" : "{ArrowDown}";
+    const mouseDelta = axis === "inline" ? { dx: 10, dy: 0 } : { dx: 0, dy: 10 };
+
+    const { el, component } = await mount<Sheet>(
+      <calcite-sheet
+        dir={changeDirAfterMount ? undefined : dir}
+        embedded
+        open
+        position={position}
+        resizable
+      >
+        <calcite-panel>Content</calcite-panel>
+      </calcite-sheet>,
+    );
+
+    if (changeDirAfterMount) {
+      el.dir = dir;
       await component.updateComplete;
-      expect(getComputedStyle(content).inlineSize).toBe(`${initialSize}px`);
-
-      return { sheet, content, resizeHandle, component };
     }
 
-    it("default size → token resize → KEYBOARD resize → method resize → clear method override", async () => {
-      const initialSize = 320;
-      const overrideSize = 400;
+    const content = el.shadowRoot.querySelector<HTMLElement>(`.${CSS.content}`)!;
+    const resizeHandle = el.shadowRoot.querySelector<HTMLElement>(`.${CSS.resizeHandle}`)!;
 
-      const { sheet, content, component } = await setupInlineSheet(initialSize);
-      await userEvent.keyboard("{Tab}{ArrowRight}");
-      expect(getComputedStyle(content).inlineSize).not.toBe(`${initialSize}px`);
+    return { sheet: el, content, resizeHandle, component, sizeProp, keyboardKey, mouseDelta };
+  }
 
-      await sheet.updateSize({ inline: overrideSize });
+  testCases.forEach(({ axis, dir, changeDirAfterMount }) => {
+    it(`default size → token resize → KEYBOARD resize → method resize → clear method override [axis=${axis}, dir=${dir}, changeDirAfterMount=${changeDirAfterMount}]`, async () => {
+      const initialSize = axis === "inline" ? 320 : 200;
+      const overrideSize = axis === "inline" ? 400 : 250;
+      const cssProp = axis === "inline" ? "--calcite-sheet-width" : "--calcite-sheet-height";
+      const { sheet, content, component, sizeProp, keyboardKey } = await setUpSheet({
+        axis,
+        dir,
+        changeDirAfterMount,
+      });
+
+      sheet.style.setProperty(cssProp, `${initialSize}px`);
       await component.updateComplete;
-      expect(getComputedStyle(content).inlineSize).toBe(`${overrideSize}px`);
+      expect(getComputedStyle(content)[sizeProp]).toBe(`${initialSize}px`);
 
-      await sheet.updateSize({ inline: null });
+      await userEvent.keyboard(`{Tab}${keyboardKey}`);
+      const afterUserResize = parseFloat(getComputedStyle(content)[sizeProp]);
+      expect(afterUserResize).not.toBe(initialSize);
+
+      if (dir === "rtl" && axis === "inline") {
+        // eslint-disable-next-line vitest/no-conditional-expect -- assertion depends on test options
+        expect(afterUserResize).toBeLessThan(initialSize);
+      } else {
+        // eslint-disable-next-line vitest/no-conditional-expect -- assertion depends on test options
+        expect(afterUserResize).toBeGreaterThan(initialSize);
+      }
+
+      await sheet.updateSize(
+        axis === "inline" ? { inline: overrideSize } : { block: overrideSize },
+      );
       await component.updateComplete;
-      expect(getComputedStyle(content).inlineSize).toBe(`${initialSize}px`);
+      expect(getComputedStyle(content)[sizeProp]).toBe(`${overrideSize}px`);
+
+      await sheet.updateSize(axis === "inline" ? { inline: null } : { block: null });
+      await component.updateComplete;
+      expect(getComputedStyle(content)[sizeProp]).toBe(`${initialSize}px`);
     });
 
-    it("default size → token resize → MOUSE resize → method resize → clear method override", async () => {
-      const initialSize = 320;
-      const overrideSize = 400;
+    it(`default size → token resize → MOUSE resize → method resize → clear method override [axis=${axis}, dir=${dir}, changeDirAfterMount=${changeDirAfterMount}]`, async () => {
+      const initialSize = axis === "inline" ? 320 : 200;
+      const overrideSize = axis === "inline" ? 400 : 250;
+      const cssProp = axis === "inline" ? "--calcite-sheet-width" : "--calcite-sheet-height";
+      const { sheet, content, resizeHandle, component, sizeProp, mouseDelta } = await setUpSheet({
+        axis,
+        dir,
+        changeDirAfterMount,
+      });
 
-      const { sheet, content, resizeHandle, component } = await setupInlineSheet(initialSize);
-
-      expect(getComputedStyle(content).inlineSize).toBe(`${initialSize}px`);
+      sheet.style.setProperty(cssProp, `${initialSize}px`);
+      await component.updateComplete;
+      expect(getComputedStyle(content)[sizeProp]).toBe(`${initialSize}px`);
 
       const handleRect = resizeHandle.getBoundingClientRect();
       const startX = handleRect.left + handleRect.width / 2;
@@ -182,91 +237,29 @@ describe("sheet updateSize public method", () => {
 
       await userEvent.hover(resizeHandle);
       await commands.mouseDown();
-      await commands.mouseMove(startX + 10, startY);
+      await commands.mouseMove(startX + mouseDelta.dx, startY + mouseDelta.dy);
       await commands.mouseUp();
 
-      expect(getComputedStyle(content).inlineSize).not.toBe(`${initialSize}px`);
+      const afterUserResize = parseFloat(getComputedStyle(content)[sizeProp]);
+      expect(afterUserResize).not.toBe(initialSize);
 
-      await sheet.updateSize({ inline: overrideSize });
-      await component.updateComplete;
-      expect(getComputedStyle(content).inlineSize).toBe(`${overrideSize}px`);
+      if (dir === "rtl" && axis === "inline") {
+        // eslint-disable-next-line vitest/no-conditional-expect -- assertion depends on test options
+        expect(afterUserResize).toBeLessThan(initialSize);
+      } else {
+        // eslint-disable-next-line vitest/no-conditional-expect -- assertion depends on test options
+        expect(afterUserResize).toBeGreaterThan(initialSize);
+      }
 
-      await sheet.updateSize({ inline: null });
-      await component.updateComplete;
-      expect(getComputedStyle(content).inlineSize).toBe(`${initialSize}px`);
-    });
-  });
-
-  describe("block (position block-start)", () => {
-    async function setupBlockSheet(initialSize: number) {
-      const { el, component } = await mount<"calcite-shell">(
-        <calcite-shell>
-          <calcite-sheet embedded open position="block-start" resizable>
-            <calcite-panel>Content</calcite-panel>
-          </calcite-sheet>
-        </calcite-shell>,
+      await sheet.updateSize(
+        axis === "inline" ? { inline: overrideSize } : { block: overrideSize },
       );
-
-      const sheet = el.querySelector("calcite-sheet")!;
-      expect(sheet).toBeTruthy();
-
-      const content = sheet.shadowRoot!.querySelector<HTMLElement>(`.${CSS.content}`)!;
-      const resizeHandle = sheet.shadowRoot!.querySelector<HTMLElement>(`.${CSS.resizeHandle}`)!;
-      expect(content).toBeTruthy();
-      expect(resizeHandle).toBeTruthy();
-
-      sheet.style.setProperty("--calcite-sheet-height", `${initialSize}px`);
       await component.updateComplete;
-      expect(getComputedStyle(content).blockSize).toBe(`${initialSize}px`);
+      expect(getComputedStyle(content)[sizeProp]).toBe(`${overrideSize}px`);
 
-      return { sheet, content, resizeHandle, component };
-    }
-
-    it("default size → token resize → KEYBOARD resize → method resize → clear method override", async () => {
-      const initialSize = 200;
-      const overrideSize = 250;
-
-      const { sheet, content, component } = await setupBlockSheet(initialSize);
-
-      await userEvent.keyboard("{Tab}{ArrowDown}");
-      const blockSizeAfterKeyboard = parseFloat(getComputedStyle(content).blockSize);
-      expect(blockSizeAfterKeyboard).not.toBe(initialSize);
-
-      await sheet.updateSize({ block: overrideSize });
+      await sheet.updateSize(axis === "inline" ? { inline: null } : { block: null });
       await component.updateComplete;
-      expect(getComputedStyle(content).blockSize).toBe(`${overrideSize}px`);
-
-      await sheet.updateSize({ block: null });
-      await component.updateComplete;
-      expect(getComputedStyle(content).blockSize).toBe(`${initialSize}px`);
-    });
-
-    it("default size → token resize → MOUSE resize → method resize → clear method override", async () => {
-      const initialSize = 200;
-      const overrideSize = 250;
-
-      const { sheet, content, resizeHandle, component } = await setupBlockSheet(initialSize);
-
-      expect(getComputedStyle(content).blockSize).toBe(`${initialSize}px`);
-
-      const handleRect = resizeHandle.getBoundingClientRect();
-      const startX = handleRect.left + handleRect.width / 2;
-      const startY = handleRect.top + handleRect.height / 2;
-
-      await userEvent.hover(resizeHandle);
-      await commands.mouseDown();
-      await commands.mouseMove(startX, startY + 10);
-      await commands.mouseUp();
-
-      expect(getComputedStyle(content).blockSize).not.toBe(`${initialSize}px`);
-
-      await sheet.updateSize({ block: overrideSize });
-      await component.updateComplete;
-      expect(getComputedStyle(content).blockSize).toBe(`${overrideSize}px`);
-
-      await sheet.updateSize({ block: null });
-      await component.updateComplete;
-      expect(getComputedStyle(content).blockSize).toBe(`${initialSize}px`);
+      expect(getComputedStyle(content)[sizeProp]).toBe(`${initialSize}px`);
     });
   });
 });

--- a/packages/components/src/components/sheet/sheet.tsx
+++ b/packages/components/src/components/sheet/sheet.tsx
@@ -55,7 +55,7 @@ export class Sheet extends LitElement {
 
   private contentRef = createRef<HTMLDivElement>();
 
-  private direction = useDirection();
+  direction = useDirection();
 
   focusTrap = useFocusTrap<this>({
     triggerProp: "open",
@@ -336,7 +336,8 @@ export class Sheet extends LitElement {
     if (
       (changes.has("open") && (this.hasUpdated || this.open !== false)) ||
       (changes.has("position") && (this.hasUpdated || this.position !== "inline-start")) ||
-      (changes.has("resizable") && (this.hasUpdated || this.resizable !== false))
+      (changes.has("resizable") && (this.hasUpdated || this.resizable !== false)) ||
+      changes.has("direction")
     ) {
       this.setupInteractions();
     }

--- a/packages/components/src/components/sheet/sheet.tsx
+++ b/packages/components/src/components/sheet/sheet.tsx
@@ -466,10 +466,6 @@ export class Sheet extends LitElement {
 
   private cleanupInteractions(): void {
     this.interaction?.unset();
-    this.updateSizeInternal({
-      inline: null,
-      block: null,
-    });
   }
 
   private async setupInteractions(): Promise<void> {

--- a/packages/components/src/components/shell-panel/shell-panel.browser.e2e.tsx
+++ b/packages/components/src/components/shell-panel/shell-panel.browser.e2e.tsx
@@ -6,7 +6,6 @@ import { commands } from "../../tests/browser/commands";
 import { defaults, reflects, hidden, renders, slots, t9n } from "../../tests/commonTests/browser";
 import { mockConsole } from "../../tests/utils/logging";
 import { Dir, Layout } from "../interfaces";
-import { afterNextTask } from "../../tests/utils/timing";
 import { CSS, SLOTS } from "./resources";
 
 mockConsole();
@@ -70,20 +69,81 @@ describe("translation support", () => {
 describe("shell-panel updateSize public method", () => {
   mockConsole();
 
-  async function setUpShellPanel({
-    layout,
-    initialSize,
-    dir,
-    changeDirAfterMount,
-  }: {
-    layout: Extract<Layout, "horizontal" | "vertical">;
-    initialSize: number;
+  type TestCase = {
+    layout: Layout;
     dir: Dir;
     changeDirAfterMount: boolean;
-  }) {
+    initialSize: number;
+    overrideSize: number;
+  };
+
+  const testCases: TestCase[] = [
+    {
+      layout: "vertical",
+      dir: "ltr",
+      changeDirAfterMount: true,
+      initialSize: 320,
+      overrideSize: 400,
+    },
+    {
+      layout: "vertical",
+      dir: "ltr",
+      changeDirAfterMount: false,
+      initialSize: 320,
+      overrideSize: 400,
+    },
+    {
+      layout: "vertical",
+      dir: "rtl",
+      changeDirAfterMount: true,
+      initialSize: 320,
+      overrideSize: 400,
+    },
+    {
+      layout: "vertical",
+      dir: "rtl",
+      changeDirAfterMount: false,
+      initialSize: 320,
+      overrideSize: 400,
+    },
+    {
+      layout: "horizontal",
+      dir: "ltr",
+      changeDirAfterMount: true,
+      initialSize: 200,
+      overrideSize: 250,
+    },
+    {
+      layout: "horizontal",
+      dir: "ltr",
+      changeDirAfterMount: false,
+      initialSize: 200,
+      overrideSize: 250,
+    },
+    {
+      layout: "horizontal",
+      dir: "rtl",
+      changeDirAfterMount: true,
+      initialSize: 200,
+      overrideSize: 250,
+    },
+    {
+      layout: "horizontal",
+      dir: "rtl",
+      changeDirAfterMount: false,
+      initialSize: 200,
+      overrideSize: 250,
+    },
+  ];
+
+  async function setUpShellPanel({
+    layout,
+    dir,
+    changeDirAfterMount,
+  }: Omit<TestCase, "initialSize" | "overrideSize">) {
     const dimensionCssProp =
       layout === "horizontal" ? "--calcite-shell-panel-height" : "--calcite-shell-panel-width";
-    const dimensionProp = layout === "horizontal" ? "block-size" : "inline-size";
+    const dimensionProp = layout === "horizontal" ? "blockSize" : "inlineSize";
     const shellPanelSlot = layout === "horizontal" ? "panel-bottom" : "panel-start";
 
     const { el, component } = await mount<"calcite-shell">(
@@ -97,7 +157,6 @@ describe("shell-panel updateSize public method", () => {
     if (changeDirAfterMount) {
       el.dir = dir;
       await component.updateComplete;
-      await afterNextTask();
     }
 
     const panel = el.querySelector("calcite-shell-panel")!;
@@ -108,153 +167,92 @@ describe("shell-panel updateSize public method", () => {
     expect(content).toBeTruthy();
     expect(handle).toBeTruthy();
 
-    panel.style.setProperty(dimensionCssProp, `${initialSize}px`);
-    await component.updateComplete;
-    expect(getComputedStyle(content)[dimensionProp]).toBe(`${initialSize}px`);
-
-    return { panel, content, handle, component };
+    return { panel, content, handle, component, dimensionProp, dimensionCssProp };
   }
 
-  const changeDirAfterMountsToTest = [true, false] as const;
+  testCases.forEach(({ layout, dir, changeDirAfterMount, initialSize, overrideSize }) => {
+    const axis = layout === "vertical" ? "inline" : "block";
+    const keyboardKey = layout === "vertical" ? "{ArrowRight}" : "{ArrowDown}";
+    const mouseDelta = layout === "vertical" ? { dx: 10, dy: 0 } : { dx: 0, dy: 10 };
+    const testLabel = `${layout} panel [dir=${dir}, changeDirAfterMount=${changeDirAfterMount}]`;
 
-  describe.for(["ltr", "rtl"] as const)("vertical panel", (dir) => {
-    changeDirAfterMountsToTest.forEach((changeDirAfterMount) => {
-      it(`should update vertical panel: default size → token resize → KEYBOARD resize → method resize → clear method override [dir=${dir}, changeDirAfterMount=${changeDirAfterMount}]`, async () => {
-        const initialSize = 320;
-        const overrideSize = 400;
-
-        const { panel, content, component } = await setUpShellPanel({
-          layout: "vertical",
-          initialSize,
-          dir,
-          changeDirAfterMount,
-        });
-
-        await userEvent.keyboard("{Tab}{ArrowRight}");
-        const afterKeyboard = parseFloat(getComputedStyle(content).inlineSize);
-        expect(afterKeyboard).not.toBe(initialSize);
-        expect(afterKeyboard).toBeGreaterThan(0);
-
-        if (dir === "ltr") {
-          // eslint-disable-next-line vitest/no-conditional-expect -- assertion depends on test options
-          expect(afterKeyboard).toBeGreaterThan(initialSize);
-        } else {
-          // eslint-disable-next-line vitest/no-conditional-expect -- assertion depends on test options
-          expect(afterKeyboard).toBeLessThan(initialSize);
-        }
-
-        await panel.updateSize({ inline: overrideSize });
-        await component.updateComplete;
-        expect(getComputedStyle(content).inlineSize).toBe(`${overrideSize}px`);
-
-        await panel.updateSize({ inline: null });
-        await component.updateComplete;
-        expect(getComputedStyle(content).inlineSize).toBe(`${initialSize}px`);
+    it(`default size → token resize → KEYBOARD resize → method resize → clear method override (${testLabel})`, async () => {
+      const { panel, content, component, dimensionProp, dimensionCssProp } = await setUpShellPanel({
+        layout,
+        dir,
+        changeDirAfterMount,
       });
 
-      it(`should update vertical panel: default size → token resize → MOUSE resize → method resize → clear method override [dir=${dir}, changeDirAfterMount=${changeDirAfterMount}]`, async () => {
-        const initialSize = 320;
-        const overrideSize = 400;
+      panel.style.setProperty(dimensionCssProp, `${initialSize}px`);
+      await component.updateComplete;
+      expect(getComputedStyle(content)[dimensionProp]).toBe(`${initialSize}px`);
 
-        const { panel, content, handle, component } = await setUpShellPanel({
-          layout: "vertical",
-          initialSize,
-          dir,
-          changeDirAfterMount,
-        });
+      await userEvent.keyboard(`{Tab}${keyboardKey}`);
+      const afterUserResize = parseFloat(getComputedStyle(content)[dimensionProp]);
+      expect(afterUserResize).not.toBe(initialSize);
+      expect(afterUserResize).toBeGreaterThan(0);
 
-        const handleRect = handle.getBoundingClientRect();
-        await userEvent.hover(handle);
-        await commands.mouseDown();
-        await commands.mouseMove(
-          handleRect.left + handleRect.width / 2 + 10,
-          handleRect.top + handleRect.height / 2,
-        );
-        await commands.mouseUp();
+      if (dir === "rtl" || layout === "horizontal") {
+        // eslint-disable-next-line vitest/no-conditional-expect -- assertion depends on test options
+        expect(afterUserResize).toBeLessThan(initialSize);
+      } else {
+        // eslint-disable-next-line vitest/no-conditional-expect -- assertion depends on test options
+        expect(afterUserResize).toBeGreaterThan(initialSize);
+      }
 
-        const afterMouse = parseFloat(getComputedStyle(content).inlineSize);
-        expect(afterMouse).not.toBe(initialSize);
-        expect(afterMouse).toBeGreaterThan(0);
+      await panel.updateSize(
+        axis === "inline" ? { inline: overrideSize } : { block: overrideSize },
+      );
+      await component.updateComplete;
+      expect(getComputedStyle(content)[dimensionProp]).toBe(`${overrideSize}px`);
 
-        if (dir === "ltr") {
-          // eslint-disable-next-line vitest/no-conditional-expect -- assertion depends on test options
-          expect(afterMouse).toBeGreaterThan(initialSize);
-        } else {
-          // eslint-disable-next-line vitest/no-conditional-expect -- assertion depends on test options
-          expect(afterMouse).toBeLessThan(initialSize);
-        }
-
-        await panel.updateSize({ inline: overrideSize });
-        await component.updateComplete;
-
-        expect(getComputedStyle(content).inlineSize).toBe(`${overrideSize}px`);
-        await panel.updateSize({ inline: null });
-        await component.updateComplete;
-        expect(getComputedStyle(content).inlineSize).toBe(`${initialSize}px`);
-      });
+      await panel.updateSize(axis === "inline" ? { inline: null } : { block: null });
+      await component.updateComplete;
+      expect(getComputedStyle(content)[dimensionProp]).toBe(`${initialSize}px`);
     });
-  });
 
-  describe.for(["ltr", "rtl"] as const)("horizontal panel", (dir) => {
-    changeDirAfterMountsToTest.forEach((changeDirAfterMount) => {
-      it(`should update horizontal panel: default size → token resize → KEYBOARD resize → method resize → clear method override [dir=${dir}, changeDirAfterMount=${changeDirAfterMount}]`, async () => {
-        const initialSize = 200;
-        const overrideSize = 250;
-
-        const { panel, content, component } = await setUpShellPanel({
-          layout: "horizontal",
-          initialSize,
+    it(`default size → token resize → MOUSE resize → method resize → clear method override (${testLabel})`, async () => {
+      const { panel, content, handle, component, dimensionProp, dimensionCssProp } =
+        await setUpShellPanel({
+          layout,
           dir,
           changeDirAfterMount,
         });
 
-        await userEvent.keyboard("{Tab}{ArrowDown}");
-        const afterKeyboard = parseFloat(getComputedStyle(content).blockSize);
-        expect(afterKeyboard).not.toBe(initialSize);
-        expect(afterKeyboard).toBeGreaterThan(0);
-        expect(afterKeyboard).toBeLessThan(initialSize);
+      panel.style.setProperty(dimensionCssProp, `${initialSize}px`);
+      await component.updateComplete;
+      expect(getComputedStyle(content)[dimensionProp]).toBe(`${initialSize}px`);
 
-        await panel.updateSize({ block: overrideSize });
-        await component.updateComplete;
-        expect(getComputedStyle(content).blockSize).toBe(`${overrideSize}px`);
+      const handleRect = handle.getBoundingClientRect();
+      const startX = handleRect.left + handleRect.width / 2 + mouseDelta.dx;
+      const startY = handleRect.top + handleRect.height / 2 + mouseDelta.dy;
 
-        await panel.updateSize({ block: null });
-        await component.updateComplete;
-        expect(getComputedStyle(content).blockSize).toBe(`${initialSize}px`);
-      });
+      await userEvent.hover(handle);
+      await commands.mouseDown();
+      await commands.mouseMove(startX, startY);
+      await commands.mouseUp();
 
-      it(`should update horizontal panel: default size → token resize → MOUSE resize → method resize → clear method override [dir=${dir}, changeDirAfterMount=${changeDirAfterMount}]`, async () => {
-        const initialSize = 200;
-        const overrideSize = 250;
+      const afterUserResize = parseFloat(getComputedStyle(content)[dimensionProp]);
+      expect(afterUserResize).not.toBe(initialSize);
+      expect(afterUserResize).toBeGreaterThan(0);
 
-        const { panel, content, handle, component } = await setUpShellPanel({
-          layout: "horizontal",
-          initialSize,
-          dir,
-          changeDirAfterMount,
-        });
+      if (dir === "rtl" || layout === "horizontal") {
+        // eslint-disable-next-line vitest/no-conditional-expect -- assertion depends on test options
+        expect(afterUserResize).toBeLessThan(initialSize);
+      } else {
+        // eslint-disable-next-line vitest/no-conditional-expect -- assertion depends on test options
+        expect(afterUserResize).toBeGreaterThan(initialSize);
+      }
 
-        const handleRect = handle.getBoundingClientRect();
-        await userEvent.hover(handle);
-        await commands.mouseDown();
-        await commands.mouseMove(
-          handleRect.left + handleRect.width / 2,
-          handleRect.top + handleRect.height / 2 - 10,
-        );
-        await commands.mouseUp();
+      await panel.updateSize(
+        axis === "inline" ? { inline: overrideSize } : { block: overrideSize },
+      );
+      await component.updateComplete;
+      expect(getComputedStyle(content)[dimensionProp]).toBe(`${overrideSize}px`);
 
-        const afterMouse = parseFloat(getComputedStyle(content).blockSize);
-        expect(afterMouse).not.toBe(initialSize);
-        expect(afterMouse).toBeGreaterThan(0);
-        expect(afterMouse).toBeGreaterThan(initialSize);
-
-        await panel.updateSize({ block: overrideSize });
-        await component.updateComplete;
-        expect(getComputedStyle(content).blockSize).toBe(`${overrideSize}px`);
-        await panel.updateSize({ block: null });
-        await component.updateComplete;
-        expect(getComputedStyle(content).blockSize).toBe(`${initialSize}px`);
-      });
+      await panel.updateSize(axis === "inline" ? { inline: null } : { block: null });
+      await component.updateComplete;
+      expect(getComputedStyle(content)[dimensionProp]).toBe(`${initialSize}px`);
     });
   });
 });

--- a/packages/components/src/components/shell-panel/shell-panel.browser.e2e.tsx
+++ b/packages/components/src/components/shell-panel/shell-panel.browser.e2e.tsx
@@ -1,11 +1,13 @@
-import { h } from "@arcgis/lumina";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { it, expect, describe } from "vitest";
-import { commands, userEvent } from "vitest/browser";
-import { defaults, reflects, hidden, renders, slots, t9n } from "../../tests/commonTests/browser";
+import { describe, expect, it } from "vitest";
+import { h } from "@arcgis/lumina";
+import { userEvent } from "vitest/browser";
+import { commands } from "../../tests/browser/commands";
+import { defaults, hidden, reflects, renders, slots, t9n } from "../../tests/commonTests/browser";
 import { mockConsole } from "../../tests/utils/logging";
-import { CSS } from "./resources";
-import { SLOTS } from "./resources";
+import { Dir, Layout } from "../interfaces";
+import { afterNextTask } from "../../tests/utils/timing";
+import { CSS, SLOTS } from "./resources";
 
 mockConsole();
 
@@ -68,142 +70,191 @@ describe("translation support", () => {
 describe("shell-panel updateSize public method", () => {
   mockConsole();
 
-  describe("vertical panel", () => {
-    async function setupVerticalPanel(initialToken: number) {
-      const { el, component } = await mount<"calcite-shell">(
-        <calcite-shell>
-          <calcite-shell-panel resizable slot="panel-start">
-            <calcite-panel>Content</calcite-panel>
-          </calcite-shell-panel>
-        </calcite-shell>,
-      );
+  async function setUpShellPanel({
+    layout,
+    initialSize,
+    dir,
+    changeDirAfterMount,
+  }: {
+    layout: Extract<Layout, "horizontal" | "vertical">;
+    initialSize: number;
+    dir: Dir;
+    changeDirAfterMount: boolean;
+  }) {
+    const dimensionCssProp =
+      layout === "horizontal" ? "--calcite-shell-panel-height" : "--calcite-shell-panel-width";
+    const dimensionProp = layout === "horizontal" ? "block-size" : "inline-size";
+    const shellPanelSlot = layout === "horizontal" ? "panel-bottom" : "panel-start";
 
-      const panel = el.querySelector("calcite-shell-panel")!;
+    const { el, component } = await mount<"calcite-shell">(
+      <calcite-shell dir={changeDirAfterMount ? undefined : dir}>
+        <calcite-shell-panel resizable slot={shellPanelSlot}>
+          <calcite-panel>Content</calcite-panel>
+        </calcite-shell-panel>
+      </calcite-shell>,
+    );
 
-      const content = panel.shadowRoot!.querySelector<HTMLElement>(`.${CSS.content}`)!;
-      const handle = panel.shadowRoot!.querySelector<HTMLElement>(`.${CSS.resizeHandle}`)!;
-
-      panel.style.setProperty("--calcite-shell-panel-width", `${initialToken}px`);
+    if (changeDirAfterMount) {
+      el.dir = dir;
       await component.updateComplete;
-      expect(getComputedStyle(content).inlineSize).toBe(`${initialToken}px`);
-
-      return { panel, content, handle, component };
+      await afterNextTask();
     }
 
-    it("should update vertical panel: default size → token resize → KEYBOARD resize → method resize → clear method override", async () => {
-      const initialSize = 320;
-      const overrideSize = 400;
+    const panel = el.querySelector("calcite-shell-panel")!;
+    expect(panel).toBeTruthy();
 
-      const { panel, content, handle, component } = await setupVerticalPanel(initialSize);
+    const content = panel.shadowRoot!.querySelector<HTMLElement>(`.${CSS.content}`)!;
+    const handle = panel.shadowRoot!.querySelector<HTMLElement>(`.${CSS.resizeHandle}`)!;
+    expect(content).toBeTruthy();
+    expect(handle).toBeTruthy();
 
-      handle.focus();
-      await userEvent.keyboard("{ArrowRight}");
-      expect(getComputedStyle(content).inlineSize).not.toBe(initialSize);
+    panel.style.setProperty(dimensionCssProp, `${initialSize}px`);
+    await component.updateComplete;
+    expect(getComputedStyle(content)[dimensionProp]).toBe(`${initialSize}px`);
 
-      await panel.updateSize({ inline: overrideSize });
-      await component.updateComplete;
-      expect(getComputedStyle(content).inlineSize).toBe(`${overrideSize}px`);
+    return { panel, content, handle, component };
+  }
 
-      await panel.updateSize({ inline: null });
-      await component.updateComplete;
-      expect(getComputedStyle(content).inlineSize).toBe(`${initialSize}px`);
-    });
+  const changeDirAfterMountsToTest = [true, false] as const;
 
-    it("should update vertical panel: default size → token resize → MOUSE resize → method resize → clear method override", async () => {
-      const initialSize = 320;
-      const overrideSize = 400;
+  describe.for(["ltr", "rtl"] as const)("vertical panel", (dir) => {
+    changeDirAfterMountsToTest.forEach((changeDirAfterMount) => {
+      it(`should update vertical panel: default size → token resize → KEYBOARD resize → method resize → clear method override [dir=${dir}, changeDirAfterMount=${changeDirAfterMount}]`, async () => {
+        const initialSize = 320;
+        const overrideSize = 400;
 
-      const { panel, content, handle, component } = await setupVerticalPanel(initialSize);
+        const { panel, content, component } = await setUpShellPanel({
+          layout: "vertical",
+          initialSize,
+          dir,
+          changeDirAfterMount,
+        });
 
-      await userEvent.click(handle);
-      const handleRect = handle.getBoundingClientRect();
-      await commands.mouseDown();
-      await commands.mouseMove(
-        handleRect.left + handleRect.width / 2,
-        handleRect.top + handleRect.height / 2,
-      );
-      await commands.mouseUp();
+        await userEvent.keyboard("{Tab}{ArrowRight}");
+        const afterKeyboard = parseFloat(getComputedStyle(content).inlineSize);
+        expect(afterKeyboard).not.toBe(initialSize);
+        expect(afterKeyboard).toBeGreaterThan(0);
 
-      expect(getComputedStyle(content).inlineSize).not.toBe(`${initialSize}px`);
+        if (dir === "ltr") {
+          // eslint-disable-next-line vitest/no-conditional-expect -- assertion depends on test options
+          expect(afterKeyboard).toBeGreaterThan(initialSize);
+        } else {
+          // eslint-disable-next-line vitest/no-conditional-expect -- assertion depends on test options
+          expect(afterKeyboard).toBeLessThan(initialSize);
+        }
 
-      await panel.updateSize({ inline: overrideSize });
-      await component.updateComplete;
+        await panel.updateSize({ inline: overrideSize });
+        await component.updateComplete;
+        expect(getComputedStyle(content).inlineSize).toBe(`${overrideSize}px`);
 
-      expect(getComputedStyle(content).inlineSize).toBe(`${overrideSize}px`);
-      await panel.updateSize({ inline: null });
-      await component.updateComplete;
-      expect(getComputedStyle(content).inlineSize).toBe(`${initialSize}px`);
+        await panel.updateSize({ inline: null });
+        await component.updateComplete;
+        expect(getComputedStyle(content).inlineSize).toBe(`${initialSize}px`);
+      });
+
+      it(`should update vertical panel: default size → token resize → MOUSE resize → method resize → clear method override [dir=${dir}, changeDirAfterMount=${changeDirAfterMount}]`, async () => {
+        const initialSize = 320;
+        const overrideSize = 400;
+
+        const { panel, content, handle, component } = await setUpShellPanel({
+          layout: "vertical",
+          initialSize,
+          dir,
+          changeDirAfterMount,
+        });
+
+        const handleRect = handle.getBoundingClientRect();
+        await userEvent.hover(handle);
+        await commands.mouseDown();
+        await commands.mouseMove(
+          handleRect.left + handleRect.width / 2 + 10,
+          handleRect.top + handleRect.height / 2,
+        );
+        await commands.mouseUp();
+
+        const afterMouse = parseFloat(getComputedStyle(content).inlineSize);
+        expect(afterMouse).not.toBe(initialSize);
+        expect(afterMouse).toBeGreaterThan(0);
+
+        if (dir === "ltr") {
+          // eslint-disable-next-line vitest/no-conditional-expect -- assertion depends on test options
+          expect(afterMouse).toBeGreaterThan(initialSize);
+        } else {
+          // eslint-disable-next-line vitest/no-conditional-expect -- assertion depends on test options
+          expect(afterMouse).toBeLessThan(initialSize);
+        }
+
+        await panel.updateSize({ inline: overrideSize });
+        await component.updateComplete;
+
+        expect(getComputedStyle(content).inlineSize).toBe(`${overrideSize}px`);
+        await panel.updateSize({ inline: null });
+        await component.updateComplete;
+        expect(getComputedStyle(content).inlineSize).toBe(`${initialSize}px`);
+      });
     });
   });
 
-  describe("horizontal panel", () => {
-    async function setupHorizontalPanel(initialSize: number) {
-      const { el, component } = await mount<"calcite-shell">(
-        <calcite-shell>
-          <calcite-shell-panel resizable slot="panel-bottom">
-            <calcite-panel>Content</calcite-panel>
-          </calcite-shell-panel>
-        </calcite-shell>,
-      );
+  describe.for(["ltr", "rtl"] as const)("horizontal panel", (dir) => {
+    changeDirAfterMountsToTest.forEach((changeDirAfterMount) => {
+      it(`should update horizontal panel: default size → token resize → KEYBOARD resize → method resize → clear method override [dir=${dir}, changeDirAfterMount=${changeDirAfterMount}]`, async () => {
+        const initialSize = 200;
+        const overrideSize = 250;
 
-      const panel = el.querySelector("calcite-shell-panel")!;
-      expect(panel).toBeTruthy();
+        const { panel, content, component } = await setUpShellPanel({
+          layout: "horizontal",
+          initialSize,
+          dir,
+          changeDirAfterMount,
+        });
 
-      const content = panel.shadowRoot!.querySelector<HTMLElement>(`.${CSS.content}`)!;
-      const handle = panel.shadowRoot!.querySelector<HTMLElement>(`.${CSS.resizeHandle}`)!;
-      expect(content).toBeTruthy();
-      expect(handle).toBeTruthy();
+        await userEvent.keyboard("{Tab}{ArrowDown}");
+        const afterKeyboard = parseFloat(getComputedStyle(content).blockSize);
+        expect(afterKeyboard).not.toBe(initialSize);
+        expect(afterKeyboard).toBeGreaterThan(0);
+        expect(afterKeyboard).toBeLessThan(initialSize);
 
-      panel.style.setProperty("--calcite-shell-panel-height", `${initialSize}px`);
-      await component.updateComplete;
-      expect(getComputedStyle(content).height).toBe(`${initialSize}px`);
+        await panel.updateSize({ block: overrideSize });
+        await component.updateComplete;
+        expect(getComputedStyle(content).blockSize).toBe(`${overrideSize}px`);
 
-      return { panel, content, handle, component };
-    }
+        await panel.updateSize({ block: null });
+        await component.updateComplete;
+        expect(getComputedStyle(content).blockSize).toBe(`${initialSize}px`);
+      });
 
-    it("should update horizontal panel: default size → token resize → KEYBOARD resize → method resize → clear method override", async () => {
-      const initialSize = 200;
-      const overrideSize = 250;
+      it(`should update horizontal panel: default size → token resize → MOUSE resize → method resize → clear method override [dir=${dir}, changeDirAfterMount=${changeDirAfterMount}]`, async () => {
+        const initialSize = 200;
+        const overrideSize = 250;
 
-      const { panel, content, handle, component } = await setupHorizontalPanel(initialSize);
+        const { panel, content, handle, component } = await setUpShellPanel({
+          layout: "horizontal",
+          initialSize,
+          dir,
+          changeDirAfterMount,
+        });
 
-      handle.focus();
-      await userEvent.keyboard("{ArrowDown}");
-      const afterKeyboard = parseFloat(getComputedStyle(content).blockSize);
-      expect(afterKeyboard).not.toBe(initialSize);
+        const handleRect = handle.getBoundingClientRect();
+        await userEvent.hover(handle);
+        await commands.mouseDown();
+        await commands.mouseMove(
+          handleRect.left + handleRect.width / 2,
+          handleRect.top + handleRect.height / 2 - 10,
+        );
+        await commands.mouseUp();
 
-      await panel.updateSize({ block: overrideSize });
-      await component.updateComplete;
-      expect(getComputedStyle(content).blockSize).toBe(`${overrideSize}px`);
+        const afterMouse = parseFloat(getComputedStyle(content).blockSize);
+        expect(afterMouse).not.toBe(initialSize);
+        expect(afterMouse).toBeGreaterThan(0);
+        expect(afterMouse).toBeGreaterThan(initialSize);
 
-      await panel.updateSize({ block: null });
-      await component.updateComplete;
-      expect(getComputedStyle(content).blockSize).toBe(`${initialSize}px`);
-    });
-
-    it("should update horizontal panel: default size → token resize → MOUSE resize → method resize → clear method override", async () => {
-      const initialSize = 200;
-      const overrideSize = 250;
-
-      const { panel, content, handle, component } = await setupHorizontalPanel(initialSize);
-
-      await userEvent.click(handle);
-      const handleRect = handle.getBoundingClientRect();
-      await commands.mouseMove(
-        handleRect.left + handleRect.width / 2,
-        handleRect.top + handleRect.height / 2,
-      );
-      await commands.mouseDown();
-      await commands.mouseUp();
-
-      expect(getComputedStyle(content).blockSize).not.toBe(initialSize);
-
-      await panel.updateSize({ block: overrideSize });
-      await component.updateComplete;
-      expect(getComputedStyle(content).blockSize).toBe(`${overrideSize}px`);
-      await panel.updateSize({ block: null });
-      await component.updateComplete;
-      expect(getComputedStyle(content).blockSize).toBe(`${initialSize}px`);
+        await panel.updateSize({ block: overrideSize });
+        await component.updateComplete;
+        expect(getComputedStyle(content).blockSize).toBe(`${overrideSize}px`);
+        await panel.updateSize({ block: null });
+        await component.updateComplete;
+        expect(getComputedStyle(content).blockSize).toBe(`${initialSize}px`);
+      });
     });
   });
 });

--- a/packages/components/src/components/shell-panel/shell-panel.tsx
+++ b/packages/components/src/components/shell-panel/shell-panel.tsx
@@ -44,7 +44,7 @@ export class ShellPanel extends LitElement {
 
   //#region Private Properties
 
-  private direction = useDirection();
+  direction = useDirection();
 
   private resizeHandleEl: HTMLDivElement;
 
@@ -192,12 +192,17 @@ export class ShellPanel extends LitElement {
     if (changes.has("layout") && (this.hasUpdated || this.layout !== "vertical")) {
       this.setActionBarsLayout(this.actionBars);
     }
+
     if (changes.has("collapsed") && this.hasUpdated) {
       if (this.collapsed) {
         this.calciteShellPanelCollapse.emit();
       } else {
         this.calciteShellPanelExpand.emit();
       }
+    }
+
+    if (changes.has("direction")) {
+      this.setupInteractions();
     }
   }
 


### PR DESCRIPTION
**Related Issue:** #13986

## Summary

This ensures that `interactjs` uses the current component direction when changed at runtime.

**Notes** 

* this also improves resizing tests
* `sheet` no longer resets the size when interactions are cleaned up