### PR TITLE
fix(link): prevent redirect on empty `href`

### DIFF
--- a/packages/components/src/components/link/link.browser.e2e.tsx
+++ b/packages/components/src/components/link/link.browser.e2e.tsx
@@ -1,7 +1,9 @@
 import { h } from "@arcgis/lumina";
-import { describe } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
+import { userEvent } from "vitest/browser";
 import { defaults, disabled, focusable, hidden, renders } from "../../tests/commonTests/browser";
+import type { Link } from "./link";
 
 describe("defaults", () => {
   defaults(
@@ -35,4 +37,86 @@ describe("renders", () => {
 
 describe("disabled", () => {
   disabled(() => mount(<calcite-link href="/">link</calcite-link>));
+});
+
+describe("link interactivity", () => {
+  let navigateHandler: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    navigateHandler = vi.fn().mockImplementation((event) => {
+      // prevent redirect and losing connection to iframe
+      event.preventDefault();
+    });
+    // @ts-expect-error -- using new navigation API -- https://developer.mozilla.org/en-US/docs/Web/API/Navigation/navigate_event
+    window.navigation.addEventListener("navigate", navigateHandler);
+  });
+
+  afterEach(() => {
+    // @ts-expect-error -- using new navigation API -- https://developer.mozilla.org/en-US/docs/Web/API/Navigation/navigate_event
+    window.navigation.removeEventListener("navigate", navigateHandler);
+  });
+
+  const targetPage = "#test";
+  let link: Link["el"];
+  let targetUrl: string;
+
+  beforeEach(async () => {
+    ({ el: link } = await mount<Link>(<calcite-link href={`/${targetPage}`}>link</calcite-link>));
+    targetUrl = `${window.location.origin}/${targetPage}`;
+  });
+
+  describe("keyboard", () => {
+    it("redirects on activation", async () => {
+      await userEvent.keyboard("{Tab}{Enter}");
+      expect(navigateHandler).toHaveBeenCalledTimes(1);
+      expect(navigateHandler.mock.lastCall![0].destination.url).toBe(targetUrl);
+    });
+
+    it("does not redirect without href", async () => {
+      const clickHandler = vi.fn();
+      link.addEventListener("click", clickHandler);
+      link.href = undefined;
+
+      await userEvent.keyboard("{Tab}{Enter}");
+      expect(navigateHandler).not.toHaveBeenCalled();
+      expect(clickHandler).toHaveBeenCalledTimes(1);
+
+      link.href = "";
+      await userEvent.keyboard("{Enter}");
+      expect(navigateHandler).not.toHaveBeenCalled();
+      expect(clickHandler).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("mouse", () => {
+    it("redirects on activation", async () => {
+      await userEvent.click(link);
+      expect(navigateHandler).toHaveBeenCalledTimes(1);
+      expect(navigateHandler.mock.lastCall![0].destination.url).toBe(targetUrl);
+    });
+
+    it("does not redirect without href", async () => {
+      const clickHandler = vi.fn();
+      link.addEventListener("click", clickHandler);
+      link.href = undefined;
+
+      await userEvent.click(link);
+      expect(navigateHandler).not.toHaveBeenCalled();
+      expect(clickHandler).toHaveBeenCalledTimes(1);
+
+      link.href = "";
+      await userEvent.click(link);
+      expect(navigateHandler).not.toHaveBeenCalled();
+      expect(clickHandler).toHaveBeenCalledTimes(2);
+    });
+
+    it("redirects on link.click()", async () => {
+      const clickEvent = vi.fn();
+      link.addEventListener("click", clickEvent);
+      link.click();
+      expect(navigateHandler).toHaveBeenCalledTimes(1);
+      expect(navigateHandler.mock.lastCall![0].destination.url).toBe(targetUrl);
+      expect(clickEvent).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/packages/components/src/components/link/link.e2e.ts
+++ b/packages/components/src/components/link/link.e2e.ts
@@ -1,6 +1,6 @@
 // @ts-strict-ignore
-import { newE2EPage, E2EPage, E2EElement } from "@arcgis/lumina-compiler/puppeteerTesting";
-import { describe, expect, it, beforeEach } from "vitest";
+import { newE2EPage, E2EElement } from "@arcgis/lumina-compiler/puppeteerTesting";
+import { describe, expect, it } from "vitest";
 import { accessible, themed } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 import { CSS } from "./resources";
@@ -156,69 +156,6 @@ it('renders with an icon-start and icon-end and role="button"', async () => {
   expect(iconStart).not.toBeNull();
   expect(elementAsLink).toEqualAttribute("role", "button");
   expect(iconEnd).not.toBeNull();
-});
-
-describe("link interactivity", () => {
-  const targetPage = "#test";
-
-  let page: E2EPage;
-  let pageUrl: string;
-  let targetUrl: string;
-
-  beforeEach(async () => {
-    page = await newE2EPage({
-      html: `<calcite-link href="/${targetPage}">link</calcite-link>`,
-    });
-
-    pageUrl = page.url();
-    targetUrl = `${pageUrl}${targetPage}`;
-  });
-
-  it("keyboard", async () => {
-    const element = await page.find("calcite-link");
-    await element.callMethod("setFocus");
-    await page.waitForChanges();
-    await page.keyboard.press("Enter");
-    await page.waitForChanges();
-
-    expect(page.url()).toBe(targetUrl);
-  });
-
-  it("keyboard without href", async () => {
-    const element = await page.find("calcite-link");
-    const clickEvent = await element.spyOnEvent("click");
-    element.setProperty("href", undefined);
-    await page.waitForChanges();
-
-    await element.callMethod("setFocus");
-    await page.waitForChanges();
-    await page.keyboard.press("Enter");
-    await page.waitForChanges();
-    expect(clickEvent).toHaveReceivedEventTimes(1);
-  });
-
-  it("mouse", async () => {
-    // workaround for https://github.com/puppeteer/puppeteer/issues/2977
-    await page.$eval("calcite-link", (link: HTMLElement): void => {
-      link.shadowRoot.querySelector("a").click();
-    });
-    await page.waitForChanges();
-
-    expect(page.url()).toBe(targetUrl);
-  });
-
-  it("non user-initiated click event", async () => {
-    const link = await page.find("calcite-link");
-    const clickEvent = await link.spyOnEvent("click");
-
-    // helps test click behavior via HTMLElement.click()
-    await link.callMethod("click");
-    await page.waitForChanges();
-
-    expect(page.url()).toBe(targetUrl);
-    // make sure forwarded internal event does not propagate
-    expect(clickEvent).toHaveReceivedEventTimes(1);
-  });
 });
 
 describe("theme", () => {

--- a/packages/components/src/components/link/link.tsx
+++ b/packages/components/src/components/link/link.tsx
@@ -144,7 +144,7 @@ export class Link extends LitElement {
             This works around that issue for now.
           */
           download={download === true || download === "" ? "" : download || undefined}
-          href={this.href}
+          href={this.href || undefined}
           onClick={this.anchorClickHandler}
           onKeyDown={actAsButton ? this.keyDownHandler : undefined}
           ref={this.anchorRef}

--- a/packages/components/src/components/link/link.tsx
+++ b/packages/components/src/components/link/link.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { LitElement, property, h, method, JsxNode, stringOrBoolean } from "@arcgis/lumina";
 import { createRef } from "lit/directives/ref.js";
 import { useDirection } from "@arcgis/lumina/controllers";
@@ -7,6 +6,7 @@ import { FlipContext } from "../interfaces";
 import { IconName } from "../icon/interfaces";
 import { useSetFocus } from "../../controllers/useSetFocus";
 import { useInteractive } from "../../controllers/useInteractive";
+import { isActivationKey } from "../../utils/key";
 import { styles } from "./link.scss";
 import { CSS } from "./resources";
 
@@ -34,7 +34,7 @@ export class Link extends LitElement {
 
   //#region Private Properties
 
-  private childRef = createRef<HTMLAnchorElement>();
+  private anchorRef = createRef<HTMLAnchorElement>();
 
   private direction = useDirection();
 
@@ -43,25 +43,15 @@ export class Link extends LitElement {
   private interactiveContainer = useInteractive(this);
 
   private keyDownHandler = (event: KeyboardEvent): void => {
-    if (this.disabled) {
-      return;
-    }
-
-    const { key } = event;
-
-    if (key === "Enter" || key === " ") {
+    if (isActivationKey(event.key)) {
       event.preventDefault();
       this.el.click();
     }
   };
 
-  private childElClickHandler = (event: MouseEvent): void => {
-    if (this.disabled) {
-      event.preventDefault();
-      event.stopPropagation();
-      return;
-    }
+  private anchorClickHandler = (event: MouseEvent): void => {
     if (!event.isTrusted) {
+      // click was invoked internally, we stop it here
       event.stopPropagation();
     }
   };
@@ -82,22 +72,22 @@ export class Link extends LitElement {
   @property({ reflect: true, converter: stringOrBoolean }) download: string | boolean = false;
 
   /** Specifies the URL of the linked resource, which can be set as an absolute or relative path. */
-  @property({ reflect: true }) href: string;
+  @property({ reflect: true }) href?: string;
 
   /** Specifies an icon to display at the end of the component. */
-  @property({ reflect: true, type: String }) iconEnd: IconName;
+  @property({ reflect: true, type: String }) iconEnd?: IconName;
 
   /** When `true` and the element direction is right-to-left (`"rtl"`), flips the component's `iconStart` and/or `iconEnd`. */
-  @property({ reflect: true }) iconFlipRtl: FlipContext;
+  @property({ reflect: true }) iconFlipRtl?: FlipContext;
 
   /** Specifies an icon to display at the start of the component. */
-  @property({ reflect: true, type: String }) iconStart: IconName;
+  @property({ reflect: true, type: String }) iconStart?: IconName;
 
   /** Specifies the relationship to the linked resource defined in `href`. */
-  @property() rel: string;
+  @property() rel?: string;
 
   /** Specifies the frame or window to open the linked resource. */
-  @property() target: string;
+  @property() target?: string;
 
   //#endregion
 
@@ -112,7 +102,7 @@ export class Link extends LitElement {
    */
   @method()
   async setFocus(options?: FocusOptions): Promise<void> {
-    return this.focusSetter(() => this.childRef.value, options);
+    return this.focusSetter(() => this.anchorRef.value, options);
   }
 
   //#endregion
@@ -129,12 +119,8 @@ export class Link extends LitElement {
   //#region Private Methods
 
   private clickHandler(event: PointerEvent): void {
-    if (this.disabled) {
-      return;
-    }
-
     if (!event.isTrusted) {
-      this.childRef.value.click();
+      this.anchorRef.value?.click();
     }
   }
 
@@ -145,49 +131,51 @@ export class Link extends LitElement {
   override render(): JsxNode {
     const { download } = this;
     const dir = this.direction;
-    const iconStartEl = (
-      <calcite-icon
-        class={{ [CSS.calciteLinkIcon]: true, [CSS.iconStart]: true }}
-        flipRtl={this.iconFlipRtl === "start" || this.iconFlipRtl === "both"}
-        icon={this.iconStart}
-        scale="s"
-      />
-    );
-
-    const iconEndEl = (
-      <calcite-icon
-        class={{ [CSS.calciteLinkIcon]: true, [CSS.iconEnd]: true }}
-        flipRtl={this.iconFlipRtl === "end" || this.iconFlipRtl === "both"}
-        icon={this.iconEnd}
-        scale="s"
-      />
-    );
-
     const actAsButton = !this.href;
     /* TODO: [MIGRATION] This used <Host> before. In Stencil, <Host> props overwrite user-provided props. If you don't wish to overwrite user-values, replace "=" here with "??=" */
     this.el.role = "presentation";
 
     return (
       <this.interactiveContainer disabled={this.disabled}>
-        {/* prettier-ignore */}
         <a
-          aria-disabled={this.disabled || undefined}
           class={{ [CSS_UTILITY.rtl]: dir === "rtl" }}
           /*
             When the 'download' property of type 'boolean | string' is set to true, the value is "".
             This works around that issue for now.
           */
-          download={download === true || download === "" ? "" : download || null}
+          download={download === true || download === "" ? "" : download || undefined}
           href={this.href}
-          onClick={this.childElClickHandler}
+          onClick={this.anchorClickHandler}
           onKeyDown={actAsButton ? this.keyDownHandler : undefined}
-          ref={this.childRef}
+          ref={this.anchorRef}
           rel={this.rel}
-          role={actAsButton ? "button" : null}
+          role={actAsButton ? "button" : undefined}
           tabIndex={actAsButton ? 0 : undefined}
           target={this.href ? this.target : undefined}
-        >{this.iconStart ? iconStartEl : null}<slot />{this.iconEnd ? iconEndEl : null}</a>
+        >
+          {this.iconStart ? this.renderIcon("start") : null}
+          <slot />
+          {this.iconEnd ? this.renderIcon("end") : null}
+        </a>
       </this.interactiveContainer>
+    );
+  }
+
+  private renderIcon(position: "start" | "end"): JsxNode {
+    const isStart = position === "start";
+    const icon = isStart ? this.iconStart : this.iconEnd;
+    const shouldFlip = this.iconFlipRtl === "both" || this.iconFlipRtl === position;
+
+    return (
+      <calcite-icon
+        class={{
+          [CSS.calciteLinkIcon]: true,
+          [isStart ? CSS.iconStart : CSS.iconEnd]: true,
+        }}
+        flipRtl={shouldFlip}
+        icon={icon}
+        scale="s"
+      />
     );
   }
 


### PR DESCRIPTION
**Related Issue:** #14315 

## Summary

Fixes regression from https://github.com/Esri/calcite-design-system/pull/13784 that caused an empty `href` to redirect when clicked.

**Note**: this also migrates link interaction tests to browser mode