### PR TITLE
docs(card, card-group): update scale property

### DIFF
--- a/packages/components/src/components/card-group/card-group.tsx
+++ b/packages/components/src/components/card-group/card-group.tsx
@@ -48,7 +48,7 @@ export class CardGroup extends LitElement {
    */
   @property() label: string;
 
-  /** Specifies the size of the component. */
+  /** Specifies the size of the component. Child `calcite-card`s inherit the component's value. */
   @property({ reflect: true }) scale: Scale = "m";
 
   /**

--- a/packages/components/src/components/card/card.tsx
+++ b/packages/components/src/components/card/card.tsx
@@ -92,7 +92,7 @@ export class Card extends LitElement {
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /**
-   * Specifies the size of the component. When the component is within a `calcite-card-group`, the size is inherited from `calcite-card-group` by default, but can also be overridden directly on the component.
+   * Specifies the size of the component. When contained in a parent `calcite-card-group`, inherits the parent's `scale` value, but can be overridden if needed.
    */
   @property({ reflect: true }) scale: Scale = "m";
 

--- a/packages/components/src/components/card/card.tsx
+++ b/packages/components/src/components/card/card.tsx
@@ -92,7 +92,7 @@ export class Card extends LitElement {
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /**
-   * Specifies the size of the component, inherited from `calcite-card-group` by default but can also be set directly on `calcite-card`; defaults to `m`.
+   * Specifies the size of the component. When the component is within a `calcite-card-group`, the size is inherited from `calcite-card-group` by default, but can also be overridden directly on the component.
    */
   @property({ reflect: true }) scale: Scale = "m";
 


### PR DESCRIPTION
**Related Issue:** #12345

## Summary
Update the Card `scale` verbiage to be in alignment with API reference conventions.

Update Card Group to mention that child Cards inherit `scale`.