### PR TITLE
Fix rating arrow keys in RTL

### DIFF
--- a/packages/components/src/components/rating/rating.e2e.ts
+++ b/packages/components/src/components/rating/rating.e2e.ts
@@ -665,6 +665,38 @@ describe("keyboard interaction", () => {
     expect(changeEvent).toHaveReceivedEventTimes(3);
   });
 
+  it("should update the UI in the physical arrow key direction when dir is rtl", async () => {
+    const page = await newE2EPage();
+    await page.setContent('<calcite-rating dir="rtl" value="3"></calcite-rating>');
+    const element = await page.find("calcite-rating");
+    const labels = await findAll(page, "calcite-rating >>> .star");
+    const changeEvent = await element.spyOnEvent("calciteRatingChange");
+
+    await page.keyboard.press("Tab");
+    await page.keyboard.press("ArrowRight");
+    await page.waitForChanges();
+
+    let hoveredElements = await findAll(page, "calcite-rating >>> .star.hovered");
+    let selectedElements = await findAll(page, "calcite-rating >>> .star.selected");
+
+    expect(element).toEqualAttribute("value", "2");
+    expect(await isElementFocused(page, `[for=${labels[1].getAttribute("for")}]`, { shadowed: true })).toBe(true);
+    expect(hoveredElements.length).toBe(2);
+    expect(selectedElements.length).toBe(2);
+
+    await page.keyboard.press("ArrowLeft");
+    await page.waitForChanges();
+
+    hoveredElements = await findAll(page, "calcite-rating >>> .star.hovered");
+    selectedElements = await findAll(page, "calcite-rating >>> .star.selected");
+
+    expect(element).toEqualAttribute("value", "3");
+    expect(await isElementFocused(page, `[for=${labels[2].getAttribute("for")}]`, { shadowed: true })).toBe(true);
+    expect(hoveredElements.length).toBe(3);
+    expect(selectedElements.length).toBe(3);
+    expect(changeEvent).toHaveReceivedEventTimes(2);
+  });
+
   it("should update the rating when a number key is pressed", async () => {
     const page = await newE2EPage();
     await page.setContent("<calcite-rating></calcite-rating>");

--- a/packages/components/src/components/rating/rating.tsx
+++ b/packages/components/src/components/rating/rating.tsx
@@ -9,6 +9,7 @@ import {
   JsxNode,
   stringOrBoolean,
 } from "@arcgis/lumina";
+import { useDirection } from "@arcgis/lumina/controllers";
 import { guid } from "../../utils/guid";
 import { connectLabel, disconnectLabel, LabelableComponent, getLabelText } from "../../utils/label";
 import { Scale, Status } from "../interfaces";
@@ -47,6 +48,8 @@ export class Rating extends LitElement implements LabelableComponent {
   //#region Private Properties
 
   defaultValue: Rating["value"];
+
+  private direction = useDirection();
 
   private emit = false;
 
@@ -286,12 +289,18 @@ export class Rating extends LitElement implements LabelableComponent {
           this.value = !this.required && this.value === inputValue ? 0 : inputValue;
           break;
         case "ArrowLeft":
-          this.value = this.getPreviousRatingValue(inputValue);
+          this.value =
+            this.direction === "rtl"
+              ? this.getNextRatingValue(inputValue)
+              : this.getPreviousRatingValue(inputValue);
           this.updateFocus();
           event.preventDefault();
           break;
         case "ArrowRight":
-          this.value = this.getNextRatingValue(inputValue);
+          this.value =
+            this.direction === "rtl"
+              ? this.getPreviousRatingValue(inputValue)
+              : this.getNextRatingValue(inputValue);
           this.updateFocus();
           event.preventDefault();
           break;


### PR DESCRIPTION
## Summary
- update calcite-rating arrow-key handling to account for RTL direction
- preserve existing LTR ArrowLeft/ArrowRight behavior
- add RTL keyboard regression coverage

## Related Issue
Fixes #14122

## Tests
- npx prettier --write packages/components/src/components/rating/rating.tsx packages/components/src/components/rating/rating.e2e.ts
- git diff --check
- npm --workspace @esri/eslint-plugin-calcite-components run build
- npm --workspace @esri/calcite-components run util:prep-build-reqs
- npm --workspace @esri/calcite-components run lint:ts -- src/components/rating/rating.tsx src/components/rating/rating.e2e.ts