### PR TITLE
test(floating-ui): use stable `input-date-picker` date for snapshot

### DIFF
--- a/packages/components/src/floating-ui.stories.ts
+++ b/packages/components/src/floating-ui.stories.ts
@@ -116,7 +116,7 @@ export const stackingWhenTopLayerDisabled = (): string => html`
       </calcite-dropdown-group>
     </calcite-dropdown>
 
-    <calcite-input-date-picker open top-layer-disabled></calcite-input-date-picker>
+    <calcite-input-date-picker open top-layer-disabled value="2018-06-06"></calcite-input-date-picker>
 
     <calcite-button id="tooltip-button">Tooltip</calcite-button>
     <calcite-tooltip reference-element="tooltip-button" placement="bottom-end" open top-layer-disabled>


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Avoids monthly screenshot diff due to current day used for default `input-date-picker` value.