### PR TITLE
fix(list): fix nested list-item property inheritance in calcite-list

### DIFF
--- a/packages/components/src/components/list/list.browser.e2e.tsx
+++ b/packages/components/src/components/list/list.browser.e2e.tsx
@@ -515,6 +515,34 @@ describe("nested selection modes", () => {
       expect(nestedMultipleItem).toHaveProperty("interactionMode", "interactive");
     };
 
+    const nestedPropertiesSettled = (): boolean => {
+      return (
+        nestedNoneDragEnabledItem.selectionMode === "none" &&
+        nestedNoneDragEnabledItem.scale === "s" &&
+        nestedNoneDragEnabledItem.selectionAppearance === "highlight" &&
+        nestedNoneDragEnabledItem.interactionMode === "static" &&
+        nestedNoneItem.selectionMode === "none" &&
+        nestedNoneItem.scale === "s" &&
+        nestedNoneItem.selectionAppearance === "highlight" &&
+        nestedNoneItem.interactionMode === "interactive" &&
+        nestedMultipleItem.selectionMode === "multiple" &&
+        nestedMultipleItem.scale === "s" &&
+        nestedMultipleItem.selectionAppearance === "highlight" &&
+        nestedMultipleItem.interactionMode === "interactive"
+      );
+    };
+
+    const waitForNestedPropertiesToSettle = async (): Promise<void> => {
+      for (let i = 0; i < 10; i++) {
+        if (nestedPropertiesSettled()) {
+          return;
+        }
+
+        await afterNextTask();
+        await afterNextFrame();
+      }
+    };
+
     // Assert immediately after initial render.
     assertSelectionModes();
 
@@ -543,8 +571,7 @@ describe("nested selection modes", () => {
     nestedListMultiple.selectionAppearance = "highlight";
     nestedListMultiple.interactionMode = "interactive";
 
-    await afterNextTask();
-    await afterNextFrame();
+    await waitForNestedPropertiesToSettle();
     assertAllNestedProperties();
 
     // Trigger parent-list updates that should not overwrite nested-list item props.
@@ -563,8 +590,7 @@ describe("nested selection modes", () => {
     rootListThree.selectionAppearance = "icon";
     rootListThree.interactionMode = "static";
 
-    await afterNextTask();
-    await afterNextFrame();
+    await waitForNestedPropertiesToSettle();
     assertAllNestedProperties();
   });
 });

--- a/packages/components/src/components/list/list.browser.e2e.tsx
+++ b/packages/components/src/components/list/list.browser.e2e.tsx
@@ -13,6 +13,7 @@ import {
   t9n,
 } from "../../tests/commonTests/browser";
 import { CSS as listItemGroupCSS } from "../list-item-group/resources";
+import type { ListItem } from "../list-item/list-item";
 import { afterNextFrame } from "../../tests/utils/timing";
 import { waitForEvent } from "../../tests/commonTests/browser/utils";
 import { DEBOUNCE } from "../../utils/resources";
@@ -421,7 +422,7 @@ describe("nested selection modes", () => {
             <calcite-list
               display-mode="flat"
               id="nested-list-none"
-              interaction-mode="static"
+              interaction-mode="interactive"
               label="Sub-level list"
               scale="s"
               selection-appearance="highlight"
@@ -459,54 +460,90 @@ describe("nested selection modes", () => {
 
     await afterNextFrame();
 
-    page.getBySelector("#nested-list-none-drag-enabled").element().setAttribute("scale", "s");
-    page
-      .getBySelector("#nested-list-none-drag-enabled")
-      .element()
-      .setAttribute("selection-appearance", "highlight");
-    page
-      .getBySelector("#nested-list-none-drag-enabled")
-      .element()
-      .setAttribute("interaction-mode", "static");
+    const nestedNoneDragEnabledItem = document.getElementById("nested-none-item-drag-enabled") as
+      | ListItem["el"]
+      | null;
+    const nestedNoneItem = document.getElementById("nested-none-item") as ListItem["el"] | null;
+    const nestedMultipleItem = document.getElementById("nested-multiple-item") as
+      | ListItem["el"]
+      | null;
 
-    page.getBySelector("#nested-list-none").element().setAttribute("scale", "s");
-    page
-      .getBySelector("#nested-list-none")
-      .element()
-      .setAttribute("selection-appearance", "highlight");
-    page.getBySelector("#nested-list-none").element().setAttribute("interaction-mode", "static");
+    const rootListOne = document.getElementById("root-list-one") as List["el"] | null;
+    const rootListTwo = document.getElementById("root-list-two") as List["el"] | null;
+    const rootListThree = document.getElementById("root-list-three") as List["el"] | null;
+    const nestedListNoneDragEnabled = document.getElementById("nested-list-none-drag-enabled") as
+      | List["el"]
+      | null;
+    const nestedListNone = document.getElementById("nested-list-none") as List["el"] | null;
+    const nestedListMultiple = document.getElementById("nested-list-multiple") as List["el"] | null;
 
-    page.getBySelector("#nested-list-multiple").element().setAttribute("scale", "s");
-    page
-      .getBySelector("#nested-list-multiple")
-      .element()
-      .setAttribute("selection-appearance", "highlight");
-    page
-      .getBySelector("#nested-list-multiple")
-      .element()
-      .setAttribute("interaction-mode", "interactive");
+    expect(nestedNoneDragEnabledItem).not.toBeNull();
+    expect(nestedNoneItem).not.toBeNull();
+    expect(nestedMultipleItem).not.toBeNull();
+    expect(rootListOne).not.toBeNull();
+    expect(rootListTwo).not.toBeNull();
+    expect(rootListThree).not.toBeNull();
+    expect(nestedListNoneDragEnabled).not.toBeNull();
+    expect(nestedListNone).not.toBeNull();
+
+    const assertSelectionModes = (): void => {
+      expect(nestedNoneDragEnabledItem).toHaveProperty("selectionMode", "none");
+      expect(nestedNoneItem).toHaveProperty("selectionMode", "none");
+      expect(nestedMultipleItem).toHaveProperty("selectionMode", "multiple");
+    };
+
+    const assertAllNestedProperties = (): void => {
+      assertSelectionModes();
+
+      expect(nestedNoneDragEnabledItem).toHaveProperty("scale", "s");
+      expect(nestedNoneDragEnabledItem).toHaveProperty("selectionAppearance", "highlight");
+      expect(nestedNoneDragEnabledItem).toHaveProperty("interactionMode", "static");
+
+      expect(nestedNoneItem).toHaveProperty("scale", "s");
+      expect(nestedNoneItem).toHaveProperty("selectionAppearance", "highlight");
+      expect(nestedNoneItem).toHaveProperty("interactionMode", "interactive");
+
+      expect(nestedMultipleItem).toHaveProperty("scale", "s");
+      expect(nestedMultipleItem).toHaveProperty("selectionAppearance", "highlight");
+      expect(nestedMultipleItem).toHaveProperty("interactionMode", "interactive");
+    };
+
+    // Assert immediately after initial render.
+    assertSelectionModes();
+
+    // Establish nested list-item baselines from nested list updates.
+    nestedListNoneDragEnabled.scale = "s";
+    nestedListNoneDragEnabled.selectionAppearance = "highlight";
+    nestedListNoneDragEnabled.interactionMode = "static";
+
+    nestedListNone.scale = "s";
+    nestedListNone.selectionAppearance = "highlight";
+    nestedListNone.interactionMode = "interactive";
+
+    nestedListMultiple.scale = "s";
+    nestedListMultiple.selectionAppearance = "highlight";
+    nestedListMultiple.interactionMode = "interactive";
 
     await afterNextFrame();
+    assertAllNestedProperties();
 
-    const nestedNoneDragEnabledItem = page
-      .getBySelector("#nested-none-item-drag-enabled")
-      .element();
-    const nestedNoneItem = page.getBySelector("#nested-none-item").element();
-    const nestedMultipleItem = page.getBySelector("#nested-multiple-item").element();
+    // Trigger parent-list updates that should not overwrite nested-list item props.
+    rootListOne.selectionMode = "single";
+    rootListOne.scale = "m";
+    rootListOne.selectionAppearance = "icon";
+    rootListOne.interactionMode = "static";
 
-    expect(nestedNoneDragEnabledItem).toHaveProperty("selectionMode", "none");
-    expect(nestedNoneDragEnabledItem).toHaveProperty("scale", "s");
-    expect(nestedNoneDragEnabledItem).toHaveProperty("selectionAppearance", "highlight");
-    expect(nestedNoneDragEnabledItem).toHaveProperty("interactionMode", "static");
+    rootListTwo.selectionMode = "single";
+    rootListTwo.scale = "m";
+    rootListTwo.selectionAppearance = "icon";
+    rootListTwo.interactionMode = "static";
 
-    expect(nestedNoneItem).toHaveProperty("selectionMode", "none");
-    expect(nestedNoneItem).toHaveProperty("scale", "s");
-    expect(nestedNoneItem).toHaveProperty("selectionAppearance", "highlight");
-    expect(nestedNoneItem).toHaveProperty("interactionMode", "static");
+    rootListThree.selectionMode = "single";
+    rootListThree.scale = "m";
+    rootListThree.selectionAppearance = "icon";
+    rootListThree.interactionMode = "static";
 
-    expect(nestedMultipleItem).toHaveProperty("selectionMode", "multiple");
-    expect(nestedMultipleItem).toHaveProperty("scale", "s");
-    expect(nestedMultipleItem).toHaveProperty("selectionAppearance", "highlight");
-    expect(nestedMultipleItem).toHaveProperty("interactionMode", "interactive");
+    await afterNextFrame();
+    assertAllNestedProperties();
   });
 });

--- a/packages/components/src/components/list/list.browser.e2e.tsx
+++ b/packages/components/src/components/list/list.browser.e2e.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { h } from "@arcgis/lumina";
+import { Fragment, h } from "@arcgis/lumina";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import { page, userEvent } from "vitest/browser";
 import {
@@ -14,7 +14,7 @@ import {
 } from "../../tests/commonTests/browser";
 import { CSS as listItemGroupCSS } from "../list-item-group/resources";
 import type { ListItem } from "../list-item/list-item";
-import { afterNextFrame } from "../../tests/utils/timing";
+import { afterNextFrame, afterNextTask } from "../../tests/utils/timing";
 import { waitForEvent } from "../../tests/commonTests/browser/utils";
 import { DEBOUNCE } from "../../utils/resources";
 import { List } from "./list";
@@ -384,8 +384,9 @@ describe("group filtering", () => {
 describe("nested selection modes", () => {
   it("preserves each nested list's direct-item properties", async () => {
     await mount(
-      <div>
+      <>
         <calcite-list
+          data-testid="root-list-one"
           display-mode="nested"
           drag-enabled
           id="root-list-one"
@@ -396,6 +397,7 @@ describe("nested selection modes", () => {
         >
           <calcite-list-item expanded label="Top-level list-item">
             <calcite-list
+              data-testid="nested-list-none-drag-enabled"
               display-mode="flat"
               drag-enabled
               id="nested-list-none-drag-enabled"
@@ -405,11 +407,16 @@ describe("nested selection modes", () => {
               selection-appearance="highlight"
               selection-mode="none"
             >
-              <calcite-list-item id="nested-none-item-drag-enabled" label="Sub-level item" />
+              <calcite-list-item
+                data-testid="nested-none-item-drag-enabled"
+                id="nested-none-item-drag-enabled"
+                label="Sub-level item"
+              />
             </calcite-list>
           </calcite-list-item>
         </calcite-list>
         <calcite-list
+          data-testid="root-list-two"
           display-mode="nested"
           drag-enabled
           id="root-list-two"
@@ -420,6 +427,7 @@ describe("nested selection modes", () => {
         >
           <calcite-list-item expanded label="Top-level list-item">
             <calcite-list
+              data-testid="nested-list-none"
               display-mode="flat"
               id="nested-list-none"
               interaction-mode="interactive"
@@ -428,11 +436,16 @@ describe("nested selection modes", () => {
               selection-appearance="highlight"
               selection-mode="none"
             >
-              <calcite-list-item id="nested-none-item" label="Sub-level item" />
+              <calcite-list-item
+                data-testid="nested-none-item"
+                id="nested-none-item"
+                label="Sub-level item"
+              />
             </calcite-list>
           </calcite-list-item>
         </calcite-list>
         <calcite-list
+          data-testid="root-list-three"
           display-mode="nested"
           drag-enabled
           id="root-list-three"
@@ -443,6 +456,7 @@ describe("nested selection modes", () => {
         >
           <calcite-list-item expanded label="Top-level list-item">
             <calcite-list
+              data-testid="nested-list-multiple"
               display-mode="flat"
               id="nested-list-multiple"
               interaction-mode="interactive"
@@ -451,45 +465,33 @@ describe("nested selection modes", () => {
               selection-appearance="highlight"
               selection-mode="multiple"
             >
-              <calcite-list-item id="nested-multiple-item" label="Sub-level item" />
+              <calcite-list-item
+                data-testid="nested-multiple-item"
+                id="nested-multiple-item"
+                label="Sub-level item"
+              />
             </calcite-list>
           </calcite-list-item>
         </calcite-list>
-      </div>,
+      </>,
     );
 
     await afterNextFrame();
 
-    const nestedNoneDragEnabledItem = document.getElementById("nested-none-item-drag-enabled") as
-      | ListItem["el"]
-      | null;
-    const nestedNoneItem = document.getElementById("nested-none-item") as ListItem["el"] | null;
-    const nestedMultipleItem = document.getElementById("nested-multiple-item") as
-      | ListItem["el"]
-      | null;
+    const nestedNoneDragEnabledItem = page
+      .getByTestId("nested-none-item-drag-enabled")
+      .element() as ListItem["el"];
+    const nestedNoneItem = page.getByTestId("nested-none-item").element() as ListItem["el"];
+    const nestedMultipleItem = page.getByTestId("nested-multiple-item").element() as ListItem["el"];
 
-    const rootListOne = document.getElementById("root-list-one") as List["el"] | null;
-    const rootListTwo = document.getElementById("root-list-two") as List["el"] | null;
-    const rootListThree = document.getElementById("root-list-three") as List["el"] | null;
-    const nestedListNoneDragEnabled = document.getElementById("nested-list-none-drag-enabled") as
-      | List["el"]
-      | null;
-    const nestedListNone = document.getElementById("nested-list-none") as List["el"] | null;
-    const nestedListMultiple = document.getElementById("nested-list-multiple") as List["el"] | null;
-
-    expect(nestedNoneDragEnabledItem).not.toBeNull();
-    expect(nestedNoneItem).not.toBeNull();
-    expect(nestedMultipleItem).not.toBeNull();
-    expect(rootListOne).not.toBeNull();
-    expect(rootListTwo).not.toBeNull();
-    expect(rootListThree).not.toBeNull();
-    expect(nestedListNoneDragEnabled).not.toBeNull();
-    expect(nestedListNone).not.toBeNull();
-    expect(nestedListMultiple).not.toBeNull();
-
-    if (!nestedListMultiple) {
-      throw new Error("Expected #nested-list-multiple to exist.");
-    }
+    const rootListOne = page.getByTestId("root-list-one").element() as List["el"];
+    const rootListTwo = page.getByTestId("root-list-two").element() as List["el"];
+    const rootListThree = page.getByTestId("root-list-three").element() as List["el"];
+    const nestedListNoneDragEnabled = page
+      .getByTestId("nested-list-none-drag-enabled")
+      .element() as List["el"];
+    const nestedListNone = page.getByTestId("nested-list-none").element() as List["el"];
+    const nestedListMultiple = page.getByTestId("nested-list-multiple").element() as List["el"];
 
     const assertSelectionModes = (): void => {
       expect(nestedNoneDragEnabledItem).toHaveProperty("selectionMode", "none");
@@ -541,7 +543,7 @@ describe("nested selection modes", () => {
     nestedListMultiple.selectionAppearance = "highlight";
     nestedListMultiple.interactionMode = "interactive";
 
-    await new Promise((resolve) => setTimeout(resolve, DEBOUNCE.nextTick));
+    await afterNextTask();
     await afterNextFrame();
     assertAllNestedProperties();
 
@@ -561,7 +563,7 @@ describe("nested selection modes", () => {
     rootListThree.selectionAppearance = "icon";
     rootListThree.interactionMode = "static";
 
-    await new Promise((resolve) => setTimeout(resolve, DEBOUNCE.nextTick));
+    await afterNextTask();
     await afterNextFrame();
     assertAllNestedProperties();
   });

--- a/packages/components/src/components/list/list.browser.e2e.tsx
+++ b/packages/components/src/components/list/list.browser.e2e.tsx
@@ -379,3 +379,65 @@ describe("group filtering", () => {
     expect(el.filteredItems).toHaveLength(4);
   });
 });
+
+describe("nested selection modes", () => {
+  it("preserves each nested list's selectionMode on its own items", async () => {
+    await mount(
+      <div>
+        <calcite-list
+          display-mode="nested"
+          drag-enabled
+          label="Top-level label"
+          selection-mode="single-persist"
+        >
+          <calcite-list-item expanded label="Top-level list-item">
+            <calcite-list
+              display-mode="flat"
+              drag-enabled
+              label="Sub-level list"
+              selection-mode="none"
+            >
+              <calcite-list-item id="nested-none-item-drag-enabled" label="Sub-level item" />
+            </calcite-list>
+          </calcite-list-item>
+        </calcite-list>
+        <calcite-list
+          display-mode="nested"
+          drag-enabled
+          label="Top-level label"
+          selection-mode="single-persist"
+        >
+          <calcite-list-item expanded label="Top-level list-item">
+            <calcite-list display-mode="flat" label="Sub-level list" selection-mode="none">
+              <calcite-list-item id="nested-none-item" label="Sub-level item" />
+            </calcite-list>
+          </calcite-list-item>
+        </calcite-list>
+        <calcite-list
+          display-mode="nested"
+          drag-enabled
+          label="Top-level label"
+          selection-mode="single-persist"
+        >
+          <calcite-list-item expanded label="Top-level list-item">
+            <calcite-list display-mode="flat" label="Sub-level list" selection-mode="multiple">
+              <calcite-list-item id="nested-multiple-item" label="Sub-level item" />
+            </calcite-list>
+          </calcite-list-item>
+        </calcite-list>
+      </div>,
+    );
+
+    await afterNextFrame();
+
+    const nestedNoneDragEnabledItem = page
+      .getBySelector("#nested-none-item-drag-enabled")
+      .element();
+    const nestedNoneItem = page.getBySelector("#nested-none-item").element();
+    const nestedMultipleItem = page.getBySelector("#nested-multiple-item").element();
+
+    expect((nestedNoneDragEnabledItem as any).selectionMode).toBe("none");
+    expect((nestedNoneItem as any).selectionMode).toBe("none");
+    expect((nestedMultipleItem as any).selectionMode).toBe("multiple");
+  });
+});

--- a/packages/components/src/components/list/list.browser.e2e.tsx
+++ b/packages/components/src/components/list/list.browser.e2e.tsx
@@ -381,20 +381,27 @@ describe("group filtering", () => {
 });
 
 describe("nested selection modes", () => {
-  it("preserves each nested list's selectionMode on its own items", async () => {
+  it("preserves each nested list's direct-item properties", async () => {
     await mount(
       <div>
         <calcite-list
           display-mode="nested"
           drag-enabled
+          id="root-list-one"
           label="Top-level label"
+          scale="l"
+          selection-appearance="icon"
           selection-mode="single-persist"
         >
           <calcite-list-item expanded label="Top-level list-item">
             <calcite-list
               display-mode="flat"
               drag-enabled
+              id="nested-list-none-drag-enabled"
+              interaction-mode="static"
               label="Sub-level list"
+              scale="s"
+              selection-appearance="highlight"
               selection-mode="none"
             >
               <calcite-list-item id="nested-none-item-drag-enabled" label="Sub-level item" />
@@ -404,11 +411,22 @@ describe("nested selection modes", () => {
         <calcite-list
           display-mode="nested"
           drag-enabled
+          id="root-list-two"
           label="Top-level label"
+          scale="l"
+          selection-appearance="icon"
           selection-mode="single-persist"
         >
           <calcite-list-item expanded label="Top-level list-item">
-            <calcite-list display-mode="flat" label="Sub-level list" selection-mode="none">
+            <calcite-list
+              display-mode="flat"
+              id="nested-list-none"
+              interaction-mode="static"
+              label="Sub-level list"
+              scale="s"
+              selection-appearance="highlight"
+              selection-mode="none"
+            >
               <calcite-list-item id="nested-none-item" label="Sub-level item" />
             </calcite-list>
           </calcite-list-item>
@@ -416,11 +434,22 @@ describe("nested selection modes", () => {
         <calcite-list
           display-mode="nested"
           drag-enabled
+          id="root-list-three"
           label="Top-level label"
+          scale="l"
+          selection-appearance="icon"
           selection-mode="single-persist"
         >
           <calcite-list-item expanded label="Top-level list-item">
-            <calcite-list display-mode="flat" label="Sub-level list" selection-mode="multiple">
+            <calcite-list
+              display-mode="flat"
+              id="nested-list-multiple"
+              interaction-mode="interactive"
+              label="Sub-level list"
+              scale="s"
+              selection-appearance="highlight"
+              selection-mode="multiple"
+            >
               <calcite-list-item id="nested-multiple-item" label="Sub-level item" />
             </calcite-list>
           </calcite-list-item>
@@ -430,14 +459,54 @@ describe("nested selection modes", () => {
 
     await afterNextFrame();
 
+    page.getBySelector("#nested-list-none-drag-enabled").element().setAttribute("scale", "s");
+    page
+      .getBySelector("#nested-list-none-drag-enabled")
+      .element()
+      .setAttribute("selection-appearance", "highlight");
+    page
+      .getBySelector("#nested-list-none-drag-enabled")
+      .element()
+      .setAttribute("interaction-mode", "static");
+
+    page.getBySelector("#nested-list-none").element().setAttribute("scale", "s");
+    page
+      .getBySelector("#nested-list-none")
+      .element()
+      .setAttribute("selection-appearance", "highlight");
+    page.getBySelector("#nested-list-none").element().setAttribute("interaction-mode", "static");
+
+    page.getBySelector("#nested-list-multiple").element().setAttribute("scale", "s");
+    page
+      .getBySelector("#nested-list-multiple")
+      .element()
+      .setAttribute("selection-appearance", "highlight");
+    page
+      .getBySelector("#nested-list-multiple")
+      .element()
+      .setAttribute("interaction-mode", "interactive");
+
+    await afterNextFrame();
+
     const nestedNoneDragEnabledItem = page
       .getBySelector("#nested-none-item-drag-enabled")
       .element();
     const nestedNoneItem = page.getBySelector("#nested-none-item").element();
     const nestedMultipleItem = page.getBySelector("#nested-multiple-item").element();
 
-    expect((nestedNoneDragEnabledItem as any).selectionMode).toBe("none");
-    expect((nestedNoneItem as any).selectionMode).toBe("none");
-    expect((nestedMultipleItem as any).selectionMode).toBe("multiple");
+    expect(nestedNoneDragEnabledItem).toHaveProperty("selectionMode", "none");
+    expect(nestedNoneDragEnabledItem).toHaveProperty("scale", "s");
+    expect(nestedNoneDragEnabledItem).toHaveProperty("selectionAppearance", "highlight");
+    expect(nestedNoneDragEnabledItem).toHaveProperty("interactionMode", "static");
+
+    expect(nestedNoneItem).toHaveProperty("selectionMode", "none");
+    expect(nestedNoneItem).toHaveProperty("scale", "s");
+    expect(nestedNoneItem).toHaveProperty("selectionAppearance", "highlight");
+    expect(nestedNoneItem).toHaveProperty("interactionMode", "static");
+
+    expect(nestedMultipleItem).toHaveProperty("selectionMode", "multiple");
+    expect(nestedMultipleItem).toHaveProperty("scale", "s");
+    expect(nestedMultipleItem).toHaveProperty("selectionAppearance", "highlight");
+    expect(nestedMultipleItem).toHaveProperty("interactionMode", "interactive");
   });
 });

--- a/packages/components/src/components/list/list.browser.e2e.tsx
+++ b/packages/components/src/components/list/list.browser.e2e.tsx
@@ -485,6 +485,11 @@ describe("nested selection modes", () => {
     expect(rootListThree).not.toBeNull();
     expect(nestedListNoneDragEnabled).not.toBeNull();
     expect(nestedListNone).not.toBeNull();
+    expect(nestedListMultiple).not.toBeNull();
+
+    if (!nestedListMultiple) {
+      throw new Error("Expected #nested-list-multiple to exist.");
+    }
 
     const assertSelectionModes = (): void => {
       expect(nestedNoneDragEnabledItem).toHaveProperty("selectionMode", "none");
@@ -512,18 +517,31 @@ describe("nested selection modes", () => {
     assertSelectionModes();
 
     // Establish nested list-item baselines from nested list updates.
+    nestedListNoneDragEnabled.scale = "l";
+    nestedListNoneDragEnabled.selectionAppearance = "icon";
+    nestedListNoneDragEnabled.interactionMode = "interactive";
+
     nestedListNoneDragEnabled.scale = "s";
     nestedListNoneDragEnabled.selectionAppearance = "highlight";
     nestedListNoneDragEnabled.interactionMode = "static";
+
+    nestedListNone.scale = "l";
+    nestedListNone.selectionAppearance = "icon";
+    nestedListNone.interactionMode = "static";
 
     nestedListNone.scale = "s";
     nestedListNone.selectionAppearance = "highlight";
     nestedListNone.interactionMode = "interactive";
 
+    nestedListMultiple.scale = "l";
+    nestedListMultiple.selectionAppearance = "icon";
+    nestedListMultiple.interactionMode = "static";
+
     nestedListMultiple.scale = "s";
     nestedListMultiple.selectionAppearance = "highlight";
     nestedListMultiple.interactionMode = "interactive";
 
+    await new Promise((resolve) => setTimeout(resolve, DEBOUNCE.nextTick));
     await afterNextFrame();
     assertAllNestedProperties();
 
@@ -543,6 +561,7 @@ describe("nested selection modes", () => {
     rootListThree.selectionAppearance = "icon";
     rootListThree.interactionMode = "static";
 
+    await new Promise((resolve) => setTimeout(resolve, DEBOUNCE.nextTick));
     await afterNextFrame();
     assertAllNestedProperties();
   });

--- a/packages/components/src/components/list/list.e2e.ts
+++ b/packages/components/src/components/list/list.e2e.ts
@@ -312,10 +312,12 @@ it("should set the scale property on items", async () => {
   await page.waitForChanges();
   await page.waitForTimeout(DEBOUNCE.filter);
 
-  const items = await findAll(page, "calcite-list-item");
+  const rootListItems = await findAll(page, "#root > calcite-list-item");
 
-  for (let i = 0; i < items.length; i++) {
-    expect(await items[i].getProperty("scale")).toBe("m");
+  expect(rootListItems).toHaveLength(3);
+
+  for (let i = 0; i < rootListItems.length; i++) {
+    expect(await rootListItems[i].getProperty("scale")).toBe("m");
   }
 
   const rootList = await page.find("#root");
@@ -324,8 +326,8 @@ it("should set the scale property on items", async () => {
   await page.waitForChanges();
   await page.waitForTimeout(DEBOUNCE.filter);
 
-  for (let i = 0; i < items.length; i++) {
-    expect(await items[i].getProperty("scale")).toBe("s");
+  for (let i = 0; i < rootListItems.length; i++) {
+    expect(await rootListItems[i].getProperty("scale")).toBe("s");
   }
 
   rootList.setProperty("scale", "m");
@@ -333,8 +335,8 @@ it("should set the scale property on items", async () => {
   await page.waitForChanges();
   await page.waitForTimeout(DEBOUNCE.filter);
 
-  for (let i = 0; i < items.length; i++) {
-    expect(await items[i].getProperty("scale")).toBe("m");
+  for (let i = 0; i < rootListItems.length; i++) {
+    expect(await rootListItems[i].getProperty("scale")).toBe("m");
   }
 
   rootList.setProperty("scale", "l");
@@ -342,8 +344,8 @@ it("should set the scale property on items", async () => {
   await page.waitForChanges();
   await page.waitForTimeout(DEBOUNCE.filter);
 
-  for (let i = 0; i < items.length; i++) {
-    expect(await items[i].getProperty("scale")).toBe("l");
+  for (let i = 0; i < rootListItems.length; i++) {
+    expect(await rootListItems[i].getProperty("scale")).toBe("l");
   }
 });
 

--- a/packages/components/src/components/list/list.stories.ts
+++ b/packages/components/src/components/list/list.stories.ts
@@ -6621,3 +6621,26 @@ function getStickyGroupHeaderHTML(filterEnabled = false): string {
 export const stickyGroupHeader = (): string => getStickyGroupHeaderHTML();
 
 export const stickyGroupHeaderFilterEnabled = (): string => getStickyGroupHeaderHTML(true);
+
+export const nestedSelectionModes = (): string =>
+  html`<calcite-list drag-enabled label="Top-level label" display-mode="nested" selection-mode="single-persist">
+      <calcite-list-item expanded label="Top-level list-item">
+        <calcite-list drag-enabled label="Sub-level list" display-mode="flat" selection-mode="none">
+          <calcite-list-item label="Sub-level list-item - should not have any selection"></calcite-list-item>
+        </calcite-list>
+      </calcite-list-item>
+    </calcite-list>
+    <calcite-list drag-enabled label="Top-level label" display-mode="nested" selection-mode="single-persist">
+      <calcite-list-item expanded label="Top-level list-item">
+        <calcite-list label="Sub-level list" display-mode="flat" selection-mode="none">
+          <calcite-list-item label="Sub-level list-item - should not have any selection"></calcite-list-item>
+        </calcite-list>
+      </calcite-list-item>
+    </calcite-list>
+    <calcite-list drag-enabled label="Top-level label" display-mode="nested" selection-mode="single-persist">
+      <calcite-list-item expanded label="Top-level list-item">
+        <calcite-list label="Sub-level list" display-mode="flat" selection-mode="multiple">
+          <calcite-list-item label="Sub-level list-item - should have selection"></calcite-list-item>
+        </calcite-list>
+      </calcite-list-item>
+    </calcite-list>`;

--- a/packages/components/src/components/list/list.tsx
+++ b/packages/components/src/components/list/list.tsx
@@ -491,11 +491,12 @@ export class List extends LitElement {
     const fromElItems = Array.from(fromEl.children).filter(isListItem);
 
     items.forEach((item) => {
-      item.scale = scale;
-      item.selectionAppearance = selectionAppearance;
-      item.selectionMode = selectionMode;
-      item.interactionMode = interactionMode;
       if (item.closest(listSelector) === el) {
+        item.scale = scale;
+        item.selectionAppearance = selectionAppearance;
+        item.selectionMode = selectionMode;
+        item.interactionMode = interactionMode;
+
         item.moveToItems = sortHandleMenuItems.filter((moveToItem) =>
           this.validateSortMenuItem({
             type: "move",


### PR DESCRIPTION
**Related Issue:** #14228

### Summary
This PR fixes nested list behavior so a parent `calcite-list` only propagates list-item properties to its own direct children. Nested list-items now keep the values defined by their owning nested list instead of being overwritten by an ancestor list.

### What Changed
- Updated list-item propagation logic so `scale`, `selectionAppearance`, `selectionMode`, and `interactionMode` are only applied to direct child list-items of the current list.
- Added browser regression coverage for nested lists to verify:
  - nested list-items preserve their own list's `selectionMode` on initial render
  - nested list-items keep their own `scale`, `selectionAppearance`, and `interactionMode`
  - parent list updates do not overwrite nested list-item properties
- Updated e2e coverage for `scale` so root-list scale assertions only target direct root items.
- Added a Storybook/demo scenario to reproduce nested selection/property combinations more easily during manual verification.
- Updated the local demo page to reflect the nested-list regression scenario.

### Why
Previously, ancestor lists could overwrite nested list-item configuration during list-item updates. That caused nested lists with their own selection and interaction settings to behave incorrectly, especially when nested under a parent list with different values.

### Testing
- Added browser regression coverage for nested list property preservation.
- Updated existing e2e coverage for root-list scale propagation.
- Ran the list browser experimental test suite successfully.
- Ran the list stable e2e test suite successfully.

### Impact
- Fixes incorrect inheritance of list-item properties in nested list structures.
- Improves regression protection for nested list behavior.
- Adds clearer manual repro coverage in stories/demo content.