### PR TITLE
docs(autocomplete): clarify `icon`'s default behavior

### DIFF
--- a/packages/components/src/components/autocomplete/autocomplete.tsx
+++ b/packages/components/src/components/autocomplete/autocomplete.tsx
@@ -190,7 +190,11 @@ export class Autocomplete
    */
   @property({ reflect: true }) form: string;
 
-  /** When `true`, shows a default recommended icon. Alternatively, pass a Calcite UI Icon name to display a specific icon. */
+  /**
+   * When `true` or not set, shows a default recommended icon. Alternatively, pass a Calcite UI Icon name to display a specific icon.
+   *
+   * To hide the default icon, set the property to `false`.
+   */
   @property({ reflect: true, converter: stringOrBoolean, type: String }) icon: IconName | boolean;
 
   /** When `true`, the icon will be flipped when the element direction is right-to-left (`"rtl"`). */

--- a/packages/components/src/components/autocomplete/autocomplete.tsx
+++ b/packages/components/src/components/autocomplete/autocomplete.tsx
@@ -193,7 +193,7 @@ export class Autocomplete
   /**
    * When `true` or not set, shows a default recommended icon. Alternatively, pass a Calcite UI Icon name to display a specific icon.
    *
-   * To hide the default icon, set the property to `false`.
+   * To hide the default icon, set the property to `false` using JavaScript.
    */
   @property({ reflect: true, converter: stringOrBoolean, type: String }) icon: IconName | boolean;
 


### PR DESCRIPTION
**Related Issue:** #14240

## Summary
Clarifies Autocomplete's `icon` documentation to specify that with no value set, a default icon will still display, and how to remove the default icon.
