### PR TITLE
feat(navigation-logo, navigation-user): remove heading's padding top when there is no description

### DIFF
--- a/packages/components/src/components/navigation-logo/navigation-logo.browser.e2e.tsx
+++ b/packages/components/src/components/navigation-logo/navigation-logo.browser.e2e.tsx
@@ -4,7 +4,6 @@ import { page } from "vitest/browser";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import { defaults, reflects, hidden, renders, focusable } from "../../tests/commonTests/browser";
 import { CSS } from "./resources";
-import { NavigationLogo } from "./navigation-logo";
 
 describe("defaults", () => {
   defaults(
@@ -84,7 +83,7 @@ describe("is focusable", () => {
 
 describe("heading", () => {
   it("renders standalone heading when description is not provided", async () => {
-    await mount<NavigationLogo>(<calcite-navigation-logo heading="John Doe" />);
+    await mount(`<calcite-navigation-logo heading="John Doe"></calcite-navigation-logo>`);
 
     const heading = page.getBySelector(`calcite-navigation-logo .${CSS.heading}`);
     const standaloneHeading = page.getBySelector(

--- a/packages/components/src/components/navigation-logo/navigation-logo.browser.e2e.tsx
+++ b/packages/components/src/components/navigation-logo/navigation-logo.browser.e2e.tsx
@@ -1,7 +1,10 @@
 import { h } from "@arcgis/lumina";
-import { describe } from "vitest";
+import { describe, expect, it } from "vitest";
+import { page } from "vitest/browser";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import { defaults, reflects, hidden, renders, focusable } from "../../tests/commonTests/browser";
+import { CSS } from "./resources";
+import { NavigationLogo } from "./navigation-logo";
 
 describe("defaults", () => {
   defaults(
@@ -77,4 +80,20 @@ describe("renders", () => {
 
 describe("is focusable", () => {
   focusable(() => mount(<calcite-navigation-logo heading="esri" href=" " />));
+});
+
+describe("heading", () => {
+  it("renders standalone heading when description is not provided", async () => {
+    await mount<NavigationLogo>(<calcite-navigation-logo heading="John Doe" />);
+
+    const heading = page.getBySelector(`calcite-navigation-logo .${CSS.heading}`);
+    const standaloneHeading = page.getBySelector(
+      `calcite-navigation-logo .${CSS.heading}.${CSS.standalone}`,
+    );
+    const description = page.getBySelector(`calcite-navigation-logo .${CSS.description}`);
+
+    await expect.element(heading).toBeInTheDocument();
+    await expect.element(standaloneHeading).toBeInTheDocument();
+    await expect.element(description).not.toBeInTheDocument();
+  });
 });

--- a/packages/components/src/components/navigation-logo/navigation-logo.browser.e2e.tsx
+++ b/packages/components/src/components/navigation-logo/navigation-logo.browser.e2e.tsx
@@ -83,7 +83,7 @@ describe("is focusable", () => {
 
 describe("heading", () => {
   it("renders standalone heading when description is not provided", async () => {
-    await mount(`<calcite-navigation-logo heading="John Doe"></calcite-navigation-logo>`);
+    await mount(<calcite-navigation-logo heading="John Doe" />);
 
     const heading = page.getBySelector(`calcite-navigation-logo .${CSS.heading}`);
     const standaloneHeading = page.getBySelector(

--- a/packages/components/src/components/navigation-logo/navigation-logo.scss
+++ b/packages/components/src/components/navigation-logo/navigation-logo.scss
@@ -148,6 +148,7 @@
 
 .standalone {
   font-size: var(--calcite-internal-navigation-logo-heading-standalone-font-size);
+  padding-block-start: 0;
 }
 
 .description {

--- a/packages/components/src/components/navigation-user/navigation-user.browser.e2e.tsx
+++ b/packages/components/src/components/navigation-user/navigation-user.browser.e2e.tsx
@@ -1,6 +1,9 @@
-import { describe } from "vitest";
+import { describe, expect, it } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
+import { page } from "vitest/browser";
 import { defaults, reflects, hidden, renders, focusable } from "../../tests/commonTests/browser";
+import { CSS } from "./resources";
+import { NavigationUser } from "./navigation-user";
 
 describe("defaults", () => {
   defaults(
@@ -48,4 +51,20 @@ describe("renders", () => {
 
 describe("is focusable", () => {
   focusable(() => mount("calcite-navigation-user"));
+});
+
+describe("fullName", () => {
+  it("renders standalone fullName when username is not provided", async () => {
+    await mount<NavigationUser>(<calcite-navigation-user full-name="John Doe" />);
+
+    const fullName = page.getBySelector(`calcite-navigation-user .${CSS.fullName}`);
+    const standaloneFullName = page.getBySelector(
+      `calcite-navigation-user .${CSS.fullName}.${CSS.standalone}`,
+    );
+    const username = page.getBySelector(`calcite-navigation-user .${CSS.username}`);
+
+    await expect.element(fullName).toBeInTheDocument();
+    await expect.element(standaloneFullName).toBeInTheDocument();
+    await expect.element(username).not.toBeInTheDocument();
+  });
 });

--- a/packages/components/src/components/navigation-user/navigation-user.browser.e2e.tsx
+++ b/packages/components/src/components/navigation-user/navigation-user.browser.e2e.tsx
@@ -3,7 +3,6 @@ import { mount } from "@arcgis/lumina-compiler/testing";
 import { page } from "vitest/browser";
 import { defaults, reflects, hidden, renders, focusable } from "../../tests/commonTests/browser";
 import { CSS } from "./resources";
-import { NavigationUser } from "./navigation-user";
 
 describe("defaults", () => {
   defaults(
@@ -55,7 +54,7 @@ describe("is focusable", () => {
 
 describe("fullName", () => {
   it("renders standalone fullName when username is not provided", async () => {
-    await mount<NavigationUser>(<calcite-navigation-user full-name="John Doe" />);
+    await mount(`<calcite-navigation-user full-name="John Doe"></calcite-navigation-user>`);
 
     const fullName = page.getBySelector(`calcite-navigation-user .${CSS.fullName}`);
     const standaloneFullName = page.getBySelector(

--- a/packages/components/src/components/navigation-user/navigation-user.browser.e2e.tsx
+++ b/packages/components/src/components/navigation-user/navigation-user.browser.e2e.tsx
@@ -1,3 +1,4 @@
+import { h } from "@arcgis/lumina";
 import { describe, expect, it } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import { page } from "vitest/browser";
@@ -54,7 +55,7 @@ describe("is focusable", () => {
 
 describe("fullName", () => {
   it("renders standalone fullName when username is not provided", async () => {
-    await mount(`<calcite-navigation-user full-name="John Doe"></calcite-navigation-user>`);
+    await mount(<calcite-navigation-user fullName="John Doe" />);
 
     const fullName = page.getBySelector(`calcite-navigation-user .${CSS.fullName}`);
     const standaloneFullName = page.getBySelector(

--- a/packages/components/src/components/navigation-user/navigation-user.scss
+++ b/packages/components/src/components/navigation-user/navigation-user.scss
@@ -98,6 +98,10 @@ calcite-avatar ~ .text-container {
   line-height: var(--calcite-internal-navigation-user-full-name-line-height);
 }
 
+.standalone {
+  padding-block-start: 0;
+}
+
 .username {
   font-size: var(--calcite-internal-navigation-user-username-font-size);
   color: var(--calcite-navigation-user-name-text-color, var(--calcite-color-text-2));

--- a/packages/components/src/components/navigation-user/navigation-user.tsx
+++ b/packages/components/src/components/navigation-user/navigation-user.tsx
@@ -90,7 +90,13 @@ export class NavigationUser extends LitElement {
         {(this.fullName || this.username) && !this.textDisabled && (
           <div class={CSS.textContainer}>
             {this.fullName && (
-              <span class={CSS.fullName} key={CSS.fullName}>
+              <span
+                class={{
+                  [CSS.fullName]: true,
+                  [CSS.standalone]: !this.username,
+                }}
+                key={CSS.fullName}
+              >
                 {this.fullName}
               </span>
             )}

--- a/packages/components/src/components/navigation-user/resources.ts
+++ b/packages/components/src/components/navigation-user/resources.ts
@@ -1,6 +1,7 @@
 export const CSS = {
   button: "button",
   fullName: "full-name",
+  standalone: "standalone",
   textContainer: "text-container",
   username: "username",
 };


### PR DESCRIPTION
**Related Issue:** [#12346](https://github.com/Esri/calcite-design-system/issues/12346)

## Summary
Remove heading's `4px` `padding-top` when there is no description. Applies to `navigation-logo` and `navigation-user`
