### PR TITLE
fix(shell-panel): reset resize state when `layout` changes

### DIFF
--- a/packages/components/src/components/shell-panel/shell-panel.browser.e2e.tsx
+++ b/packages/components/src/components/shell-panel/shell-panel.browser.e2e.tsx
@@ -1,13 +1,13 @@
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { h } from "@arcgis/lumina";
-import { it, expect, describe } from "vitest";
+import { describe, expect, it } from "vitest";
 import { userEvent } from "vitest/browser";
 import { commands } from "../../tests/browser/commands";
-import { defaults, reflects, hidden, renders, slots, t9n } from "../../tests/commonTests/browser";
+import { defaults, hidden, reflects, renders, slots, t9n } from "../../tests/commonTests/browser";
 import { mockConsole } from "../../tests/utils/logging";
-import { Dir, Layout } from "../interfaces";
+import { Dir } from "../interfaces";
 import { CSS, SLOTS } from "./resources";
 import type { ShellPanel } from "./shell-panel";
+import type { Shell } from "../shell/shell";
 
 mockConsole();
 
@@ -70,10 +70,17 @@ describe("translation support", () => {
 describe("shell-panel updateSize public method", () => {
   mockConsole();
 
+  type PanelSlot = "panel-start" | "panel-end" | "panel-top" | "panel-bottom";
+  type PanelLayout = ShellPanel["layout"];
+  type ResizeAxis = "inline" | "block";
+  type ComputedSizeProp = "inlineSize" | "blockSize";
+  type SizeCssProp = "--calcite-shell-panel-width" | "--calcite-shell-panel-height";
+  type RectDimensionProp = "width" | "height";
+
   type TestCase = {
     dir: Dir;
     changeAfterMount?: "dir" | "slot" | "position";
-    slot: "panel-start" | "panel-end" | "panel-top" | "panel-bottom";
+    slot: PanelSlot;
     position: ShellPanel["position"];
   };
 
@@ -114,34 +121,104 @@ describe("shell-panel updateSize public method", () => {
     { dir: "rtl", slot: "panel-bottom", position: "end", changeAfterMount: "slot" },
   ];
 
-  function layoutFromPanelSlot(
-    slot: `panel-${"start" | "end" | "top" | "bottom"}`,
-  ): Extract<Layout, "vertical" | "horizontal"> {
+  function layoutFromPanelSlot(slot: PanelSlot): PanelLayout {
     return slot === "panel-start" || slot === "panel-end" ? "vertical" : "horizontal";
   }
 
-  async function setUpShellPanel({ dir, changeAfterMount, slot, position }: Omit<TestCase, never>) {
+  function getCrossAxisResizeTestSlot(slot: PanelSlot): PanelSlot {
     const layout = layoutFromPanelSlot(slot);
-    const requestedShellPanelSlot = slot;
-    const requestedPosition = position;
-    const initialShellPanelSlot =
+
+    return layout === "horizontal"
+      ? slot === "panel-bottom"
+        ? "panel-end"
+        : "panel-start"
+      : slot === "panel-start"
+        ? "panel-top"
+        : "panel-bottom";
+  }
+
+  function getRectDimensionProp(layout: PanelLayout): RectDimensionProp {
+    return layout === "vertical" ? "width" : "height";
+  }
+
+  type SetupResult = Awaited<ReturnType<typeof setUpShellPanel>>;
+  type LayoutResetContext = Pick<
+    SetupResult,
+    "shell" | "content" | "afterConnectContentRect" | "panel"
+  > & {
+    slot: PanelSlot;
+  };
+  type MethodOverrideContext = Pick<
+    SetupResult,
+    | "axis"
+    | "baselineContentSize"
+    | "shell"
+    | "content"
+    | "overrideSize"
+    | "panel"
+    | "computedSizeProp"
+  >;
+
+  async function assertLayoutChangeResetsSize({
+    shell,
+    content,
+    afterConnectContentRect,
+    panel,
+    slot,
+  }: LayoutResetContext): Promise<void> {
+    const layout = layoutFromPanelSlot(slot);
+    panel.slot = getCrossAxisResizeTestSlot(slot);
+    await panel.manager.component.updateComplete;
+    await shell.manager.component.updateComplete;
+    const currentRect = content.getBoundingClientRect();
+    const rectDimensionProp = getRectDimensionProp(layout);
+
+    expect(currentRect[rectDimensionProp]).toBe(afterConnectContentRect[rectDimensionProp]);
+
+    panel.slot = slot;
+    await panel.manager.component.updateComplete;
+    await shell.manager.component.updateComplete;
+  }
+
+  async function assertMethodOverride({
+    axis,
+    baselineContentSize,
+    shell,
+    content,
+    overrideSize,
+    panel,
+    computedSizeProp,
+  }: MethodOverrideContext): Promise<void> {
+    await panel.updateSize({ [axis]: overrideSize });
+    await shell.manager.component.updateComplete;
+    expect(getComputedStyle(content)[computedSizeProp]).toBe(`${overrideSize}px`);
+
+    await panel.updateSize({ [axis]: null });
+    await shell.manager.component.updateComplete;
+    expect(getComputedStyle(content)[computedSizeProp]).toBe(`${baselineContentSize}px`);
+  }
+
+  async function setUpShellPanel({ dir, changeAfterMount, slot, position }: TestCase): Promise<{
+    axis: ResizeAxis;
+    panel: ShellPanel["el"];
+    content: HTMLElement;
+    handle: HTMLElement;
+    shell: Shell["el"];
+    computedSizeProp: ComputedSizeProp;
+    sizeCssProp: SizeCssProp;
+    afterConnectContentRect: DOMRect;
+    baselineContentSize: number;
+    overrideSize: number;
+  }> {
+    const layout = layoutFromPanelSlot(slot);
+    const axis: ResizeAxis = layout === "vertical" ? "inline" : "block";
+    const initialShellPanelSlot: PanelSlot =
       changeAfterMount === "slot"
-        ? layout === "horizontal"
-          ? // we use cross-axis slot for additional coverage
-            requestedShellPanelSlot === "panel-bottom"
-            ? "panel-end"
-            : "panel-start"
-          : requestedShellPanelSlot === "panel-start"
-            ? // we use cross-axis slot for additional coverage
-              "panel-top"
-            : "panel-bottom"
-        : requestedShellPanelSlot;
-    const initialPosition =
-      changeAfterMount === "position"
-        ? requestedPosition === "start"
-          ? "end"
-          : "start"
-        : requestedPosition;
+        ? // we use cross-axis slot for additional coverage
+          getCrossAxisResizeTestSlot(slot)
+        : slot;
+    const initialPosition: ShellPanel["position"] =
+      changeAfterMount === "position" ? (position === "start" ? "end" : "start") : position;
 
     const { el, component } = await mount<"calcite-shell">(
       <calcite-shell dir={changeAfterMount === "dir" ? undefined : dir}>
@@ -151,42 +228,42 @@ describe("shell-panel updateSize public method", () => {
       </calcite-shell>,
     );
     const panel = el.querySelector("calcite-shell-panel")!;
+    const content = panel.shadowRoot!.querySelector<HTMLElement>(`.${CSS.content}`)!;
+    const handle = panel.shadowRoot!.querySelector<HTMLElement>(`.${CSS.resizeHandle}`)!;
+    const sizeCssProp =
+      layout === "horizontal" ? "--calcite-shell-panel-height" : "--calcite-shell-panel-width";
+    const computedSizeProp: ComputedSizeProp = layout === "horizontal" ? "blockSize" : "inlineSize";
+    const afterConnectContentRect = content.getBoundingClientRect();
 
     if (changeAfterMount === "dir") {
       el.dir = dir;
     } else if (changeAfterMount === "slot") {
-      panel.slot = requestedShellPanelSlot;
+      panel.slot = slot;
     } else if (changeAfterMount === "position") {
-      panel.position = requestedPosition;
+      panel.position = position;
     }
 
     await component.updateComplete;
     await panel.manager.component.updateComplete;
 
-    const content = panel.shadowRoot!.querySelector<HTMLElement>(`.${CSS.content}`)!;
-    const handle = panel.shadowRoot!.querySelector<HTMLElement>(`.${CSS.resizeHandle}`)!;
-
-    const dimensionCssProp =
-      layout === "horizontal" ? "--calcite-shell-panel-height" : "--calcite-shell-panel-width";
-    const dimensionProp = layout === "horizontal" ? "blockSize" : "inlineSize";
-
-    const initialSize = parseFloat(getComputedStyle(content)[dimensionProp]);
-    const overrideSize = Math.round(initialSize + 10);
+    const baselineContentSize = parseFloat(getComputedStyle(content)[computedSizeProp]);
+    const overrideSize = Math.round(baselineContentSize + 10);
 
     return {
+      axis,
       panel,
       content,
       handle,
-      component,
-      dimensionProp,
-      dimensionCssProp,
-      initialSize,
+      shell: component,
+      computedSizeProp,
+      sizeCssProp,
+      afterConnectContentRect,
+      baselineContentSize,
       overrideSize,
-      requestedPosition,
     };
   }
 
-  function getUserInteraction({ dir, slot }: Pick<TestCase, "dir" | "slot" | "position">): {
+  function getUserInteraction({ dir, slot }: Pick<TestCase, "dir" | "slot">): {
     keyboardKey: string;
     mouseDelta: {
       dx: number;
@@ -230,19 +307,20 @@ describe("shell-panel updateSize public method", () => {
 
   testCases.forEach(({ dir, changeAfterMount, slot, position }) => {
     const layout = layoutFromPanelSlot(slot);
-    const axis = layout === "vertical" ? "inline" : "block";
-    const { keyboardKey, mouseDelta } = getUserInteraction({ dir, slot, position });
+    const { keyboardKey, mouseDelta } = getUserInteraction({ dir, slot });
 
     const testLabel = `${layout} panel [dir=${dir}, changeAfterMount=${changeAfterMount ?? "none"}, slot=${slot}, position=${position}]`;
 
     it(`default size → token resize → KEYBOARD resize → method resize → clear method override (${testLabel})`, async () => {
       const {
+        axis,
         panel,
         content,
-        component,
-        dimensionProp,
-        dimensionCssProp,
-        initialSize,
+        shell,
+        computedSizeProp,
+        sizeCssProp,
+        afterConnectContentRect,
+        baselineContentSize,
         overrideSize,
       } = await setUpShellPanel({
         dir,
@@ -251,33 +329,50 @@ describe("shell-panel updateSize public method", () => {
         position,
       });
 
-      panel.style.setProperty(dimensionCssProp, `${initialSize}px`);
-      await component.updateComplete;
+      panel.style.setProperty(sizeCssProp, `${baselineContentSize}px`);
+      await shell.manager.component.updateComplete;
 
-      expect(getComputedStyle(content)).toHaveProperty(dimensionProp, `${initialSize}px`);
+      expect(getComputedStyle(content)).toHaveProperty(
+        computedSizeProp,
+        `${baselineContentSize}px`,
+      );
 
       await userEvent.keyboard(`{Tab}${keyboardKey}`);
-      const afterUserResize = parseFloat(getComputedStyle(content)[dimensionProp]);
-      expect(afterUserResize).toBeGreaterThan(initialSize);
+      const afterUserResize = parseFloat(getComputedStyle(content)[computedSizeProp]);
+      expect(afterUserResize).toBeGreaterThan(baselineContentSize);
 
-      await panel.updateSize({ [axis]: overrideSize });
-      await component.updateComplete;
-      expect(getComputedStyle(content)[dimensionProp]).toBe(`${overrideSize}px`);
+      if (changeAfterMount === "slot") {
+        await assertLayoutChangeResetsSize({
+          shell,
+          content,
+          afterConnectContentRect,
+          panel,
+          slot,
+        });
+      }
 
-      await panel.updateSize({ [axis]: null });
-      await component.updateComplete;
-      expect(getComputedStyle(content)[dimensionProp]).toBe(`${initialSize}px`);
+      await assertMethodOverride({
+        axis,
+        baselineContentSize,
+        shell,
+        content,
+        overrideSize,
+        panel,
+        computedSizeProp,
+      });
     });
 
     it(`default size → token resize → MOUSE resize → method resize → clear method override (${testLabel})`, async () => {
       const {
+        axis,
         panel,
         content,
         handle,
-        component,
-        dimensionProp,
-        dimensionCssProp,
-        initialSize,
+        shell,
+        computedSizeProp,
+        sizeCssProp,
+        afterConnectContentRect,
+        baselineContentSize,
         overrideSize,
       } = await setUpShellPanel({
         dir,
@@ -286,9 +381,9 @@ describe("shell-panel updateSize public method", () => {
         position,
       });
 
-      panel.style.setProperty(dimensionCssProp, `${initialSize}px`);
-      await component.updateComplete;
-      expect(getComputedStyle(content)[dimensionProp]).toBe(`${initialSize}px`);
+      panel.style.setProperty(sizeCssProp, `${baselineContentSize}px`);
+      await shell.manager.component.updateComplete;
+      expect(getComputedStyle(content)[computedSizeProp]).toBe(`${baselineContentSize}px`);
 
       const handleRect = handle.getBoundingClientRect();
       const startX = handleRect.left + handleRect.width / 2 + mouseDelta.dx;
@@ -299,16 +394,28 @@ describe("shell-panel updateSize public method", () => {
       await commands.mouseMove(startX, startY);
       await commands.mouseUp();
 
-      const afterUserResize = parseFloat(getComputedStyle(content)[dimensionProp]);
-      expect(afterUserResize).toBeGreaterThan(initialSize);
+      const afterUserResize = parseFloat(getComputedStyle(content)[computedSizeProp]);
+      expect(afterUserResize).toBeGreaterThan(baselineContentSize);
 
-      await panel.updateSize({ [axis]: overrideSize });
-      await component.updateComplete;
-      expect(getComputedStyle(content)[dimensionProp]).toBe(`${overrideSize}px`);
+      if (changeAfterMount === "slot") {
+        await assertLayoutChangeResetsSize({
+          shell,
+          content,
+          afterConnectContentRect,
+          panel,
+          slot,
+        });
+      }
 
-      await panel.updateSize({ [axis]: null });
-      await component.updateComplete;
-      expect(getComputedStyle(content)[dimensionProp]).toBe(`${initialSize}px`);
+      await assertMethodOverride({
+        axis,
+        baselineContentSize,
+        shell,
+        content,
+        overrideSize,
+        panel,
+        computedSizeProp,
+      });
     });
   });
 });

--- a/packages/components/src/components/shell-panel/shell-panel.tsx
+++ b/packages/components/src/components/shell-panel/shell-panel.tsx
@@ -2,7 +2,7 @@
 import interact from "interactjs";
 import type { Interactable, ResizeEvent } from "@interactjs/types";
 import { PropertyValues } from "lit";
-import { LitElement, property, createEvent, h, state, JsxNode, method } from "@arcgis/lumina";
+import { createEvent, h, JsxNode, LitElement, method, property, state } from "@arcgis/lumina";
 import { createRef } from "lit/directives/ref.js";
 import { useDirection } from "@arcgis/lumina/controllers";
 import {
@@ -12,12 +12,11 @@ import {
 } from "../../utils/dom";
 import { getDimensionClass } from "../../utils/dynamicClasses";
 import { Height, Layout, Position, Scale, Width } from "../interfaces";
-import { CSS_UTILITY } from "../../utils/resources";
+import { CSS_UTILITY, resizeShiftStep, resizeStep } from "../../utils/resources";
 import { ariaValueFromSize } from "../../utils/aria";
 import { useT9n } from "../../controllers/useT9n";
 import { useSizeOverride } from "../../controllers/useSizeOverride";
 import type { ActionBar } from "../action-bar/action-bar";
-import { resizeStep, resizeShiftStep } from "../../utils/resources";
 import { IconName } from "../icon/interfaces";
 import { styles as animationStyles } from "../../styles/component/animation.scss";
 import T9nStrings from "./assets/t9n/messages.en.json";
@@ -46,7 +45,7 @@ export class ShellPanel extends LitElement {
 
   direction = useDirection();
 
-  private resizeHandleEl: HTMLDivElement;
+  private resizeHandleRef = createRef<HTMLDivElement>();
 
   private interaction: Interactable;
 
@@ -184,21 +183,35 @@ export class ShellPanel extends LitElement {
 
   //#region Lifecycle
 
+  override connectedCallback(): void {
+    if (this.hasUpdated) {
+      this.refreshResize();
+    }
+  }
+
   override willUpdate(changes: PropertyValues<this>): void {
     /* TODO: [MIGRATION] First time Lit calls willUpdate(), changes will include not just properties provided by the user, but also any default values your component set.
     To account for this semantics change, the checks for (this.hasUpdated || value != defaultValue) was added in this method
     Please refactor your code to reduce the need for this check.
     Docs: https://webgis.esri.com/arcgis-components/?path=/docs/lumina-transition-from-stencil--docs#watching-for-property-changes */
+    let shouldRefreshResize = false;
+
     if (changes.has("layout") && (this.hasUpdated || this.layout !== "vertical")) {
       this.setActionBarsLayout(this.actionBars);
-      this.setupInteractions();
+      this.updateSizeInternal({ inline: null, block: null }); // we clear sizing as it won't be applicable across axes
+      shouldRefreshResize = true;
     }
 
     if (
       (changes.has("direction") && this.hasUpdated) ||
-      (changes.has("position") && (this.hasUpdated || this.position !== "start"))
+      (changes.has("position") && (this.hasUpdated || this.position !== "start")) ||
+      (changes.has("resizable") && (this.hasUpdated || this.resizable !== false))
     ) {
-      this.setupInteractions();
+      shouldRefreshResize = true;
+    }
+
+    if (shouldRefreshResize) {
+      this.refreshResize();
     }
 
     if (changes.has("collapsed") && this.hasUpdated) {
@@ -211,7 +224,7 @@ export class ShellPanel extends LitElement {
   }
 
   override disconnectedCallback(): void {
-    this.cleanupInteractions();
+    this.cleanUpInteractions();
   }
 
   //#endregion
@@ -299,55 +312,63 @@ export class ShellPanel extends LitElement {
     }
   }
 
-  private cleanupInteractions(): void {
+  private cleanUpInteractions(): void {
     this.interaction?.unset();
   }
 
-  private async setupInteractions(): Promise<void> {
-    this.cleanupInteractions();
+  private updateResizeValues(): void {
+    const { contentRef } = this;
 
-    const { el, contentRef, resizable, position, collapsed, resizeHandleEl, layout } = this;
-
-    if (!contentRef.value || collapsed || !resizable || !resizeHandleEl) {
+    if (!contentRef.value) {
       return;
     }
 
-    await this.el.componentOnReady();
+    const computedStyle = window.getComputedStyle(contentRef.value);
 
-    const { inlineSize, minInlineSize, blockSize, minBlockSize, maxInlineSize, maxBlockSize } =
-      window.getComputedStyle(contentRef.value);
-
-    const values: ResizeValues = {
-      inlineSize: getStylePixelValue(inlineSize),
-      blockSize: getStylePixelValue(blockSize),
-      minInlineSize: getStylePixelValue(minInlineSize),
-      minBlockSize: getStylePixelValue(minBlockSize),
-      maxInlineSize: getStylePixelValue(maxInlineSize) || window.innerWidth,
-      maxBlockSize: getStylePixelValue(maxBlockSize) || window.innerHeight,
+    this.resizeValues = {
+      inlineSize: getStylePixelValue(computedStyle.inlineSize),
+      blockSize: getStylePixelValue(computedStyle.blockSize),
+      minInlineSize: getStylePixelValue(computedStyle.minInlineSize),
+      minBlockSize: getStylePixelValue(computedStyle.minBlockSize),
+      maxInlineSize: getStylePixelValue(computedStyle.maxInlineSize) || window.innerWidth,
+      maxBlockSize: getStylePixelValue(computedStyle.maxBlockSize) || window.innerHeight,
     };
+  }
 
-    this.resizeValues = values;
+  private async refreshResize(): Promise<void> {
+    await this.componentOnReady();
+    this.updateResizeValues();
+    this.setUpResizeInteractions();
+  }
+
+  private setUpResizeInteractions(): void {
+    this.cleanUpInteractions();
+
+    const { el, contentRef, resizable, position, collapsed, resizeHandleRef, layout } = this;
+    const resizeHandle = resizeHandleRef.value;
+
+    if (!contentRef.value || collapsed || !resizable || !resizeHandle) {
+      return;
+    }
 
     const rtl = this.direction === "rtl";
 
     this.interaction = interact(contentRef.value, { context: el.ownerDocument }).resizable({
       edges: {
-        top: position === "end" && layout === "horizontal" ? resizeHandleEl : false,
-        right:
-          position === (rtl ? "end" : "start") && layout === "vertical" ? resizeHandleEl : false,
-        bottom: position === "start" && layout === "horizontal" ? resizeHandleEl : false,
-        left:
-          position === (rtl ? "start" : "end") && layout === "vertical" ? resizeHandleEl : false,
+        top: position === "end" && layout === "horizontal" ? resizeHandle : false,
+        right: position === (rtl ? "end" : "start") && layout === "vertical" ? resizeHandle : false,
+        bottom: position === "start" && layout === "horizontal" ? resizeHandle : false,
+        left: position === (rtl ? "start" : "end") && layout === "vertical" ? resizeHandle : false,
       },
       modifiers: [
         interact.modifiers.restrictSize({
           min: {
-            width: values.minInlineSize,
-            height: values.minBlockSize,
+            width: this.resizeValues.minInlineSize,
+            height: this.resizeValues.minBlockSize,
           },
           max: {
-            width: values.maxInlineSize,
-            height: values.maxBlockSize,
+            width: this.resizeValues.maxInlineSize,
+            height: this.resizeValues.maxBlockSize,
           },
         }),
       ],
@@ -365,11 +386,6 @@ export class ShellPanel extends LitElement {
         },
       },
     });
-  }
-
-  private setResizeHandleEl(el: HTMLDivElement): void {
-    this.resizeHandleEl = el;
-    this.setupInteractions();
   }
 
   private setActionBarsLayout(actionBars: ActionBar["el"][]): void {
@@ -436,7 +452,7 @@ export class ShellPanel extends LitElement {
           class={CSS.resizeHandle}
           key="resize-handle"
           onKeyDown={this.handleKeyDown}
-          ref={this.setResizeHandleEl}
+          ref={this.resizeHandleRef}
           role="separator"
           tabIndex={0}
           touch-action="none"

--- a/packages/components/src/components/shell-panel/shell-panel.tsx
+++ b/packages/components/src/components/shell-panel/shell-panel.tsx
@@ -209,8 +209,11 @@ export class ShellPanel extends LitElement {
       shouldRefreshResize = true;
     }
 
-    if (changes.has("resizable") && (this.hasUpdated || this.resizable !== false)) {
-      shouldRefreshResize = this.resizable;
+    if (
+      (changes.has("collapsed") && (this.hasUpdated || this.collapsed !== false)) ||
+      (changes.has("resizable") && (this.hasUpdated || this.resizable !== false))
+    ) {
+      shouldRefreshResize = this.resizable && !this.collapsed;
 
       if (!shouldRefreshResize) {
         this.cleanUpInteractions();

--- a/packages/components/src/components/shell-panel/shell-panel.tsx
+++ b/packages/components/src/components/shell-panel/shell-panel.tsx
@@ -344,6 +344,7 @@ export class ShellPanel extends LitElement {
 
   private async refreshResize(): Promise<void> {
     await this.componentOnReady();
+    await this.updateComplete;
     this.updateResizeValues();
     this.setUpResizeInteractions();
   }

--- a/packages/components/src/components/shell-panel/shell-panel.tsx
+++ b/packages/components/src/components/shell-panel/shell-panel.tsx
@@ -204,10 +204,17 @@ export class ShellPanel extends LitElement {
 
     if (
       (changes.has("direction") && this.hasUpdated) ||
-      (changes.has("position") && (this.hasUpdated || this.position !== "start")) ||
-      (changes.has("resizable") && (this.hasUpdated || this.resizable !== false))
+      (changes.has("position") && (this.hasUpdated || this.position !== "start"))
     ) {
       shouldRefreshResize = true;
+    }
+
+    if (changes.has("resizable") && (this.hasUpdated || this.resizable !== false)) {
+      shouldRefreshResize = this.resizable;
+
+      if (!shouldRefreshResize) {
+        this.cleanUpInteractions();
+      }
     }
 
     if (shouldRefreshResize) {


### PR DESCRIPTION
**Related Issue:** #13986 

## Summary

This addresses an issue where the resize state would be applied when the layout changed from `horizontal` to `vertical` and vice versa, leading to an incompatible size after the layout change.

### Notable changes

* moves interaction setup/teardown to `willUpdate`
* uses ref to store handle element
* revisit resize interaction naming
* cleans up test