### PR TITLE
fix(input-time-zone): ensure item labels update on locale/reference date change

### DIFF
--- a/packages/components/src/components/input-time-zone/input-time-zone.e2e.ts
+++ b/packages/components/src/components/input-time-zone/input-time-zone.e2e.ts
@@ -191,6 +191,55 @@ describe("mode", () => {
 
       expect(matchedTimeZoneItems.length).toBeGreaterThan(1);
     });
+
+    it("recreates time zone items when item-dependent props change", async () => {
+      const itemSelector = `calcite-input-time-zone >>> calcite-combobox-item[value='${testTimeZoneItems[1].offset}']`;
+      const selectedItemSelector = `calcite-input-time-zone >>> calcite-combobox >>> .${ComboboxCSS.label}`;
+      const page = await newE2EPage();
+      await page.emulateTimezone(testTimeZoneItems[0].name);
+      await page.setContent(html`<calcite-input-time-zone reference-date="2020-01-01"></calcite-input-time-zone>`);
+      const inputTimeZone = await page.find("calcite-input-time-zone");
+
+      let prevItem = await page.find(itemSelector);
+      let prevItemLabel = await prevItem.getProperty("heading");
+      let prevSelectedItemLabel = (await page.find(selectedItemSelector)).textContent;
+      inputTimeZone.setProperty("lang", "ja");
+      await page.waitForChanges();
+
+      let currItem = await page.find(itemSelector);
+      let currItemLabel = await currItem.getProperty("heading");
+      let currSelectedItemLabel = (await page.find(selectedItemSelector)).textContent;
+      expect(currItem).not.toBe(prevItem);
+      expect(currItemLabel).not.toBe(prevItemLabel);
+      expect(currSelectedItemLabel).not.toBe(prevSelectedItemLabel);
+
+      prevItem = currItem;
+      prevItemLabel = currItemLabel;
+      prevSelectedItemLabel = currSelectedItemLabel;
+      inputTimeZone.setProperty("referenceDate", "2020-06-01");
+      await page.waitForChanges();
+
+      currItem = await page.find(itemSelector);
+      currItemLabel = await currItem.getProperty("heading");
+      currSelectedItemLabel = (await page.find(selectedItemSelector)).textContent;
+
+      expect(currItem).not.toBe(prevItem);
+      expect(currItemLabel).not.toBe(prevItemLabel);
+      expect(currSelectedItemLabel).not.toBe(prevSelectedItemLabel);
+
+      prevItem = currItem;
+      prevItemLabel = currItemLabel;
+      prevSelectedItemLabel = currSelectedItemLabel;
+      inputTimeZone.setProperty("mode", "offset");
+      await page.waitForChanges();
+
+      currItem = await page.find(itemSelector);
+      currItemLabel = await currItem.getProperty("heading");
+      currSelectedItemLabel = (await page.find(selectedItemSelector)).textContent;
+      expect(currItem).not.toBe(prevItem);
+      expect(currItemLabel).toBe(prevItemLabel); // same mode would not change label from same mode update
+      expect(currSelectedItemLabel).toBe(prevSelectedItemLabel); // same mode would not change label from same mode update
+    });
   });
 
   describe("name", () => {
@@ -242,6 +291,55 @@ describe("mode", () => {
       const timeZoneItem = await page.find("calcite-input-time-zone >>> calcite-combobox-item[selected]");
 
       expect(await timeZoneItem.getProperty("heading")).toMatch(testTimeZoneItems[0].name);
+    });
+
+    it("recreates time zone items when item-dependent props change", async () => {
+      const itemSelector = `calcite-input-time-zone >>> calcite-combobox-item[value='${testTimeZoneItems[1].name}']`;
+      const selectedItemSelector = `calcite-input-time-zone >>> calcite-combobox >>> .${ComboboxCSS.label}`;
+      const page = await newE2EPage();
+      await page.emulateTimezone(testTimeZoneItems[0].name);
+      await page.setContent(
+        html`<calcite-input-time-zone mode="name" reference-date="2020-01-01"></calcite-input-time-zone>`,
+      );
+      const inputTimeZone = await page.find("calcite-input-time-zone");
+
+      let prevItem = await page.find(itemSelector);
+      let prevItemLabel = await prevItem.getProperty("heading");
+      let prevSelectedItemLabel = (await page.find(selectedItemSelector)).textContent;
+      inputTimeZone.setProperty("lang", "ja");
+      await page.waitForChanges();
+
+      let currItem = await page.find(itemSelector);
+      let currItemLabel = await currItem.getProperty("heading");
+      let currSelectedItemLabel = (await page.find(selectedItemSelector)).textContent;
+      expect(currItem).not.toBe(prevItem);
+      expect(currItemLabel).toBe(prevItemLabel); // this mode does not translate time zone names
+      expect(currSelectedItemLabel).toBe(prevSelectedItemLabel); // this mode does not translate time zone names
+
+      prevItem = currItem;
+      prevItemLabel = currItemLabel;
+      prevSelectedItemLabel = currSelectedItemLabel;
+      inputTimeZone.setProperty("referenceDate", "2020-06-01");
+      await page.waitForChanges();
+
+      currItem = await page.find(itemSelector);
+      currItemLabel = await currItem.getProperty("heading");
+      currSelectedItemLabel = (await page.find(selectedItemSelector)).textContent;
+      expect(currItem).not.toBe(prevItem);
+      expect(currItemLabel).toBe(prevItemLabel); // same mode would not change label from reference date update
+      expect(currSelectedItemLabel).toBe(prevSelectedItemLabel); // same mode would not change label from reference date update
+
+      prevItem = currItem;
+      prevItemLabel = currItemLabel;
+      prevSelectedItemLabel = currSelectedItemLabel;
+      inputTimeZone.setProperty("mode", "name");
+      await page.waitForChanges();
+
+      currItem = await page.find(itemSelector);
+      currItemLabel = await currItem.getProperty("heading");
+      expect(currItem).not.toBe(prevItem);
+      expect(currItemLabel).toBe(prevItemLabel); // same mode would not change label from same mode update
+      expect(currSelectedItemLabel).toBe(prevSelectedItemLabel); // same mode would not change label from same mode update
     });
   });
 
@@ -366,6 +464,57 @@ describe("mode", () => {
       await page.waitForChanges();
 
       expect(await input.getProperty("value")).toBe(aliasTimeZone2);
+    });
+
+    it("recreates time zone items when item-dependent props change", async () => {
+      const itemSelector = `calcite-input-time-zone >>> calcite-combobox-item[value='${testTimeZoneItems[1].name}']`;
+      const selectedItemSelector = `calcite-input-time-zone >>> calcite-combobox >>> .${ComboboxCSS.label}`;
+      const page = await newE2EPage();
+      await page.emulateTimezone(testTimeZoneItems[0].name);
+      await page.setContent(
+        html`<calcite-input-time-zone mode="region" reference-date="2020-01-01"></calcite-input-time-zone>`,
+      );
+      const inputTimeZone = await page.find("calcite-input-time-zone");
+
+      let prevItem = await page.find(itemSelector);
+      let prevItemLabel = await prevItem.getProperty("heading");
+      let prevSelectedItemLabel = (await page.find(selectedItemSelector)).textContent;
+      inputTimeZone.setProperty("lang", "ja");
+      await page.waitForChanges();
+
+      let currItem = await page.find(itemSelector);
+      let currItemLabel = await currItem.getProperty("heading");
+      let currSelectedItemLabel = (await page.find(selectedItemSelector)).textContent;
+      expect(currItem).not.toBe(prevItem);
+      expect(currItemLabel).not.toBe(prevItemLabel);
+      expect(currSelectedItemLabel).not.toBe(prevSelectedItemLabel);
+
+      prevItem = currItem;
+      prevItemLabel = currItemLabel;
+      prevSelectedItemLabel = currSelectedItemLabel;
+      inputTimeZone.setProperty("referenceDate", "2020-06-01");
+      await page.waitForChanges();
+
+      currItem = await page.find(itemSelector);
+      currItemLabel = await currItem.getProperty("heading");
+      currSelectedItemLabel = (await page.find(selectedItemSelector)).textContent;
+
+      expect(currItem).not.toBe(prevItem);
+      expect(currItemLabel).toBe(prevItemLabel); // same mode would not change label from reference date update
+      expect(currSelectedItemLabel).toBe(prevSelectedItemLabel); // same mode would not change label from reference date update
+
+      prevItem = currItem;
+      prevItemLabel = currItemLabel;
+      prevSelectedItemLabel = currSelectedItemLabel;
+      inputTimeZone.setProperty("mode", "region");
+      await page.waitForChanges();
+
+      currItem = await page.find(itemSelector);
+      currItemLabel = await currItem.getProperty("heading");
+      currSelectedItemLabel = (await page.find(selectedItemSelector)).textContent;
+      expect(currItem).not.toBe(prevItem);
+      expect(currItemLabel).toBe(prevItemLabel); // same mode would not change label from same mode update
+      expect(currSelectedItemLabel).toBe(prevSelectedItemLabel); // same mode would not change label from same mode update
     });
   });
 });
@@ -523,35 +672,6 @@ it("supports setting maxItems to display", async () => {
 
   // we assume maxItems works properly on combobox
   expect(await internalCombobox.getProperty("maxItems")).toBe(7);
-});
-
-it("recreates time zone items when item-dependent props change", async () => {
-  const page = await newE2EPage();
-  await page.emulateTimezone(testTimeZoneItems[0].name);
-  await page.setContent(html`<calcite-input-time-zone mode="name"></calcite-input-time-zone>`);
-  await page.waitForChanges();
-  const inputTimeZone = await page.find("calcite-input-time-zone");
-
-  let prevComboboxItem = await page.find("calcite-input-time-zone >>> calcite-combobox-item");
-  inputTimeZone.setProperty("lang", "es");
-  await page.waitForChanges();
-
-  let currComboboxItem = await page.find("calcite-input-time-zone >>> calcite-combobox-item");
-  expect(currComboboxItem).not.toBe(prevComboboxItem);
-
-  prevComboboxItem = currComboboxItem;
-  inputTimeZone.setProperty("referenceDate", "2021-01-01");
-  await page.waitForChanges();
-
-  currComboboxItem = await page.find("calcite-input-time-zone >>> calcite-combobox-item");
-  expect(currComboboxItem).not.toBe(prevComboboxItem);
-
-  prevComboboxItem = currComboboxItem;
-  inputTimeZone.setProperty("mode", "name");
-  await page.waitForChanges();
-
-  currComboboxItem = await page.find("calcite-input-time-zone >>> calcite-combobox-item");
-  expect(currComboboxItem).not.toBe(prevComboboxItem);
 });
 
 describe("offsetStyle", () => {

--- a/packages/components/src/components/input-time-zone/input-time-zone.e2e.ts
+++ b/packages/components/src/components/input-time-zone/input-time-zone.e2e.ts
@@ -337,6 +337,7 @@ describe("mode", () => {
 
       currItem = await page.find(itemSelector);
       currItemLabel = await currItem.getProperty("heading");
+      currSelectedItemLabel = (await page.find(selectedItemSelector)).textContent;
       expect(currItem).not.toBe(prevItem);
       expect(currItemLabel).toBe(prevItemLabel); // same mode would not change label from same mode update
       expect(currSelectedItemLabel).toBe(prevSelectedItemLabel); // same mode would not change label from same mode update

--- a/packages/components/src/components/input-time-zone/input-time-zone.tsx
+++ b/packages/components/src/components/input-time-zone/input-time-zone.tsx
@@ -7,6 +7,7 @@ import {
   LitElement,
   method,
   property,
+  state,
   stringOrBoolean,
 } from "@arcgis/lumina";
 import { createRef } from "lit/directives/ref.js";
@@ -68,10 +69,6 @@ export class InputTimeZone extends LitElement implements LabelableComponent {
 
   private normalizer: (timeZone: TimeZone) => TimeZone;
 
-  private selectedTimeZoneItem: TimeZoneItem;
-
-  private timeZoneItems: TimeZoneItem[] | TimeZoneItemGroup[];
-
   private _value: string;
 
   /**
@@ -89,6 +86,14 @@ export class InputTimeZone extends LitElement implements LabelableComponent {
    * Note: The `internal` context is reserved for future use to provide more granular update context information.
    */
   #valueUpdateContext: "user" | "internal" | null = null;
+
+  //#endregion
+
+  //#region State Properties
+
+  @state() selectedTimeZoneItem: TimeZoneItem;
+
+  @state() timeZoneItems: TimeZoneItem[] | TimeZoneItemGroup[];
 
   //#endregion
 


### PR DESCRIPTION
**Related Issue:** #12930 

## Summary

Makes `selectedTimeZoneItem` and `timeZoneItems` reactive (state) to ensure item labels are updated accordingly.