### PR TITLE
ci(actions): log sync ID `source` when found

### DIFF
--- a/.github/scripts/support/monday.js
+++ b/.github/scripts/support/monday.js
@@ -871,9 +871,9 @@ module.exports = function Monday(issue, core, updateIssueBody) {
       handleMilestone();
     }
 
-    const { id: syncId } = await getId();
+    const { id: syncId, source } = await getId();
     if (syncId) {
-      core.notice(`Sync ID "${syncId}" provided, updating existing item instead of creating new.`, logParams);
+      core.notice(`Sync ID "${syncId}" provided from "${source}", updating existing item instead of creating new.`, logParams);
       setColumnValue(mondayColumns.title, issue.title);
       handleState();
 


### PR DESCRIPTION
**Related Issue:** n/a

## Summary

Updates the syncing log message to include the `source` where the Monday.com ID was found, to help with future debugging.
