### PR TITLE
ci(actions): support documentation site Monday.com syncing

### DIFF
--- a/.github/actions/monday/action.yml
+++ b/.github/actions/monday/action.yml
@@ -1,0 +1,137 @@
+name: Sync Issue to Monday.com
+description: Syncs a new issue or specific issue changes to Monday.com tasks.
+
+inputs:
+  monday_key:
+    description: The API key for Monday.com (set as a secret in the repository)
+    required: true
+  monday_board:
+    description: The ID of the Monday.com board to sync with (set as a secret in the repository)
+    required: true
+  username_map:
+    description: JSON string mapping public GH usernames to Devtopia usernames
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: "Create Task"
+      if: github.event.action == 'opened' ||
+        (github.event.action == 'labeled' && github.event.label.name == 'monday.com sync')
+      uses: actions/github-script@v7
+      env:
+        MONDAY_KEY: ${{ inputs.monday_key }}
+        MONDAY_BOARD: ${{ inputs.monday_board }}
+        USERNAME_MAP: ${{ inputs.username_map }}
+        GITHUB_REPO: ${{ github.event.repository.name }}
+      with:
+        script: |
+          core.startGroup("Create Task");
+          const action = require('${{ github.action_path }}/../../scripts/monday/createTask.js')
+          await action({github, context, core})
+          core.endGroup();
+
+    - name: "Update Label on Task"
+      if: github.event.action == 'labeled' && github.event.label.name != 'monday.com sync'
+      uses: actions/github-script@v7
+      env:
+        MONDAY_KEY: ${{ inputs.monday_key }}
+        MONDAY_BOARD: ${{ inputs.monday_board }}
+        USERNAME_MAP: ${{ inputs.username_map }}
+        GITHUB_REPO: ${{ github.event.repository.name }}
+      with:
+        script: |
+          core.startGroup("Update Label on Task");
+          const action = require('${{ github.action_path }}/../../scripts/monday/updateLabels.js')
+          await action({github, context, core})
+          core.endGroup();
+
+    - name: "Remove Label from Task"
+      if: github.event.action == 'unlabeled'
+      uses: actions/github-script@v7
+      env:
+        MONDAY_KEY: ${{ inputs.monday_key }}
+        MONDAY_BOARD: ${{ inputs.monday_board }}
+        USERNAME_MAP: ${{ inputs.username_map }}
+        GITHUB_REPO: ${{ github.event.repository.name }}
+      with:
+        script: |
+          core.startGroup("Remove Label from Task");
+          const action = require('${{ github.action_path }}/../../scripts/monday/removeLabel.js')
+          await action({github, context, core})
+          core.endGroup();
+
+    - name: "Update Milestone"
+      if: github.event.action == 'milestoned' || github.event.action == 'demilestoned'
+      uses: actions/github-script@v7
+      env:
+        MONDAY_KEY: ${{ inputs.monday_key }}
+        MONDAY_BOARD: ${{ inputs.monday_board }}
+        USERNAME_MAP: ${{ inputs.username_map }}
+        GITHUB_REPO: ${{ github.event.repository.name }}
+      with:
+        script: |
+          core.startGroup("Update Milestone");
+          const action = require('${{ github.action_path }}/../../scripts/monday/updateMilestone.js')
+          await action({github, context, core})
+          core.endGroup();
+
+    - name: "Update Task Title"
+      if: github.event.action == 'edited'
+      uses: actions/github-script@v7
+      env:
+        MONDAY_KEY: ${{ inputs.monday_key }}
+        MONDAY_BOARD: ${{ inputs.monday_board }}
+        USERNAME_MAP: ${{ inputs.username_map }}
+        GITHUB_REPO: ${{ github.event.repository.name }}
+      with:
+        script: |
+          core.startGroup("Update Task Title");
+          const action = require('${{ github.action_path }}/../../scripts/monday/updateTitle.js')
+          await action({github, context, core})
+          core.endGroup();
+
+    - name: "Update Task Assignee"
+      if: github.event.action == 'assigned' || github.event.action == 'unassigned'
+      uses: actions/github-script@v7
+      env:
+        MONDAY_KEY: ${{ inputs.monday_key }}
+        MONDAY_BOARD: ${{ inputs.monday_board }}
+        USERNAME_MAP: ${{ inputs.username_map }}
+        GITHUB_REPO: ${{ github.event.repository.name }}
+      with:
+        script: |
+          core.startGroup("Update Task Assignee");
+          const action = require('${{ github.action_path }}/../../scripts/monday/updateAssignee.js')
+          await action({github, context, core})
+          core.endGroup();
+
+    - name: "Update Task Status"
+      if: github.event.action == 'closed' || github.event.action == 'reopened'
+      uses: actions/github-script@v7
+      env:
+        MONDAY_KEY: ${{ inputs.monday_key }}
+        MONDAY_BOARD: ${{ inputs.monday_board }}
+        USERNAME_MAP: ${{ inputs.username_map }}
+        GITHUB_REPO: ${{ github.event.repository.name }}
+      with:
+        script: |
+          core.startGroup("Update Task Status");
+          const action = require('${{ github.action_path }}/../../scripts/monday/updateState.js')
+          await action({github, context, core})
+          core.endGroup();
+
+    - name: "Sync Action Changes"
+      if: github.event.inputs.event_type == 'SyncActionChanges'
+      uses: actions/github-script@v7
+      env:
+        MONDAY_KEY: ${{ inputs.monday_key }}
+        MONDAY_BOARD: ${{ inputs.monday_board }}
+        USERNAME_MAP: ${{ inputs.username_map }}
+        GITHUB_REPO: ${{ github.event.repository.name }}
+      with:
+        script: |
+          core.startGroup("Sync Action Changes");
+          const action = require('${{ github.action_path }}/../../scripts/monday/syncActionChanges.js')
+          await action({github, context, core})
+          core.endGroup();

--- a/.github/actions/monday/action.yml
+++ b/.github/actions/monday/action.yml
@@ -18,7 +18,7 @@ runs:
     - name: "Create Task"
       if: github.event.action == 'opened' ||
         (github.event.action == 'labeled' && github.event.label.name == 'monday.com sync')
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       env:
         MONDAY_KEY: ${{ inputs.monday_key }}
         MONDAY_BOARD: ${{ inputs.monday_board }}
@@ -33,7 +33,7 @@ runs:
 
     - name: "Update Label on Task"
       if: github.event.action == 'labeled' && github.event.label.name != 'monday.com sync'
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       env:
         MONDAY_KEY: ${{ inputs.monday_key }}
         MONDAY_BOARD: ${{ inputs.monday_board }}
@@ -48,7 +48,7 @@ runs:
 
     - name: "Remove Label from Task"
       if: github.event.action == 'unlabeled'
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       env:
         MONDAY_KEY: ${{ inputs.monday_key }}
         MONDAY_BOARD: ${{ inputs.monday_board }}
@@ -63,7 +63,7 @@ runs:
 
     - name: "Update Milestone"
       if: github.event.action == 'milestoned' || github.event.action == 'demilestoned'
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       env:
         MONDAY_KEY: ${{ inputs.monday_key }}
         MONDAY_BOARD: ${{ inputs.monday_board }}
@@ -78,7 +78,7 @@ runs:
 
     - name: "Update Task Title"
       if: github.event.action == 'edited'
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       env:
         MONDAY_KEY: ${{ inputs.monday_key }}
         MONDAY_BOARD: ${{ inputs.monday_board }}
@@ -93,7 +93,7 @@ runs:
 
     - name: "Update Task Assignee"
       if: github.event.action == 'assigned' || github.event.action == 'unassigned'
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       env:
         MONDAY_KEY: ${{ inputs.monday_key }}
         MONDAY_BOARD: ${{ inputs.monday_board }}
@@ -108,7 +108,7 @@ runs:
 
     - name: "Update Task Status"
       if: github.event.action == 'closed' || github.event.action == 'reopened'
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       env:
         MONDAY_KEY: ${{ inputs.monday_key }}
         MONDAY_BOARD: ${{ inputs.monday_board }}
@@ -123,7 +123,7 @@ runs:
 
     - name: "Sync Action Changes"
       if: github.event.inputs.event_type == 'SyncActionChanges'
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       env:
         MONDAY_KEY: ${{ inputs.monday_key }}
         MONDAY_BOARD: ${{ inputs.monday_board }}

--- a/.github/actions/monday/action.yml
+++ b/.github/actions/monday/action.yml
@@ -18,7 +18,7 @@ runs:
     - name: "Create Task"
       if: github.event.action == 'opened' ||
         (github.event.action == 'labeled' && github.event.label.name == 'monday.com sync')
-      uses: actions/github-script@v8
+      uses: actions/github-script@v9
       env:
         MONDAY_KEY: ${{ inputs.monday_key }}
         MONDAY_BOARD: ${{ inputs.monday_board }}
@@ -33,7 +33,7 @@ runs:
 
     - name: "Update Label on Task"
       if: github.event.action == 'labeled' && github.event.label.name != 'monday.com sync'
-      uses: actions/github-script@v8
+      uses: actions/github-script@v9
       env:
         MONDAY_KEY: ${{ inputs.monday_key }}
         MONDAY_BOARD: ${{ inputs.monday_board }}
@@ -48,7 +48,7 @@ runs:
 
     - name: "Remove Label from Task"
       if: github.event.action == 'unlabeled'
-      uses: actions/github-script@v8
+      uses: actions/github-script@v9
       env:
         MONDAY_KEY: ${{ inputs.monday_key }}
         MONDAY_BOARD: ${{ inputs.monday_board }}
@@ -63,7 +63,7 @@ runs:
 
     - name: "Update Milestone"
       if: github.event.action == 'milestoned' || github.event.action == 'demilestoned'
-      uses: actions/github-script@v8
+      uses: actions/github-script@v9
       env:
         MONDAY_KEY: ${{ inputs.monday_key }}
         MONDAY_BOARD: ${{ inputs.monday_board }}
@@ -78,7 +78,7 @@ runs:
 
     - name: "Update Task Title"
       if: github.event.action == 'edited'
-      uses: actions/github-script@v8
+      uses: actions/github-script@v9
       env:
         MONDAY_KEY: ${{ inputs.monday_key }}
         MONDAY_BOARD: ${{ inputs.monday_board }}
@@ -93,7 +93,7 @@ runs:
 
     - name: "Update Task Assignee"
       if: github.event.action == 'assigned' || github.event.action == 'unassigned'
-      uses: actions/github-script@v8
+      uses: actions/github-script@v9
       env:
         MONDAY_KEY: ${{ inputs.monday_key }}
         MONDAY_BOARD: ${{ inputs.monday_board }}
@@ -108,7 +108,7 @@ runs:
 
     - name: "Update Task Status"
       if: github.event.action == 'closed' || github.event.action == 'reopened'
-      uses: actions/github-script@v8
+      uses: actions/github-script@v9
       env:
         MONDAY_KEY: ${{ inputs.monday_key }}
         MONDAY_BOARD: ${{ inputs.monday_board }}
@@ -123,7 +123,7 @@ runs:
 
     - name: "Sync Action Changes"
       if: github.event.inputs.event_type == 'SyncActionChanges'
-      uses: actions/github-script@v8
+      uses: actions/github-script@v9
       env:
         MONDAY_KEY: ${{ inputs.monday_key }}
         MONDAY_BOARD: ${{ inputs.monday_board }}

--- a/.github/scripts/support/monday.js
+++ b/.github/scripts/support/monday.js
@@ -338,6 +338,14 @@ module.exports = function Monday(issue, core, updateIssueBody) {
       },
     ],
     [
+      issueType.themeUpdate,
+      {
+        column: mondayColumns.typeDropdown,
+        value: "Theme Update",
+        clearable: true,
+      },
+    ],
+    [
       priority.low,
       {
         column: mondayColumns.priority,

--- a/.github/scripts/support/monday.js
+++ b/.github/scripts/support/monday.js
@@ -5,18 +5,8 @@ const {
   packages,
 } = require("./resources");
 const { includesLabel, notInLifecycle } = require("./utils");
-
-/**
- * @param {NodeJS.ProcessEnv} env
- * @param {import('@actions/core')} core
- * @returns {asserts env is NodeJS.ProcessEnv & { MONDAY_KEY: string; MONDAY_BOARD: string }}
- */
-function assertMondayEnv(env, core) {
-  if (!env.MONDAY_KEY || !env.MONDAY_BOARD) {
-    core.setFailed("A Monday.com env variable is not set.");
-    process.exit(1);
-  }
-}
+const REPO_CALCITE = "calcite-design-system";
+const REPO_DOCS = "calcite-documentation";
 
 /**
  * @param {import('@octokit/webhooks-types').Issue} issue - The GitHub issue object
@@ -24,14 +14,35 @@ function assertMondayEnv(env, core) {
  * @param {import('./utils').UpdateBodyCallback} updateIssueBody - A callback to update the Issue body with correct context
  */
 module.exports = function Monday(issue, core, updateIssueBody) {
-  assertMondayEnv(process.env, core);
-  const { MONDAY_KEY, MONDAY_BOARD } = process.env;
-  if (!issue) {
-    core.setFailed("No GitHub issue provided.");
+  /**
+   * Declare the workflow as failed and exit the process.
+   * @param {string} message - The failure message to report
+   */
+  function failWorkflow(message) {
+    core.setFailed(message);
     process.exit(1);
+  }
+  
+  /**
+   * @param {NodeJS.ProcessEnv} env
+   * @returns {asserts env is NodeJS.ProcessEnv & { MONDAY_KEY: string; MONDAY_BOARD: string; GITHUB_REPO: typeof REPO_CALCITE | typeof REPO_DOCS; }}
+   */
+  function assertMondayEnv(env) {
+    if (!env.MONDAY_KEY || !env.MONDAY_BOARD || (env.GITHUB_REPO !== REPO_CALCITE && env.GITHUB_REPO !== REPO_DOCS)) {
+      failWorkflow("A Monday.com env variable is not set.");
+    }
+  }
+  
+  assertMondayEnv(process.env);
+  const { MONDAY_KEY, MONDAY_BOARD, GITHUB_REPO } = process.env;
+  if (!issue) {
+    failWorkflow("No GitHub issue provided.");
   }
 
   const { title, body, number: issueNumber, milestone: issueMilestone, labels, assignee, assignees, html_url } = issue;
+  
+  /** @type {Record<string, string> | null} - The username mapping for the Doc repo, if provided and parsed **/
+  let usernameMap = null;
 
   /** @type {boolean} - Whether to create new column values in Monday.com if they do not exist */
   let createLabelsIfMissing = false;
@@ -42,6 +53,49 @@ module.exports = function Monday(issue, core, updateIssueBody) {
    */
   /** @type {Record<string, ColumnValue>} */
   let columnUpdates = {};
+  
+  /**
+   * Parse the USERNAME_MAP environment variable as JSON and validate its structure.
+   * Fails the workflow if JSON is missing or invalid.
+   * @returns {Record<string, string>} The parsed username map object
+   */
+  function parseUsernameJSON() {
+    let parsed;
+    try {
+      parsed = JSON.parse(process.env.USERNAME_MAP || "{}");
+    } catch (error) {
+      failWorkflow(`Invalid Username JSON Map: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  
+    if (typeof parsed !== "object" || parsed === null) {
+      failWorkflow(`Username Map must be a non-null object`);
+    }
+  
+    for (const [key, value] of Object.entries(parsed)) {
+      if (typeof value !== "string") {
+        throw new Error(`Value for key "${key}" must be a string`);
+      }
+    }
+  
+    return parsed;
+  }
+  
+  /**
+   * Return the appropriate username based on repository context and username mapping values.
+   * @param {string} publicUsername - The public GitHub username to map
+   * @return {string}
+   */
+  function getUsername(publicUsername) {
+    if (GITHUB_REPO === REPO_CALCITE) {
+      return publicUsername;
+    }
+    
+    if (!usernameMap) {
+      usernameMap = parseUsernameJSON();
+    }
+    
+    return usernameMap[publicUsername] || publicUsername;
+  }
 
   /** @typedef {object} MondayColumn
    * @property {string} id - The Monday.com column ID
@@ -421,24 +475,24 @@ module.exports = function Monday(issue, core, updateIssueBody) {
   /** @type {Map<string, MondayPerson>} */
   const peopleMap = new Map([
     /* eslint-disable @cspell/spellchecker -- GitHub usernames */
-    ["anveshmekala", { role: mondayColumns.developers, id: 48387134 }],
-    ["aPreciado88", { role: mondayColumns.developers, id: 60795249 }],
-    ["ashetland", { role: mondayColumns.designers, id: 45851619 }],
-    ["brendan-vincent-rice", { role: mondayColumns.developers, id: 96903694 }],
-    ["chezHarper", { role: mondayColumns.designers, id: 71157966 }],
-    ["DintaMel", { role: mondayColumns.productEngineers, id: 92955697 }],
-    ["DitwanP", { role: mondayColumns.productEngineers, id: 53683093 }],
-    ["driskull", { role: mondayColumns.developers, id: 45944985 }],
-    ["Elijbet", { role: mondayColumns.developers, id: 55852207 }],
-    ["eriklharper", { role: mondayColumns.developers, id: 49699973 }],
-    ["geospatialem", { role: mondayColumns.productEngineers, id: 45853373 }],
-    ["isaacbraun", { role: mondayColumns.productEngineers, id: 76547859 }],
-    ["jcfranco", { role: mondayColumns.developers, id: 45854945 }],
-    ["macandcheese", { role: mondayColumns.developers, id: 45854918 }],
-    ["matgalla", { role: mondayColumns.designers, id: 69473378 }],
-    ["rmstinson", { role: mondayColumns.designers, id: 47277636 }],
-    ["SkyeSeitz", { role: mondayColumns.designers, id: 45854937 }],
-    ["Amretasre002762670", { role: mondayColumns.developers, id: 77031889 }],
+    [getUsername("anveshmekala"), { role: mondayColumns.developers, id: 48387134 }],
+    [getUsername("aPreciado88"), { role: mondayColumns.developers, id: 60795249 }],
+    [getUsername("ashetland"), { role: mondayColumns.designers, id: 45851619 }],
+    [getUsername("brendan-vincent-rice"), { role: mondayColumns.developers, id: 96903694 }],
+    [getUsername("chezHarper"), { role: mondayColumns.designers, id: 71157966 }],
+    [getUsername("DintaMel"), { role: mondayColumns.productEngineers, id: 92955697 }],
+    [getUsername("DitwanP"), { role: mondayColumns.productEngineers, id: 53683093 }],
+    [getUsername("driskull"), { role: mondayColumns.developers, id: 45944985 }],
+    [getUsername("Elijbet"), { role: mondayColumns.developers, id: 55852207 }],
+    [getUsername("eriklharper"), { role: mondayColumns.developers, id: 49699973 }],
+    [getUsername("geospatialem"), { role: mondayColumns.productEngineers, id: 45853373 }],
+    [getUsername("isaacbraun"), { role: mondayColumns.productEngineers, id: 76547859 }],
+    [getUsername("jcfranco"), { role: mondayColumns.developers, id: 45854945 }],
+    [getUsername("macandcheese"), { role: mondayColumns.developers, id: 45854918 }],
+    [getUsername("matgalla"), { role: mondayColumns.designers, id: 69473378 }],
+    [getUsername("rmstinson"), { role: mondayColumns.designers, id: 47277636 }],
+    [getUsername("SkyeSeitz"), { role: mondayColumns.designers, id: 45854937 }],
+    [getUsername("Amretasre002762670"), { role: mondayColumns.developers, id: 77031889 }],
     /* eslint-enable @cspell/spellchecker */
   ]);
 

--- a/.github/scripts/support/resources.js
+++ b/.github/scripts/support/resources.js
@@ -21,6 +21,7 @@ const resources = {
       research: "research",
       test: "testing",
       tooling: "tooling",
+      themeUpdate: "Theme Update",
     },
     issueWorkflow: {
       needsTriage: "needs triage",

--- a/.github/workflows/issue-monday-sync.yml
+++ b/.github/workflows/issue-monday-sync.yml
@@ -42,79 +42,16 @@ on:
         options:
           - added
           - removed
-env:
-  MONDAY_KEY: ${{ secrets.MONDAY_KEY }}
-  MONDAY_BOARD: ${{ secrets.MONDAY_BOARD }}
 jobs:
-  determine-action:
+  sync-issue:
     runs-on: ubuntu-latest
     permissions:
       issues: write
       contents: read
     steps:
       - uses: actions/checkout@v6
-
-      - name: "Create Task"
-        if: github.event.action == 'opened' ||
-          (github.event.action == 'labeled' && github.event.label.name == 'monday.com sync')
-        uses: actions/github-script@v9
+      - name: Sync Issue to Monday.com
+        uses: ./.github/actions/monday
         with:
-          script: |
-            const action = require('${{ github.workspace }}/.github/scripts/monday/createTask.js')
-            await action({github, context, core})
-
-      - name: "Update Label on Task"
-        if: github.event.action == 'labeled' && github.event.label.name != 'monday.com sync'
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const action = require('${{ github.workspace }}/.github/scripts/monday/updateLabels.js')
-            await action({github, context, core})
-
-      - name: "Remove Label from Task"
-        if: github.event.action == 'unlabeled'
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const action = require('${{ github.workspace }}/.github/scripts/monday/removeLabel.js')
-            await action({github, context, core})
-
-      - name: "Update Milestone"
-        if: github.event.action == 'milestoned' || github.event.action == 'demilestoned'
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const action = require('${{ github.workspace }}/.github/scripts/monday/updateMilestone.js')
-            await action({github, context, core})
-
-      - name: "Update Task Title"
-        if: github.event.action == 'edited'
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const action = require('${{ github.workspace }}/.github/scripts/monday/updateTitle.js')
-            await action({github, context, core})
-
-      - name: "Update Task Assignee"
-        if: github.event.action == 'assigned' || github.event.action == 'unassigned'
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const action = require('${{ github.workspace }}/.github/scripts/monday/updateAssignee.js')
-            await action({github, context, core})
-
-      - name: "Update Task Status"
-        if: github.event.action == 'closed' || github.event.action == 'reopened'
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const action = require('${{ github.workspace }}/.github/scripts/monday/updateState.js')
-            await action({github, context, core})
-
-      - name: "Sync Action Changes"
-        if: github.event.inputs.event_type == 'SyncActionChanges'
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const action = require('${{ github.workspace }}/.github/scripts/monday/syncActionChanges.js')
-            await action({github, context, core})
+          monday_key: ${{ secrets.MONDAY_KEY }}
+          monday_board: ${{ secrets.MONDAY_BOARD }}


### PR DESCRIPTION
**Related Issue:** n/a

## Summary
This PR refactors the Monday.com sync workflow and script to support usage by our Devtopia documentation repository. This is done through the following changes:

- Moving the workflow steps to a composite action that can be called from Devtopia: `./github/actions/monday/action.yml`. The `actions` dir is the recommended location for composite actions. We have a few others that could/should be moved there.
- Changing the path references to use `github.action_path` to support external usage.
- Adding repository detection and Devtopia username mapping (via `USERNAME_MAP` var and `getUsername` helper). `USERNAME_MAP` is a repo secret on the doc site that allows us to easily see and update those values, but only within the Esri network.
- Adds the "Theme Updates" issue type label and mapping