### PR TITLE
deprecate(dom): deprecate `hasVisibleContent` utility

### DIFF
--- a/packages/components/src/utils/dom.ts
+++ b/packages/components/src/utils/dom.ts
@@ -399,8 +399,7 @@ export function slotChangeGetTextContent(event: Event): string {
 /**
  * This helper checks if an element has visible content.
  *
- * @deprecated Has problems with nested slots and dynamic content,
- * refer to https://github.com/Esri/calcite-design-system/issues/14270.
+ * @deprecated Has problems with nested slots and dynamic content, refer to https://github.com/Esri/calcite-design-system/issues/14270.
  *
  * @param element The element to check.
  * @returns True if the element has visible content, otherwise false.

--- a/packages/components/src/utils/dom.ts
+++ b/packages/components/src/utils/dom.ts
@@ -399,7 +399,8 @@ export function slotChangeGetTextContent(event: Event): string {
 /**
  * This helper checks if an element has visible content.
  *
- * @deprecated Has problems with nested slots and dynamic content, refer to https://github.com/Esri/calcite-design-system/issues/14270.
+ * @deprecated Using this utility with slots/content that start empty or may change creates incorrect behavior.
+ * It should not be used until a solution is found via https://github.com/Esri/calcite-design-system/issues/14270.
  *
  * @param element The element to check.
  * @returns True if the element has visible content, otherwise false.

--- a/packages/components/src/utils/dom.ts
+++ b/packages/components/src/utils/dom.ts
@@ -399,6 +399,9 @@ export function slotChangeGetTextContent(event: Event): string {
 /**
  * This helper checks if an element has visible content.
  *
+ * @deprecated Has problems with nested slots and dynamic content,
+ * refer to https://github.com/Esri/calcite-design-system/issues/14270.
+ *
  * @param element The element to check.
  * @returns True if the element has visible content, otherwise false.
  */


### PR DESCRIPTION
**Related Issue:** #14270

## Summary
Deprecates the `hasVisibleContent` utility, to prevent it being used in new places while a better solution is found. Using deprecation to ensure devs have in-editor feedback that they should not use this utility, even though it may not be 100% accurate. Removal timeline unknown.
