### PR TITLE
fix(combobox, input-time-zone): only cancel `Escape` key event when open or clearing text

### DIFF
--- a/packages/components/src/components/combobox/combobox.browser.e2e.tsx
+++ b/packages/components/src/components/combobox/combobox.browser.e2e.tsx
@@ -11,11 +11,11 @@ import {
   formAssociated,
   hidden,
   internalLabel,
+  openClose,
   reflects,
   renders,
   t9n,
   topLayer,
-  openClose,
 } from "../../tests/commonTests/browser";
 import { mockConsole } from "../../tests/utils/logging";
 import { defaultMenuPlacement } from "../../utils/floating-ui";
@@ -998,11 +998,23 @@ describe("keyboard interactions", async () => {
       } else {
         const combobox = page.getBySelector("calcite-combobox");
         const input = page.getBySelector("calcite-combobox input");
+        const changeHandler = vi.fn();
+        combobox.element().addEventListener("calciteComboboxChange", changeHandler);
+        const keyDownHandler = vi.fn();
+        el.addEventListener("keydown", keyDownHandler);
+
         await expect.element(combobox).toBeInTheDocument();
         await expect.element(input).toBeInTheDocument();
 
-        await userEvent.click(combobox);
-        await userEvent.keyboard("{Escape}");
+        await userEvent.keyboard("{Tab}{Escape}");
+
+        if (expectedBehavior === "clear") {
+          expect(changeHandler).toHaveBeenCalled();
+          expect(keyDownHandler.mock.lastCall![0]).toHaveProperty("defaultPrevented", true);
+        } else {
+          expect(changeHandler).not.toHaveBeenCalled();
+          expect(keyDownHandler.mock.lastCall![0]).toHaveProperty("defaultPrevented", false);
+        }
       }
 
       if (expectedBehavior === "clear") {
@@ -1026,7 +1038,7 @@ describe("keyboard interactions", async () => {
       });
 
       describe("via keyboard", () => {
-        test.for(selectionModes)("does not clear the value in selection mode", (selectionMode) =>
+        test.for(selectionModes)("does not clear the value in %s selection mode", (selectionMode) =>
           assertValueClearing(selectionMode, false, "keyboard", "no-clear"),
         );
       });
@@ -1041,10 +1053,41 @@ describe("keyboard interactions", async () => {
       });
 
       describe("via keyboard", () => {
-        test.for(selectionModes)("does not clear the value in selection mode", (selectionMode) =>
+        test.for(selectionModes)("does not clear the value in %s selection mode", (selectionMode) =>
           assertValueClearing(selectionMode, true, "keyboard", "no-clear"),
         );
       });
     });
+  });
+});
+
+describe("keyboard interaction", () => {
+  it(`remains focused after toggling`, async () => {
+    const { el } = await mount<Combobox>(() => (
+      <calcite-combobox>
+        <calcite-combobox-item value="one" />
+      </calcite-combobox>
+    ));
+    const floatingUI = await page.getBySelector(`calcite-combobox .${CSS.floatingUIContainer}`);
+    const keyDownHandler = vi.fn();
+    el.addEventListener("keydown", keyDownHandler);
+    const openEvent = waitForEvent(el, "calciteComboboxOpen");
+
+    await userEvent.keyboard("{Tab}{Escape}");
+
+    expect(keyDownHandler.mock.lastCall![0]).toHaveProperty("defaultPrevented", false);
+
+    await userEvent.keyboard("{Space}");
+    await openEvent;
+
+    await expect.element(floatingUI).toBeVisible();
+
+    const closeEvent = waitForEvent(el, "calciteComboboxClose");
+    await userEvent.keyboard("{Escape}");
+    await closeEvent;
+
+    await expect.element(floatingUI).not.toBeVisible();
+    await expect.element(el).toHaveFocus();
+    expect(keyDownHandler.mock.lastCall![0]).toHaveProperty("defaultPrevented", true);
   });
 });

--- a/packages/components/src/components/combobox/combobox.browser.e2e.tsx
+++ b/packages/components/src/components/combobox/combobox.browser.e2e.tsx
@@ -1038,9 +1038,15 @@ describe("keyboard interactions", async () => {
       });
 
       describe("via keyboard", () => {
-        test.for(selectionModes)("does not clear the value in %s selection mode", (selectionMode) =>
-          assertValueClearing(selectionMode, false, "keyboard", "no-clear"),
-        );
+        selectionModes.forEach((selectionMode) => {
+          if (selectionMode === "single-persist") {
+            it(`does not clear the value in ${selectionMode}-selection mode`, () =>
+              assertValueClearing(selectionMode, false, "keyboard", "no-clear"));
+          } else {
+            it(`clears the value in ${selectionMode}-selection mode`, () =>
+              assertValueClearing(selectionMode, false, "keyboard", "clear"));
+          }
+        });
       });
     });
 

--- a/packages/components/src/components/combobox/combobox.e2e.ts
+++ b/packages/components/src/components/combobox/combobox.e2e.ts
@@ -1087,30 +1087,6 @@ describe("keyboard navigation in all selection-display mode", () => {
     expect(firstFocusedGroupItem).toBeTruthy();
   });
 
-  it(`Escape closes the dropdown, but remains focused`, async () => {
-    const inputEl = await page.find(`#myCombobox >>> input`);
-    await inputEl.focus();
-    await page.waitForChanges();
-
-    expect(await page.evaluate(() => document.activeElement.id)).toBe("myCombobox");
-
-    const openEventSpy = await page.spyOnEvent("calciteComboboxOpen");
-    await page.keyboard.press("Space");
-    await page.waitForChanges();
-    await openEventSpy.next();
-    const floatingUI = await page.find(`#myCombobox >>> .${CSS.floatingUIContainer}`);
-
-    expect(await floatingUI.isVisible()).toBe(true);
-
-    const closeEventSpy = await page.spyOnEvent("calciteComboboxClose");
-    await page.keyboard.press("Escape");
-    await page.waitForChanges();
-    await closeEventSpy.next();
-
-    expect(await floatingUI.isVisible()).toBe(false);
-    expect(await page.evaluate(() => document.activeElement.id)).toBe("myCombobox");
-  });
-
   it(`Space opens dropdown and puts focus on first item and subsequent Space do not change the focus`, async () => {
     const inputEl = await page.find(`#myCombobox >>> input`);
     await inputEl.focus();

--- a/packages/components/src/components/combobox/combobox.tsx
+++ b/packages/components/src/components/combobox/combobox.tsx
@@ -942,12 +942,14 @@ export class Combobox extends LitElement implements LabelableComponent, Floating
         }
         break;
       case "Escape":
-        if (!this.clearDisabled && !this.open) {
+        if (this.open) {
+          this.open = false;
+          event.preventDefault();
+        } else if (!this.clearDisabled && this.textInputRef.value.value) {
           this.clearValue();
+          event.preventDefault();
         }
 
-        this.open = false;
-        event.preventDefault();
         break;
       case "Enter":
         if (this.open && this.activeItemIndex > -1) {

--- a/packages/components/src/components/combobox/combobox.tsx
+++ b/packages/components/src/components/combobox/combobox.tsx
@@ -945,7 +945,11 @@ export class Combobox extends LitElement implements LabelableComponent, Floating
         if (this.open) {
           this.open = false;
           event.preventDefault();
-        } else if (!this.clearDisabled && this.textInputRef.value.value) {
+        } else if (
+          !this.clearDisabled &&
+          this.selectedItems.length > 0 &&
+          this.selectionMode !== "single-persist"
+        ) {
           this.clearValue();
           event.preventDefault();
         }

--- a/packages/components/src/components/combobox/combobox.tsx
+++ b/packages/components/src/components/combobox/combobox.tsx
@@ -945,13 +945,17 @@ export class Combobox extends LitElement implements LabelableComponent, Floating
         if (this.open) {
           this.open = false;
           event.preventDefault();
-        } else if (
-          !this.clearDisabled &&
-          this.selectedItems.length > 0 &&
-          this.selectionMode !== "single-persist"
-        ) {
-          this.clearValue();
-          event.preventDefault();
+          break;
+        }
+
+        if (!this.clearDisabled) {
+          if (this.textInputRef.value?.value.length > 0) {
+            this.resetText();
+            event.preventDefault();
+          } else if (this.selectedItems.length > 0 && this.selectionMode !== "single-persist") {
+            this.clearValue();
+            event.preventDefault();
+          }
         }
 
         break;


### PR DESCRIPTION
**Related Issue:** #14298 

## Summary

Updates `combobox` to only cancel the `Escape` key when handling the event.

### Noteworthy changes

* migrates a keyboard interaction test to browser mode and updates it for coverage
* tweaks test titles to display selection mode (via [print formatting params](https://vitest.dev/api/test.html#test-each))
* updates `Escape` to first clear filter text, if present, then clear values