### PR TITLE
fix: handle `Escape` in expected order with focus-trapping and non-focus-trapping hierarchies

### DIFF
--- a/packages/components/src/controllers/useFocusTrap.browser.e2e.tsx
+++ b/packages/components/src/controllers/useFocusTrap.browser.e2e.tsx
@@ -1,10 +1,10 @@
 import { h, JsxNode, LitElement, property } from "@arcgis/lumina";
 import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { PropertyValues } from "lit";
+import { html, PropertyValues } from "lit";
 import * as focusTrap from "focus-trap";
-import { Locator, page } from "vitest/browser";
-import { html } from "../../support/formatting";
+import { Locator, page, userEvent } from "vitest/browser";
+import { createRef } from "lit/directives/ref.js";
 import { afterNextTask } from "../tests/utils/timing";
 import { GlobalTestProps } from "../tests/utils/interfaces";
 import { CalciteConfig, clearConfig } from "../utils/config";
@@ -295,5 +295,100 @@ describe("useFocusTrap", () => {
     await waitForFocusShift();
 
     expect(document.activeElement!.tagName).toBe("BODY");
+  });
+
+  it("handles Escape in a hierarchy of focus-trapping and non-focus-trapping components", async () => {
+    class FocusTrapping extends LitElement {
+      static tagName = "focus-trapping";
+
+      #inputRef = createRef<HTMLInputElement>();
+
+      @property({ type: Boolean }) open? = false;
+
+      #focusTrap = useFocusTrap<this>({
+        focusTrapOptions: {
+          escapeDeactivates: (event) => {
+            if (!event.defaultPrevented) {
+              this.open = false;
+              event.preventDefault();
+            }
+
+            return true;
+          },
+        },
+        triggerProp: "open",
+      })(this);
+
+      override updated(changes: PropertyValues<this>): void {
+        if (changes.has("open")) {
+          if (this.open) {
+            this.#focusTrap.activate();
+          } else {
+            this.#focusTrap.deactivate();
+          }
+        }
+      }
+
+      override render(): JsxNode {
+        return <div>{this.open ? <input ref={this.#inputRef} /> : null}</div>;
+      }
+    }
+
+    class NonFocusTrapping extends LitElement {
+      static tagName = "non-focus-trapping";
+
+      #buttonRef = createRef<HTMLButtonElement>();
+
+      @property({ type: Boolean }) open? = false;
+
+      override updated(changes: PropertyValues<this>): void {
+        if (changes.has("open")) {
+          if (this.open) {
+            this.#buttonRef.value?.focus();
+          }
+        }
+      }
+
+      override render(): JsxNode {
+        return (
+          <div
+            onKeyDown={(event) => {
+              if (event.key === "Escape" && !event.defaultPrevented) {
+                this.open = false;
+                event.preventDefault();
+              }
+            }}
+          >
+            {this.open ? (
+              <div>
+                <slot />
+                <button ref={this.#buttonRef}>fake close button</button>
+              </div>
+            ) : null}
+          </div>
+        );
+      }
+    }
+
+    await mount(
+      html`
+        <non-focus-trapping open data-testid="non-focus-trapping">
+          <focus-trapping open data-testid="focus-trapping"></focus-trapping>
+        </non-focus-trapping>
+      `,
+      { dynamicComponents: [NonFocusTrapping, FocusTrapping] },
+    );
+    const nonFocusTrapping = page.getByTestId("non-focus-trapping");
+    const focusTrapping = nonFocusTrapping.getByTestId("focus-trapping");
+
+    await expect.element(focusTrapping).toHaveFocus();
+    await expect.element(nonFocusTrapping).not.toHaveFocus();
+
+    await userEvent.keyboard("{Escape}");
+
+    await expect.element(focusTrapping).not.toHaveFocus();
+    await expect.element(nonFocusTrapping).toHaveFocus();
+    await expect.element(focusTrapping).toHaveProperty("open", false);
+    await expect.element(nonFocusTrapping).toHaveProperty("open", true);
   });
 });

--- a/packages/components/src/controllers/useFocusTrap.browser.e2e.tsx
+++ b/packages/components/src/controllers/useFocusTrap.browser.e2e.tsx
@@ -12,6 +12,8 @@ import { FocusTrap, useFocusTrap } from "./useFocusTrap";
 
 describe("useFocusTrap", () => {
   class Test extends LitElement {
+    static tagName = "focus-trap-component";
+
     @property() open? = false;
 
     focusTrap = useFocusTrap<this>({
@@ -197,9 +199,12 @@ describe("useFocusTrap", () => {
       };
     }
 
+    let previousFocusedEl: HTMLInputElement;
+    let nextFocusedEl: HTMLInputElement;
+
     beforeEach(async () => {
-      const previousFocusedEl = document.createElement("input");
-      const nextFocusedEl = document.createElement("input");
+      previousFocusedEl = document.createElement("input");
+      nextFocusedEl = document.createElement("input");
       document.body.append(nextFocusedEl, previousFocusedEl);
 
       previousFocusedLocator = page.elementLocator(previousFocusedEl);
@@ -208,6 +213,11 @@ describe("useFocusTrap", () => {
       insideButtonLocator = page.getByTestId("inside-button");
 
       await previousFocusedLocator.click();
+    });
+
+    afterEach(() => {
+      previousFocusedEl.remove();
+      nextFocusedEl.remove();
     });
 
     describe("setReturnFocus option", () => {
@@ -282,8 +292,10 @@ describe("useFocusTrap", () => {
   });
 
   it("does not try to restore focus to the document when there was no previously focused element", async () => {
-    document.body.innerHTML = html`<a href="/">should not focus here</a>`;
-    const { el, component } = await mount(Test);
+    const { el, component } = await mount<Test>(html`
+      <a href="/">should not focus here</a>
+      <focus-trap-component></focus-trap-component>
+    `);
     el.open = true;
     await component.updateComplete;
     await waitForFocusShift();

--- a/packages/components/src/controllers/useFocusTrap.browser.e2e.tsx
+++ b/packages/components/src/controllers/useFocusTrap.browser.e2e.tsx
@@ -310,48 +310,55 @@ describe("useFocusTrap", () => {
   });
 
   it("handles Escape in a hierarchy of focus-trapping and non-focus-trapping components", async () => {
-    class FocusTrapping extends LitElement {
+    class FocusTrapComponent extends LitElement {
       static tagName = "focus-trapping";
 
-      #inputRef = createRef<HTMLInputElement>();
+      @property({ type: Boolean }) open = false;
 
-      @property({ type: Boolean }) open? = false;
-
-      #focusTrap = useFocusTrap<this>({
+      focusTrap = useFocusTrap<this>({
+        triggerProp: "open",
         focusTrapOptions: {
           escapeDeactivates: (event) => {
             if (!event.defaultPrevented) {
               this.open = false;
               event.preventDefault();
             }
-
             return true;
           },
         },
-        triggerProp: "open",
       })(this);
 
       override updated(changes: PropertyValues<this>): void {
         if (changes.has("open")) {
           if (this.open) {
-            this.#focusTrap.activate();
+            this.focusTrap.activate();
           } else {
-            this.#focusTrap.deactivate();
+            this.focusTrap.deactivate();
           }
         }
       }
 
       override render(): JsxNode {
-        return <div>{this.open ? <input ref={this.#inputRef} /> : null}</div>;
+        return this.open ? <input /> : null;
       }
     }
 
-    class NonFocusTrapping extends LitElement {
+    class NonFocusTrapComponent extends LitElement {
       static tagName = "non-focus-trapping";
+
+      @property({ type: Boolean }) open = false;
 
       #buttonRef = createRef<HTMLButtonElement>();
 
-      @property({ type: Boolean }) open? = false;
+      constructor() {
+        super();
+        this.listen("keydown", (event) => {
+          if (event.key === "Escape" && !event.defaultPrevented) {
+            this.open = false;
+            event.preventDefault();
+          }
+        });
+      }
 
       override updated(changes: PropertyValues<this>): void {
         if (changes.has("open")) {
@@ -362,23 +369,12 @@ describe("useFocusTrap", () => {
       }
 
       override render(): JsxNode {
-        return (
-          <div
-            onKeyDown={(event) => {
-              if (event.key === "Escape" && !event.defaultPrevented) {
-                this.open = false;
-                event.preventDefault();
-              }
-            }}
-          >
-            {this.open ? (
-              <div>
-                <slot />
-                <button ref={this.#buttonRef}>fake close button</button>
-              </div>
-            ) : null}
+        return this.open ? (
+          <div>
+            <slot />
+            <button ref={this.#buttonRef}>close</button>
           </div>
-        );
+        ) : null;
       }
     }
 
@@ -388,19 +384,17 @@ describe("useFocusTrap", () => {
           <focus-trapping open data-testid="focus-trapping"></focus-trapping>
         </non-focus-trapping>
       `,
-      { dynamicComponents: [NonFocusTrapping, FocusTrapping] },
+      { dynamicComponents: [NonFocusTrapComponent, FocusTrapComponent] },
     );
-    const nonFocusTrapping = page.getByTestId("non-focus-trapping");
-    const focusTrapping = nonFocusTrapping.getByTestId("focus-trapping");
+    const nonTrap = page.getByTestId("non-focus-trapping");
+    const trap = nonTrap.getByTestId("focus-trapping");
 
-    await expect.element(focusTrapping).toHaveFocus();
-    await expect.element(nonFocusTrapping).not.toHaveFocus();
+    await expect.element(trap).toHaveFocus();
 
     await userEvent.keyboard("{Escape}");
 
-    await expect.element(focusTrapping).not.toHaveFocus();
-    await expect.element(nonFocusTrapping).toHaveFocus();
-    await expect.element(focusTrapping).toHaveProperty("open", false);
-    await expect.element(nonFocusTrapping).toHaveProperty("open", true);
+    await expect.element(nonTrap).toHaveFocus();
+    await expect.element(trap).toHaveProperty("open", false);
+    await expect.element(nonTrap).toHaveProperty("open", true);
   });
 });

--- a/packages/components/src/controllers/useFocusTrap.ts
+++ b/packages/components/src/controllers/useFocusTrap.ts
@@ -144,6 +144,7 @@ export function createFocusTrapOptions(
 ): Options {
   const fallbackFocus = options?.fallbackFocus || hostEl;
   const clickOutsideDeactivates = options?.clickOutsideDeactivates ?? true;
+  let abortController: AbortController | undefined;
 
   return {
     fallbackFocus,
@@ -158,6 +159,27 @@ export function createFocusTrapOptions(
         outsideClickDeactivated.add(hostEl);
       }
       return typeof clickOutsideDeactivates === "function" ? clickOutsideDeactivates(event) : clickOutsideDeactivates;
+    },
+    onActivate: () => {
+      if (options?.escapeDeactivates) {
+        abortController = new AbortController();
+        hostEl.addEventListener(
+          "keydown",
+          (event) => {
+            // we check for Escape at each focus-trap host as the event bubbles
+            // in case non-focus-trapping elements in between handle (e.g., cancel) it
+            // before it reaches the focus-trap document-level listener
+            if (event.key === "Escape" && typeof options?.escapeDeactivates === "function") {
+              options.escapeDeactivates(event);
+            }
+          },
+          { signal: abortController.signal },
+        );
+      }
+    },
+    onDeactivate: () => {
+      abortController?.abort();
+      abortController = undefined;
     },
     onPostDeactivate: () => {
       outsideClickDeactivated.delete(hostEl);

--- a/packages/components/src/controllers/useFocusTrap.ts
+++ b/packages/components/src/controllers/useFocusTrap.ts
@@ -176,10 +176,13 @@ export function createFocusTrapOptions(
           { signal: abortController.signal },
         );
       }
+
+      options?.onActivate?.();
     },
     onDeactivate: () => {
       abortController?.abort();
       abortController = undefined;
+      options?.onDeactivate?.();
     },
     onPostDeactivate: () => {
       outsideClickDeactivated.delete(hostEl);


### PR DESCRIPTION
**Related Issue:** #13225

## Summary

This updates `Escape` handling to run at each focus trap host as the event bubbles.
It addresses cases where non-focus-trapping elements between nested traps handle or cancel the event before it reaches the [document-level listener used by `focus-trap`](https://github.com/focus-trap/focus-trap/blob/master/index.js#L899).

By handling `Escape` earlier, nested traps preserve the expected behavior and ordering regardless of intermediate listeners.