### PR TITLE
test(input-time-picker): skip unstable test introduced in #13630

### DIFF
--- a/packages/components/src/components/input-time-picker/input-time-picker.browser.e2e.tsx
+++ b/packages/components/src/components/input-time-picker/input-time-picker.browser.e2e.tsx
@@ -55,7 +55,7 @@ describe("is focusable", () => {
   });
 });
 
-describe("openClose", () => {
+describe.skip("openClose", () => {
   openClose((mountOptions) => mount("calcite-input-time-picker", mountOptions));
 });
 


### PR DESCRIPTION
**Related Issue:** #13630

## Summary

This skips an unstable test introduced in #13630 that is causing `next` deployments to fail.
