### PR TITLE
fix(tree-item): ensure content grows to full height when expanded

### DIFF
--- a/packages/components/src/components/tree-item/tree-item.scss
+++ b/packages/components/src/components/tree-item/tree-item.scss
@@ -22,10 +22,6 @@
 @use "../../styles/includes";
 @use "../../styles/shared/animation";
 
-// :host {
-//   interpolate-size: allow-keywords;
-// }
-
 :host([scale="s"]) {
   --calcite-internal-tree-item-spacing-unit: 0.25rem;
   --calcite-internal-tree-item-padding-block: 0.25rem;

--- a/packages/components/src/components/tree-item/tree-item.scss
+++ b/packages/components/src/components/tree-item/tree-item.scss
@@ -22,6 +22,10 @@
 @use "../../styles/includes";
 @use "../../styles/shared/animation";
 
+:host {
+  interpolate-size: allow-keywords;
+}
+
 :host([scale="s"]) {
   --calcite-internal-tree-item-spacing-unit: 0.25rem;
   --calcite-internal-tree-item-padding-block: 0.25rem;
@@ -58,6 +62,12 @@
 
   .children-container ::slotted(*) {
     padding-inline-start: var(--calcite-internal-tree-item-children-container-padding);
+  }
+}
+
+@supports not (interpolate-size: allow-keywords) {
+  :host .children-container ::slotted(*) {
+    overflow: hidden;
   }
 }
 
@@ -173,15 +183,23 @@
 
 .item--expanded > .children-container {
   opacity: 1;
-  overflow: visible;
-  max-block-size: 1000dvb;
-  transition:
-    opacity var(--calcite-internal-animation-timing-slow) animation.$easing-function,
-    max-block-size calc(2 * var(--calcite-internal-animation-timing-slow)) animation.$easing-function;
+  max-block-size: max-content;
+}
 
-  @starting-style {
-    opacity: 0;
-    max-block-size: 0;
+@supports not (interpolate-size: allow-keywords) {
+  .children-container {
+    display: grid;
+    grid-template-rows: 0fr;
+    opacity: 1;
+    max-block-size: max-content;
+    transition:
+      opacity var(--calcite-internal-animation-timing-slow) animation.$easing-function,
+      max-block-size var(--calcite-internal-animation-timing-medium) animation.$easing-function,
+      grid-template-rows var(--calcite-internal-animation-timing-medium) animation.$easing-function;
+  }
+
+  .item--expanded > .children-container {
+    grid-template-rows: 1fr;
   }
 }
 

--- a/packages/components/src/components/tree-item/tree-item.scss
+++ b/packages/components/src/components/tree-item/tree-item.scss
@@ -170,7 +170,6 @@
   position: relative;
   transition:
     opacity var(--calcite-internal-animation-timing-slow) animation.$easing-function,
-    max-block-size var(--calcite-internal-animation-timing-medium) animation.$easing-function,
     grid-template-rows var(--calcite-internal-animation-timing-medium) animation.$easing-function;
 }
 
@@ -181,7 +180,6 @@
 
   @starting-style {
     opacity: 0;
-    max-block-size: 0;
     grid-template-rows: 0fr;
   }
 }

--- a/packages/components/src/components/tree-item/tree-item.scss
+++ b/packages/components/src/components/tree-item/tree-item.scss
@@ -58,11 +58,6 @@
 
   .children-container ::slotted(*) {
     padding-inline-start: var(--calcite-internal-tree-item-children-container-padding);
-  }
-}
-
-@supports not (interpolate-size: allow-keywords) {
-  :host .children-container ::slotted(*) {
     overflow: hidden;
   }
 }
@@ -168,35 +163,26 @@
 }
 
 .children-container {
-  opacity: 0;
-  max-block-size: 0;
-  overflow: hidden;
+  display: grid;
+  grid-template-rows: 0fr;
+  max-block-size: max-content;
+  opacity: 1;
   position: relative;
   transition:
     opacity var(--calcite-internal-animation-timing-slow) animation.$easing-function,
-    max-block-size var(--calcite-internal-animation-timing-medium) animation.$easing-function;
-  interpolate-size: allow-keywords;
+    max-block-size var(--calcite-internal-animation-timing-medium) animation.$easing-function,
+    grid-template-rows var(--calcite-internal-animation-timing-medium) animation.$easing-function;
 }
 
 .item--expanded > .children-container {
+  grid-template-rows: 1fr;
   opacity: 1;
   max-block-size: max-content;
-}
 
-@supports not (interpolate-size: allow-keywords) {
-  .children-container {
-    display: grid;
+  @starting-style {
+    opacity: 0;
+    max-block-size: 0;
     grid-template-rows: 0fr;
-    opacity: 1;
-    max-block-size: max-content;
-    transition:
-      opacity var(--calcite-internal-animation-timing-slow) animation.$easing-function,
-      max-block-size var(--calcite-internal-animation-timing-medium) animation.$easing-function,
-      grid-template-rows var(--calcite-internal-animation-timing-medium) animation.$easing-function;
-  }
-
-  .item--expanded > .children-container {
-    grid-template-rows: 1fr;
   }
 }
 

--- a/packages/components/src/components/tree-item/tree-item.scss
+++ b/packages/components/src/components/tree-item/tree-item.scss
@@ -22,9 +22,9 @@
 @use "../../styles/includes";
 @use "../../styles/shared/animation";
 
-:host {
-  interpolate-size: allow-keywords;
-}
+// :host {
+//   interpolate-size: allow-keywords;
+// }
 
 :host([scale="s"]) {
   --calcite-internal-tree-item-spacing-unit: 0.25rem;
@@ -179,6 +179,7 @@
   transition:
     opacity var(--calcite-internal-animation-timing-slow) animation.$easing-function,
     max-block-size var(--calcite-internal-animation-timing-medium) animation.$easing-function;
+  interpolate-size: allow-keywords;
 }
 
 .item--expanded > .children-container {

--- a/packages/components/src/components/tree-item/tree-item.scss
+++ b/packages/components/src/components/tree-item/tree-item.scss
@@ -174,7 +174,7 @@
 .item--expanded > .children-container {
   opacity: 1;
   overflow: visible;
-  max-block-size: 100dvb;
+  max-block-size: 1000dvb;
   transition:
     opacity var(--calcite-internal-animation-timing-slow) animation.$easing-function,
     max-block-size calc(2 * var(--calcite-internal-animation-timing-slow)) animation.$easing-function;

--- a/packages/components/src/components/tree/tree.e2e.ts
+++ b/packages/components/src/components/tree/tree.e2e.ts
@@ -268,7 +268,7 @@ describe("item selection", () => {
     const tree = await page.find("calcite-tree");
     const selectEventSpy = await tree.spyOnEvent("calciteTreeSelect");
     const grandchildOne = await page.find("#grandchild-one");
-    await grandchildOne.click();
+    await directItemClick(page, grandchildOne);
     expect(selectEventSpy).toHaveReceivedEventTimes(1);
   });
 

--- a/packages/components/src/components/tree/tree.stories.ts
+++ b/packages/components/src/components/tree/tree.stories.ts
@@ -210,7 +210,7 @@ darkModeRTL.decorators = [allScaleTreeBuilder];
 
 export const OverflowingSubtree = (): string =>
   html`<div style="width:400px">
-      <calcite-tree>
+      <calcite-tree lines>
         <calcite-tree-item label="nested items" expanded>
           Layer 2
           <calcite-tree slot="children">


### PR DESCRIPTION
**Related Issue:** #14187 

## Summary

This updates `tree-item` to ensure it expands to fit its content while preserving animation.