### PR TITLE
fix(flow-item): support overriding collapse message

### DIFF
--- a/packages/components/src/components/flow-item/flow-item.browser.e2e.tsx
+++ b/packages/components/src/components/flow-item/flow-item.browser.e2e.tsx
@@ -175,7 +175,7 @@ describe("delegates to floating-ui-owner component", () => {
 });
 
 describe("translation support", () => {
-  t9n(() => mount("calcite-flow-item"), ["calcite-panel"]);
+  t9n(() => mount("calcite-flow-item"), [{ tag: "calcite-panel" }]);
 });
 
 describe("disabled", () => {

--- a/packages/components/src/components/flow-item/flow-item.browser.e2e.tsx
+++ b/packages/components/src/components/flow-item/flow-item.browser.e2e.tsx
@@ -175,13 +175,7 @@ describe("delegates to floating-ui-owner component", () => {
 });
 
 describe("translation support", () => {
-  t9n(() => mount("calcite-flow-item"), {
-    back: "back",
-    close: "close",
-    options: "options",
-    collapse: "collapse",
-    expand: "expand",
-  });
+  t9n(() => mount("calcite-flow-item"), ["calcite-panel"]);
 });
 
 describe("disabled", () => {

--- a/packages/components/src/components/flow-item/flow-item.browser.e2e.tsx
+++ b/packages/components/src/components/flow-item/flow-item.browser.e2e.tsx
@@ -175,7 +175,13 @@ describe("delegates to floating-ui-owner component", () => {
 });
 
 describe("translation support", () => {
-  t9n(() => mount("calcite-flow-item"));
+  t9n(() => mount("calcite-flow-item"), {
+    back: "back",
+    close: "close",
+    options: "options",
+    collapse: "collapse",
+    expand: "expand",
+  });
 });
 
 describe("disabled", () => {

--- a/packages/components/src/components/flow-item/flow-item.browser.e2e.tsx
+++ b/packages/components/src/components/flow-item/flow-item.browser.e2e.tsx
@@ -175,7 +175,7 @@ describe("delegates to floating-ui-owner component", () => {
 });
 
 describe("translation support", () => {
-  t9n(() => mount("calcite-flow-item"), [{ tag: "calcite-panel" }]);
+  t9n(() => mount("calcite-flow-item"), ["calcite-panel"]);
 });
 
 describe("disabled", () => {

--- a/packages/components/src/components/flow-item/flow-item.tsx
+++ b/packages/components/src/components/flow-item/flow-item.tsx
@@ -309,7 +309,7 @@ export class FlowItem extends LitElement {
       headingLevel,
       loading,
       menuOpen,
-      messages,
+      messageOverrides,
       overlayPositioning,
       beforeClose,
       icon,
@@ -332,7 +332,7 @@ export class FlowItem extends LitElement {
           iconFlipRtl={iconFlipRtl}
           loading={loading}
           menuOpen={menuOpen}
-          messageOverrides={messages}
+          messageOverrides={messageOverrides}
           oncalcitePanelClose={this.handleInternalPanelClose}
           oncalcitePanelScroll={this.handleInternalPanelScroll}
           oncalcitePanelToggle={this.handleInternalPanelToggle}

--- a/packages/components/src/components/flow-item/flow-item.tsx
+++ b/packages/components/src/components/flow-item/flow-item.tsx
@@ -120,7 +120,7 @@ export class FlowItem extends LitElement {
   @property({ reflect: true }) menuOpen = false;
 
   /** Overrides individual strings used by the component. */
-  @property() messageOverrides?: typeof this.messages._overrides;
+  @property() messageOverrides?: typeof this.messages._overrides & Panel["messageOverrides"];
 
   /**
    * Specifies the type of positioning to use for overlaid content, where:

--- a/packages/components/src/tests/commonTests/browser/t9n.ts
+++ b/packages/components/src/tests/commonTests/browser/t9n.ts
@@ -4,16 +4,6 @@ import { IntrinsicElementsWithProp } from "../../utils/interfaces";
 
 type ComponentWithMessageOverrides = IntrinsicElementsWithProp<"messageOverrides">;
 type TagName = keyof DeclareElements;
-
-type SubComponentSpec<Tag extends TagName = TagName> = {
-  tag: Tag;
-  /**
-   * Optional selector
-   *
-   */
-  selector?: string;
-};
-
 type MessagesBundle = Record<string, string>;
 
 type T9nComponent = {
@@ -56,10 +46,7 @@ const getMessages = async (el: HTMLElement): Promise<void> => {
   return el["messages"];
 };
 
-export async function t9n<TSubTag extends TagName = TagName>(
-  setup: () => ReturnType<typeof mount>,
-  subComponents?: SubComponentSpec<TSubTag>[],
-): Promise<void> {
+export async function t9n(setup: () => ReturnType<typeof mount>, subComponents?: TagName[]): Promise<void> {
   afterEach(() => {
     vi.restoreAllMocks();
   });
@@ -84,7 +71,7 @@ export async function t9n<TSubTag extends TagName = TagName>(
     expect(await getCurrentMessages(component)).toBeDefined();
   }
 
-  async function assertOverrides(subComponents?: SubComponentSpec<TagName>[]): Promise<void> {
+  async function assertOverrides(subComponents?: TagName[]): Promise<void> {
     const { el, component, reRender } = (await setup()) as RenderResult<ComponentWithMessageOverrides>;
     const messages = await getCurrentMessages(component);
     const firstMessageProp = Object.keys(messages).find((key) => !key.startsWith("_"));
@@ -102,8 +89,9 @@ export async function t9n<TSubTag extends TagName = TagName>(
     });
 
     if (subComponents?.length) {
+      // for prototyping we are only supporting a single sub-component, but this could be easily extended to support multiple sub-components and message overrides for each
       const subComponent = subComponents[0];
-      const subComponentMessages = await importMessagesJson(subComponent.tag);
+      const subComponentMessages = await importMessagesJson(subComponent);
       const firstSubComponentMessageKey = Object.keys(subComponentMessages).find((key) => !key.startsWith("_"))[0];
 
       if (!firstSubComponentMessageKey) {
@@ -113,7 +101,7 @@ export async function t9n<TSubTag extends TagName = TagName>(
       el.messageOverrides = { [firstSubComponentMessageKey]: overrideValue } as any;
       await reRender();
 
-      const subComponentEl = findSubComponentElement(el, subComponent.tag);
+      const subComponentEl = findSubComponentElement(el, subComponent);
       expect(subComponentEl).toBeTruthy();
       expect(isT9nComponent(subComponentEl)).toBe(true);
 

--- a/packages/components/src/tests/commonTests/browser/t9n.ts
+++ b/packages/components/src/tests/commonTests/browser/t9n.ts
@@ -4,18 +4,62 @@ import { IntrinsicElementsWithProp } from "../../utils/interfaces";
 
 type ComponentWithMessageOverrides = IntrinsicElementsWithProp<"messageOverrides">;
 type TagName = keyof DeclareElements;
-/**
- * Helper to test t9n component setup.
- *
- * Note that this helper should be used within a describe block.
- *
- * @example
- * describe("translation support", () => {
- *   t9n("calcite-action");
- * });
- */
 
-export async function t9n(setup: () => ReturnType<typeof mount>, subComponents?: TagName[]): Promise<void> {
+type SubComponentSpec<Tag extends TagName = TagName> = {
+  tag: Tag;
+  /**
+   * Optional selector
+   *
+   */
+  selector?: string;
+};
+
+type MessagesBundle = Record<string, string>;
+
+type T9nComponent = {
+  messages: Record<string, string> & { _loading?: boolean };
+  messageOverrides?: Record<string, string>;
+};
+
+const isT9nComponent = (el: unknown): el is HTMLElement & T9nComponent => {
+  return Boolean(
+    el &&
+    typeof el === "object" &&
+    "messages" in (el as any) &&
+    (el as any).messages &&
+    typeof (el as any).messages === "object",
+  );
+};
+
+const tagNameToComponentFolder = (tagName: TagName): string => String(tagName).replace(/^calcite-/, "");
+
+async function importMessagesJson(tagName: TagName): Promise<MessagesBundle> {
+  const folder = tagNameToComponentFolder(tagName);
+
+  // eslint-disable-next-line import/no-dynamic-require
+  const messages = await import(`../../../components/${folder}/assets/t9n/messages.json`);
+
+  return (messages.default ?? messages) as MessagesBundle;
+}
+
+const getRenderedRoot = (host: Element): ParentNode => host.shadowRoot ?? host;
+
+const findSubComponentElement = (host: Element, tagName: TagName): HTMLElement | null => {
+  const root = getRenderedRoot(host);
+  return root.querySelector(tagName);
+};
+
+const getMessages = async (el: HTMLElement): Promise<void> => {
+  if (el["messages"]._loading) {
+    await vi.waitUntil(() => !el["messages"]._loading);
+  }
+  return el["messages"];
+};
+
+export async function t9n<TSubTag extends TagName = TagName>(
+  setup: () => ReturnType<typeof mount>,
+  subComponents?: SubComponentSpec<TSubTag>[],
+): Promise<void> {
   afterEach(() => {
     vi.restoreAllMocks();
   });
@@ -40,35 +84,44 @@ export async function t9n(setup: () => ReturnType<typeof mount>, subComponents?:
     expect(await getCurrentMessages(component)).toBeDefined();
   }
 
-  async function assertOverrides(subComponents?: TagName[]): Promise<void> {
-    let subComponentMessages = {};
-    if (Array.isArray(subComponents) && subComponents.length > 0) {
-      for (const subComponent of subComponents) {
-        const { component } = (await mount(subComponent)) as RenderResult<ComponentWithMessageOverrides>;
-        const subComponentCurrentMessages = await getCurrentMessages(component);
-        const filteredSubComponentCurrentMessages = Object.fromEntries(
-          Object.entries(subComponentCurrentMessages).filter(([key]) => !key.startsWith("_")),
-        );
-        expect(subComponentMessages).toBeDefined();
-        subComponentMessages = { ...subComponentMessages, ...filteredSubComponentCurrentMessages };
-      }
-    }
+  async function assertOverrides(subComponents?: SubComponentSpec<TagName>[]): Promise<void> {
     const { el, component, reRender } = (await setup()) as RenderResult<ComponentWithMessageOverrides>;
     const messages = await getCurrentMessages(component);
     const firstMessageProp = Object.keys(messages).find((key) => !key.startsWith("_"));
-    const messageOverrides = {
-      [firstMessageProp as keyof typeof messages]: "override test",
-    };
-    el.messageOverrides = { ...messageOverrides, ...subComponentMessages };
+    if (!firstMessageProp) {
+      return;
+    }
+    const overrideValue = "override test";
+    const messageOverride = { [firstMessageProp]: overrideValue };
+    el.messageOverrides = messageOverride;
     await reRender();
 
     expect(await getCurrentMessages(component)).toMatchObject({
       ...messages,
-      ...messageOverrides,
-      ...subComponentMessages,
+      ...messageOverride,
     });
 
-    // reset test changes
+    if (subComponents?.length) {
+      const subComponent = subComponents[0];
+      const subComponentMessages = await importMessagesJson(subComponent.tag);
+      const firstSubComponentMessageKey = Object.keys(subComponentMessages).find((key) => !key.startsWith("_"))[0];
+
+      if (!firstSubComponentMessageKey) {
+        return;
+      }
+
+      el.messageOverrides = { [firstSubComponentMessageKey]: overrideValue } as any;
+      await reRender();
+
+      const subComponentEl = findSubComponentElement(el, subComponent.tag);
+      expect(subComponentEl).toBeTruthy();
+      expect(isT9nComponent(subComponentEl)).toBe(true);
+
+      const childMessages = await getMessages(subComponentEl);
+      expect(childMessages).toBeDefined();
+      expect(childMessages[firstSubComponentMessageKey]).toBe(overrideValue);
+    }
+
     el.messageOverrides = undefined;
     await reRender();
   }
@@ -79,16 +132,12 @@ export async function t9n(setup: () => ReturnType<typeof mount>, subComponents?:
     const fakeBundleIdentifier = "__fake__";
 
     const originalFetch = window.fetch;
-    vi.spyOn(window, "fetch").mockImplementation(async (input, init) => {
+    vi.spyOn(window, "fetch").mockImplementation(async (input) => {
       if (typeof input === "string" && input.endsWith(".es.json")) {
-        const fakeEsMessages = {
-          ...enMessages,
-          [fakeBundleIdentifier]: true,
-        };
+        const fakeEsMessages = { ...enMessages, [fakeBundleIdentifier]: true };
         return new Response(new Blob([JSON.stringify(fakeEsMessages, null, 2)], { type: "application/json" }));
       }
-
-      return originalFetch(input, init);
+      return originalFetch(input);
     });
 
     el.lang = "es";

--- a/packages/components/src/tests/commonTests/browser/t9n.ts
+++ b/packages/components/src/tests/commonTests/browser/t9n.ts
@@ -2,6 +2,8 @@ import { afterEach, expect, it, vi } from "vitest";
 import { mount, RenderResult } from "@arcgis/lumina-compiler/testing";
 import { IntrinsicElementsWithProp } from "../../utils/interfaces";
 
+type ComponentWithMessageOverrides = IntrinsicElementsWithProp<"messageOverrides">;
+type TagName = keyof DeclareElements;
 /**
  * Helper to test t9n component setup.
  *
@@ -12,17 +14,16 @@ import { IntrinsicElementsWithProp } from "../../utils/interfaces";
  *   t9n("calcite-action");
  * });
  */
-export async function t9n(setup: () => ReturnType<typeof mount>, messageOverrides?: object): Promise<void> {
+
+export async function t9n(setup: () => ReturnType<typeof mount>, subComponents?: TagName[]): Promise<void> {
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
   it("has defined default messages", async () => await assertDefaultMessages());
-  it("overrides messages", async () => await assertOverrides(messageOverrides));
+  it("overrides messages", async () => await assertOverrides(subComponents));
   it("switches messages", async () => await assertLangSwitch());
   it("does not throw when removed during message loading", async () => await assertNoErrorOnRemovalDuringMessageLoad());
-
-  type ComponentWithMessageOverrides = IntrinsicElementsWithProp<"messageOverrides">;
 
   async function getCurrentMessages(
     component: ComponentWithMessageOverrides,
@@ -34,67 +35,37 @@ export async function t9n(setup: () => ReturnType<typeof mount>, messageOverride
     return component.messages;
   }
 
-  // const getCtor = (component: ComponentWithMessageOverrides): any => component?.el?.constructor;
-
-  // const getPropMeta = (component: ComponentWithMessageOverrides, propName: string) => {
-  //   const ctor = getCtor(component);
-  //   if (!ctor) {
-  //     return undefined;
-  //   }
-
-  //   // Lumina / Lit-style static metadata (best-effort)
-  //   return (
-  //     ctor?.properties?.[propName] ??
-  //     ctor?.props?.[propName] ??
-  //     ctor?.__properties?.[propName] ??
-  //     ctor?.[propName] // very last-ditch (unlikely)
-  //   );
-  // };
-
-  // const getShapeKeysFromMeta = (meta): string[] => {
-  //   if (!meta) {
-  //     return [];
-  //   }
-
-  //   const shape = meta.shape ?? meta.schema;
-  //   if (shape && typeof shape === "object") {
-  //     return Object.keys(shape);
-  //   }
-
-  //   return [];
-  // };
-
-  // async function getMessageOverridesKeys(
-  //   component: ComponentWithMessageOverrides,
-  // ): Promise<(keyof ComponentWithMessageOverrides["messageOverrides"])[]> {
-  //   const meta = getPropMeta(component, "messageOverrides");
-  //   const shapeKeys = getShapeKeysFromMeta(meta);
-  //   if (shapeKeys.length) {
-  //     return shapeKeys as (keyof ComponentWithMessageOverrides["messageOverrides"])[];
-  //   }
-
-  // }
-
   async function assertDefaultMessages(): Promise<void> {
     const { component } = (await setup()) as RenderResult<ComponentWithMessageOverrides>;
     expect(await getCurrentMessages(component)).toBeDefined();
   }
 
-  async function assertOverrides(messageOverrides?: object): Promise<void> {
+  async function assertOverrides(subComponents?: TagName[]): Promise<void> {
+    let subComponentMessages = {};
+    if (Array.isArray(subComponents) && subComponents.length > 0) {
+      for (const subComponent of subComponents) {
+        const { component } = (await mount(subComponent)) as RenderResult<ComponentWithMessageOverrides>;
+        const subComponentCurrentMessages = await getCurrentMessages(component);
+        const filteredSubComponentCurrentMessages = Object.fromEntries(
+          Object.entries(subComponentCurrentMessages).filter(([key]) => !key.startsWith("_")),
+        );
+        expect(subComponentMessages).toBeDefined();
+        subComponentMessages = { ...subComponentMessages, ...filteredSubComponentCurrentMessages };
+      }
+    }
     const { el, component, reRender } = (await setup()) as RenderResult<ComponentWithMessageOverrides>;
     const messages = await getCurrentMessages(component);
     const firstMessageProp = Object.keys(messages).find((key) => !key.startsWith("_"));
-    // const messageOverridesKeys = await getMessageOverridesKeys(component);
-
-    const messageOverridesToApply = messageOverrides || {
+    const messageOverrides = {
       [firstMessageProp as keyof typeof messages]: "override test",
     };
-    el.messageOverrides = messageOverridesToApply;
+    el.messageOverrides = { ...messageOverrides, ...subComponentMessages };
     await reRender();
 
     expect(await getCurrentMessages(component)).toMatchObject({
       ...messages,
       ...messageOverrides,
+      ...subComponentMessages,
     });
 
     // reset test changes

--- a/packages/components/src/tests/commonTests/browser/t9n.ts
+++ b/packages/components/src/tests/commonTests/browser/t9n.ts
@@ -67,6 +67,7 @@ export async function t9n(setup: () => ReturnType<typeof mount>, subComponents?:
     if (subComponents?.length) {
       el.messageOverrides = messageOverride;
       await reRender();
+
       for (const subComponent of subComponents) {
         const subComponentEl = findSubComponentElement(el, subComponent) as DeclareElements[TagName];
         expect(subComponentEl).toBeTruthy();

--- a/packages/components/src/tests/commonTests/browser/t9n.ts
+++ b/packages/components/src/tests/commonTests/browser/t9n.ts
@@ -86,12 +86,12 @@ export async function t9n(setup: () => ReturnType<typeof mount>, subComponents?:
     const fakeBundleIdentifier = "__fake__";
 
     const originalFetch = window.fetch;
-    vi.spyOn(window, "fetch").mockImplementation(async (input) => {
+    vi.spyOn(window, "fetch").mockImplementation(async (input, init) => {
       if (typeof input === "string" && input.endsWith(".es.json")) {
         const fakeEsMessages = { ...enMessages, [fakeBundleIdentifier]: true };
         return new Response(new Blob([JSON.stringify(fakeEsMessages, null, 2)], { type: "application/json" }));
       }
-      return originalFetch(input);
+      return originalFetch(input, init);
     });
 
     el.lang = "es";

--- a/packages/components/src/tests/commonTests/browser/t9n.ts
+++ b/packages/components/src/tests/commonTests/browser/t9n.ts
@@ -2,14 +2,18 @@ import { afterEach, expect, it, vi } from "vitest";
 import { mount, RenderResult } from "@arcgis/lumina-compiler/testing";
 import { IntrinsicElementsWithProp } from "../../utils/interfaces";
 
-type ComponentWithMessageOverrides = IntrinsicElementsWithProp<"messageOverrides">;
 type TagName = keyof DeclareElements;
 
-const findSubComponentElement = (host: Element, tagName: TagName): HTMLElement => {
-  const root = host.shadowRoot ?? host;
-  return root.querySelector(tagName);
-};
-
+/**
+ * Helper to test t9n component setup.
+ *
+ * Note that this helper should be used within a describe block.
+ *
+ * @example
+ * describe("translation support", () => {
+ *   t9n("calcite-action");
+ * });
+ */
 export async function t9n(setup: () => ReturnType<typeof mount>, subComponents?: TagName[]): Promise<void> {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -19,6 +23,8 @@ export async function t9n(setup: () => ReturnType<typeof mount>, subComponents?:
   it("overrides messages", async () => await assertOverrides(subComponents));
   it("switches messages", async () => await assertLangSwitch());
   it("does not throw when removed during message loading", async () => await assertNoErrorOnRemovalDuringMessageLoad());
+
+  type ComponentWithMessageOverrides = IntrinsicElementsWithProp<"messageOverrides">;
 
   async function getCurrentMessages(
     component: ComponentWithMessageOverrides,
@@ -30,6 +36,11 @@ export async function t9n(setup: () => ReturnType<typeof mount>, subComponents?:
     return component.messages;
   }
 
+  const findSubComponentElement = (host: Element, tagName: TagName): HTMLElement => {
+    const root = host.shadowRoot ?? host;
+    return root.querySelector(tagName);
+  };
+
   async function assertDefaultMessages(): Promise<void> {
     const { component } = (await setup()) as RenderResult<ComponentWithMessageOverrides>;
     expect(await getCurrentMessages(component)).toBeDefined();
@@ -39,9 +50,6 @@ export async function t9n(setup: () => ReturnType<typeof mount>, subComponents?:
     const { el, component, reRender } = (await setup()) as RenderResult<ComponentWithMessageOverrides>;
     const messages = await getCurrentMessages(component);
     const firstMessageProp = Object.keys(messages).find((key) => !key.startsWith("_"));
-    if (!firstMessageProp) {
-      return;
-    }
     const overrideValue = "override test";
     const messageOverride = { [firstMessageProp]: overrideValue };
     el.messageOverrides = messageOverride;
@@ -52,6 +60,7 @@ export async function t9n(setup: () => ReturnType<typeof mount>, subComponents?:
       ...messageOverride,
     });
 
+    // reset test changes
     el.messageOverrides = undefined;
     await reRender();
 

--- a/packages/components/src/tests/commonTests/browser/t9n.ts
+++ b/packages/components/src/tests/commonTests/browser/t9n.ts
@@ -11,7 +11,7 @@ type TagName = keyof DeclareElements;
  *
  * @example
  * describe("translation support", () => {
- *   t9n("calcite-action");
+ *   t9n(() => mount("calcite-input-date-picker"), ["calcite-date-picker"]);
  * });
  */
 export async function t9n(setup: () => ReturnType<typeof mount>, subComponents?: TagName[]): Promise<void> {

--- a/packages/components/src/tests/commonTests/browser/t9n.ts
+++ b/packages/components/src/tests/commonTests/browser/t9n.ts
@@ -36,7 +36,7 @@ export async function t9n(setup: () => ReturnType<typeof mount>, subComponents?:
     return component.messages;
   }
 
-  const findSubComponentElement = (host: Element, tagName: TagName): HTMLElement => {
+  const findSubComponentElement = (host: Element, tagName: TagName): Element | null => {
     const root = host.shadowRoot ?? host;
     return root.querySelector(tagName);
   };
@@ -70,7 +70,7 @@ export async function t9n(setup: () => ReturnType<typeof mount>, subComponents?:
 
       for (const subComponent of subComponents) {
         const subComponentEl = findSubComponentElement(el, subComponent) as DeclareElements[TagName];
-        expect(subComponentEl).toBeTruthy();
+        expect(subComponentEl).not.toBeNull();
         const subComponentManager = subComponentEl.manager.component as ComponentWithMessageOverrides;
         // Assert whether parent component passed the override value to the sub-component.
         expect(subComponentManager.messageOverrides[firstMessageProp]).toBe(overrideValue);

--- a/packages/components/src/tests/commonTests/browser/t9n.ts
+++ b/packages/components/src/tests/commonTests/browser/t9n.ts
@@ -12,13 +12,13 @@ import { IntrinsicElementsWithProp } from "../../utils/interfaces";
  *   t9n("calcite-action");
  * });
  */
-export async function t9n(setup: () => ReturnType<typeof mount>): Promise<void> {
+export async function t9n(setup: () => ReturnType<typeof mount>, messageOverrides?: object): Promise<void> {
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
   it("has defined default messages", async () => await assertDefaultMessages());
-  it("overrides messages", async () => await assertOverrides());
+  it("overrides messages", async () => await assertOverrides(messageOverrides));
   it("switches messages", async () => await assertLangSwitch());
   it("does not throw when removed during message loading", async () => await assertNoErrorOnRemovalDuringMessageLoad());
 
@@ -34,23 +34,67 @@ export async function t9n(setup: () => ReturnType<typeof mount>): Promise<void> 
     return component.messages;
   }
 
+  // const getCtor = (component: ComponentWithMessageOverrides): any => component?.el?.constructor;
+
+  // const getPropMeta = (component: ComponentWithMessageOverrides, propName: string) => {
+  //   const ctor = getCtor(component);
+  //   if (!ctor) {
+  //     return undefined;
+  //   }
+
+  //   // Lumina / Lit-style static metadata (best-effort)
+  //   return (
+  //     ctor?.properties?.[propName] ??
+  //     ctor?.props?.[propName] ??
+  //     ctor?.__properties?.[propName] ??
+  //     ctor?.[propName] // very last-ditch (unlikely)
+  //   );
+  // };
+
+  // const getShapeKeysFromMeta = (meta): string[] => {
+  //   if (!meta) {
+  //     return [];
+  //   }
+
+  //   const shape = meta.shape ?? meta.schema;
+  //   if (shape && typeof shape === "object") {
+  //     return Object.keys(shape);
+  //   }
+
+  //   return [];
+  // };
+
+  // async function getMessageOverridesKeys(
+  //   component: ComponentWithMessageOverrides,
+  // ): Promise<(keyof ComponentWithMessageOverrides["messageOverrides"])[]> {
+  //   const meta = getPropMeta(component, "messageOverrides");
+  //   const shapeKeys = getShapeKeysFromMeta(meta);
+  //   if (shapeKeys.length) {
+  //     return shapeKeys as (keyof ComponentWithMessageOverrides["messageOverrides"])[];
+  //   }
+
+  // }
+
   async function assertDefaultMessages(): Promise<void> {
     const { component } = (await setup()) as RenderResult<ComponentWithMessageOverrides>;
     expect(await getCurrentMessages(component)).toBeDefined();
   }
 
-  async function assertOverrides(): Promise<void> {
+  async function assertOverrides(messageOverrides?: object): Promise<void> {
     const { el, component, reRender } = (await setup()) as RenderResult<ComponentWithMessageOverrides>;
     const messages = await getCurrentMessages(component);
     const firstMessageProp = Object.keys(messages).find((key) => !key.startsWith("_"));
-    const messageOverride = { [firstMessageProp as keyof typeof messages]: "override test" };
+    // const messageOverridesKeys = await getMessageOverridesKeys(component);
 
-    el.messageOverrides = messageOverride;
+    const messageOverridesToApply = messageOverrides || {
+      [firstMessageProp as keyof typeof messages]: "override test",
+    };
+    el.messageOverrides = messageOverridesToApply;
     await reRender();
 
     expect(await getCurrentMessages(component)).toMatchObject({
       ...messages,
-      ...messageOverride,
+      ...messageOverrides,
     });
 
     // reset test changes

--- a/packages/components/src/tests/commonTests/browser/t9n.ts
+++ b/packages/components/src/tests/commonTests/browser/t9n.ts
@@ -4,46 +4,10 @@ import { IntrinsicElementsWithProp } from "../../utils/interfaces";
 
 type ComponentWithMessageOverrides = IntrinsicElementsWithProp<"messageOverrides">;
 type TagName = keyof DeclareElements;
-type MessagesBundle = Record<string, string>;
 
-type T9nComponent = {
-  messages: Record<string, string> & { _loading?: boolean };
-  messageOverrides?: Record<string, string>;
-};
-
-const isT9nComponent = (el: unknown): el is HTMLElement & T9nComponent => {
-  return Boolean(
-    el &&
-    typeof el === "object" &&
-    "messages" in (el as any) &&
-    (el as any).messages &&
-    typeof (el as any).messages === "object",
-  );
-};
-
-const tagNameToComponentFolder = (tagName: TagName): string => String(tagName).replace(/^calcite-/, "");
-
-async function importMessagesJson(tagName: TagName): Promise<MessagesBundle> {
-  const folder = tagNameToComponentFolder(tagName);
-
-  // eslint-disable-next-line import/no-dynamic-require
-  const messages = await import(`../../../components/${folder}/assets/t9n/messages.json`);
-
-  return (messages.default ?? messages) as MessagesBundle;
-}
-
-const getRenderedRoot = (host: Element): ParentNode => host.shadowRoot ?? host;
-
-const findSubComponentElement = (host: Element, tagName: TagName): HTMLElement | null => {
-  const root = getRenderedRoot(host);
+const findSubComponentElement = (host: Element, tagName: TagName): HTMLElement => {
+  const root = host.shadowRoot ?? host;
   return root.querySelector(tagName);
-};
-
-const getMessages = async (el: HTMLElement): Promise<void> => {
-  if (el["messages"]._loading) {
-    await vi.waitUntil(() => !el["messages"]._loading);
-  }
-  return el["messages"];
 };
 
 export async function t9n(setup: () => ReturnType<typeof mount>, subComponents?: TagName[]): Promise<void> {
@@ -88,26 +52,19 @@ export async function t9n(setup: () => ReturnType<typeof mount>, subComponents?:
       ...messageOverride,
     });
 
+    el.messageOverrides = undefined;
+    await reRender();
+
     if (subComponents?.length) {
-      // for prototyping we are only supporting a single sub-component, but this could be easily extended to support multiple sub-components and message overrides for each
-      const subComponent = subComponents[0];
-      const subComponentMessages = await importMessagesJson(subComponent);
-      const firstSubComponentMessageKey = Object.keys(subComponentMessages).find((key) => !key.startsWith("_"))[0];
-
-      if (!firstSubComponentMessageKey) {
-        return;
-      }
-
-      el.messageOverrides = { [firstSubComponentMessageKey]: overrideValue } as any;
+      el.messageOverrides = messageOverride;
       await reRender();
-
-      const subComponentEl = findSubComponentElement(el, subComponent);
-      expect(subComponentEl).toBeTruthy();
-      expect(isT9nComponent(subComponentEl)).toBe(true);
-
-      const childMessages = await getMessages(subComponentEl);
-      expect(childMessages).toBeDefined();
-      expect(childMessages[firstSubComponentMessageKey]).toBe(overrideValue);
+      for (const subComponent of subComponents) {
+        const subComponentEl = findSubComponentElement(el, subComponent) as DeclareElements[TagName];
+        expect(subComponentEl).toBeTruthy();
+        const subComponentManager = subComponentEl.manager.component as ComponentWithMessageOverrides;
+        // Assert whether parent component passed the override value to the sub-component.
+        expect(subComponentManager.messageOverrides[firstMessageProp]).toBe(overrideValue);
+      }
     }
 
     el.messageOverrides = undefined;


### PR DESCRIPTION
**Related Issue:** #14292 

## Summary

Allow overriding collapse message in flow-item.