### PR TITLE
docs(button): clarify `alignment`'s reliance on `width`

### DIFF
--- a/packages/components/src/components/button/button.tsx
+++ b/packages/components/src/components/button/button.tsx
@@ -93,7 +93,7 @@ export class Button extends LitElement implements LabelableComponent {
 
   //#region Public Properties
 
-  /** Specifies the alignment of the component's elements. */
+  /** When `width` is not `"auto"`, specifies the alignment of the component's elements. */
   @property({ reflect: true }) alignment: ButtonAlignment = "center";
 
   /** Specifies the appearance style of the component. */


### PR DESCRIPTION
**Related Issue:** n/a

## Summary
Clarifies the doc string for `alignment`, specifying that the `width` property must not be set to `"auto"` in order to
work.
