### PR TITLE
chore: drop invalid hydrate references

### DIFF
--- a/packages/components/.gitignore
+++ b/packages/components/.gitignore
@@ -1,6 +1,5 @@
 __docs-temp__/*
 docs/
-hydrate/
 *.js
 !/lint-staged.config.mjs
 src/components/icon/assets

--- a/packages/components/eslint.config.mjs
+++ b/packages/components/eslint.config.mjs
@@ -11,7 +11,7 @@ import storybookPlugin from "eslint-plugin-storybook";
 
 export default tseslint.config(
   {
-    ignores: ["**/dist", "**/docs", "**/hydrate", "**/*.d.ts"],
+    ignores: ["**/dist", "**/docs", "**/*.d.ts"],
   },
 
   {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -17,7 +17,6 @@
     "./components/*/customElement": "./dist/components/*/customElement.js",
     "./components/*": "./dist/components/*/index.js",
     "./types/*": "./dist/types/*.d.ts",
-    "./hydrate": "./hydrate/index.js",
     "./docs/*": "./dist/docs/*",
     "./dist/loader": "./dist/loader.js",
     "./dist/components": "./dist/index.js",
@@ -31,7 +30,6 @@
   "types": "dist/index.d.ts",
   "files": [
     "dist/",
-    "hydrate/",
     "THIRD-PARTY-NOTICES.md"
   ],
   "scripts": {
@@ -41,7 +39,7 @@
     "build:dev": "vite build --mode development",
     "build:watch": "npm run util:prep-build-reqs && vite --mode production",
     "build:watch-dev": "npm run util:prep-build-reqs && vite --mode development",
-    "clean": "npm run util:clean-js-files && rimraf node_modules dist hydrate docs .turbo",
+    "clean": "npm run util:clean-js-files && rimraf node_modules dist docs .turbo",
     "lint": "concurrently npm:lint:*",
     "lint:html": "prettier --ignore-path \"../../.prettierignore\" --write \"**/*.html\" >/dev/null",
     "lint:json": "prettier --ignore-path \"../../.prettierignore\" --write \"**/*.json\" >/dev/null",

--- a/packages/components/tsconfig.eslint.json
+++ b/packages/components/tsconfig.eslint.json
@@ -1,5 +1,5 @@
 {
   "extends": "@esri/calcite-typescript-config/tsconfig.base.json",
   "include": ["**/*", "**/*.config.mjs", "**/.*.cjs", ".storybook/*"],
-  "exclude": ["**/[!_]*assets*/**", "dist", "hydrate", "docs"]
+  "exclude": ["**/[!_]*assets*/**", "dist", "docs"]
 }

--- a/turbo.json
+++ b/turbo.json
@@ -3,7 +3,7 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["**/dist/**", "hydrate/**", "docs/**"]
+      "outputs": ["**/dist/**", "docs/**"]
     },
     "start": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
**Related Issue:** #14157 

## Summary

Removes all references to legacy (Stencil) `hydrate` output.