### PR TITLE
fix(input-time-zone): avoid internal clear-disabled warning

### DIFF
--- a/packages/components/src/components/input-time-zone/input-time-zone.e2e.ts
+++ b/packages/components/src/components/input-time-zone/input-time-zone.e2e.ts
@@ -371,6 +371,17 @@ describe("mode", () => {
 });
 
 describe("clearable", () => {
+  it("does not trigger the internal combobox warning when clearable is disabled", async () => {
+    const page = await newE2EPage();
+    await page.emulateTimezone(testTimeZoneItems[0].name);
+    await page.setContent(html`<calcite-input-time-zone></calcite-input-time-zone>`);
+    await page.waitForChanges();
+
+    expect(console.warn).not.toHaveBeenCalledWith(
+      'clearDisabled is ignored when selection-mode is set to "single-persist"',
+    );
+  });
+
   it("does not allow users to deselect a time zone value by default", async () => {
     const page = await newE2EPage();
     await page.emulateTimezone(testTimeZoneItems[1].name);

--- a/packages/components/src/components/input-time-zone/input-time-zone.tsx
+++ b/packages/components/src/components/input-time-zone/input-time-zone.tsx
@@ -495,7 +495,7 @@ export class InputTimeZone extends LitElement implements LabelableComponent {
     return (
       <this.interactiveContainer disabled={this.disabled}>
         <calcite-combobox
-          clearDisabled={!this.clearable}
+          clearDisabled={this.clearable ? false : undefined}
           disabled={this.disabled}
           label={this.messages.chooseTimeZone}
           labelText={this.labelText}


### PR DESCRIPTION
## Summary
- avoid passing `clearDisabled` to the internal combobox when `calcite-input-time-zone` uses `selection-mode="single-persist"`
- add coverage to ensure the internal combobox warning is not emitted

Closes #13036

## Testing
- `git diff --check`
- `npm --workspace @esri/calcite-components run test:stable -- src/components/input-time-zone/input-time-zone.e2e.ts` (blocked locally: Puppeteer browser launch fails in this container)