### PR TITLE
ci(actions): create or re-sync task when issue is reopened

### DIFF
--- a/.github/scripts/monday/updateState.js
+++ b/.github/scripts/monday/updateState.js
@@ -9,6 +9,13 @@ module.exports = async ({ github, context, core }) => {
       context.payload
     );
   const monday = Monday(issue, core, createBodyUpdater({ github, context, core }));
-  monday.handleState(action);
+
+  if (action === "reopened") {
+    core.notice(`Issue reopened, creating or re-syncing task.`, { title: "Create Task" });
+    await monday.createTask();
+  } else {
+    monday.handleState(action);
+  }
+  
   await monday.commit();
 };


### PR DESCRIPTION
**Related Issue:** #14295

## Summary

Creates or re-syncs all issue data to Monday.com when an issue is `reopened`. Before this, only the `status` of the issue was updated.

This solves de-sync problems with task values, as well as entire tasks if an issue that was closed before Monday syncing began was reopened.

I plan to refactor the Monday sync action to always create/update the whole task, so calling `createTask()` here solves the issues in an efficient manner and starts that effort.

cc @ashetland 
