### PR TITLE
fix(input-text): use placeholder text token

### DIFF
--- a/packages/components/src/components/input-text/input-text.e2e.ts
+++ b/packages/components/src/components/input-text/input-text.e2e.ts
@@ -263,6 +263,10 @@ describe("theme", () => {
         shadowSelector: `input`,
         targetProp: "borderRadius",
       },
+      "--calcite-input-text-placeholder-text-color": {
+        shadowSelector: `input::placeholder`,
+        targetProp: "color",
+      },
     };
     themed(html`<calcite-input-text></calcite-input-text>`, componentTokens);
   });

--- a/packages/components/src/components/input-text/input-text.scss
+++ b/packages/components/src/components/input-text/input-text.scss
@@ -216,7 +216,7 @@ input {
   &:-ms-input-placeholder,
   &::-ms-input-placeholder {
     @apply font-normal;
-    color: var(--calcite-input-number-placeholder-text-color, var(--calcite-color-text-3));
+    color: var(--calcite-input-text-placeholder-text-color, var(--calcite-color-text-3));
   }
 }
 input:focus {


### PR DESCRIPTION
**Related Issue:** #12945

## Summary
- updates the input text placeholder color token reference
- adds coverage for the input text placeholder token in the themed token test

## Tests
- npm exec prettier -- --check packages/components/src/components/input-text/input-text.scss packages/components/src/components/input-text/input-text.e2e.ts
- git diff --check

Note: targeted local e2e could not complete in this container because Chromium requires a usable sandbox.