### PR TITLE
chore(linting): disable `eslint-plugin-import` rules until they support ESLint 10

### DIFF
--- a/packages/components/src/components/input-date-picker/input-date-picker.e2e.ts
+++ b/packages/components/src/components/input-date-picker/input-date-picker.e2e.ts
@@ -529,10 +529,8 @@ describe("localization", () => {
     const month = "4";
     const day = "19";
 
-    /* eslint-disable import/no-dynamic-require -- allowing dynamic asset path for maintainability */
     const langTranslations = await import(`../date-picker/assets/nls/${lang}.json`);
     const newLangTranslations = await import(`../date-picker/assets/nls/${newLang}.json`);
-    /* eslint-enable import/no-dynamic-require */
 
     const page = await newE2EPage();
     await page.setContent(

--- a/packages/eslint-config/core.js
+++ b/packages/eslint-config/core.js
@@ -1,7 +1,6 @@
 import cspellPlugin from "@cspell/eslint-plugin";
 import eslint from "@eslint/js";
 import prettierConfig from "eslint-config-prettier";
-import * as importPlugin from "eslint-plugin-import";
 import jsdocPlugin from "eslint-plugin-jsdoc";
 import unicornPlugin from "eslint-plugin-unicorn";
 import tseslint from "typescript-eslint";
@@ -14,7 +13,6 @@ export default tseslint.config(
     extends: [eslint.configs.recommended, tseslint.configs.recommended, jsdocPlugin.configs["flat/recommended"]],
     plugins: {
       "@cspell": cspellPlugin,
-      import: importPlugin,
       unicorn: unicornPlugin,
     },
 

--- a/packages/eslint-config/core.js
+++ b/packages/eslint-config/core.js
@@ -39,19 +39,6 @@ export default tseslint.config(
       "@typescript-eslint/no-unnecessary-type-assertion": "error",
       "@typescript-eslint/explicit-module-boundary-types": "off", // enabled in override config object below, see https://typescript-eslint.io/rules/explicit-module-boundary-types/#configuring-in-a-mixed-jsts-codebase
 
-      "import/no-dynamic-require": [
-        "error",
-        {
-          esmodule: true,
-        },
-      ],
-      "import/order": [
-        "error",
-        {
-          "newlines-between": "never",
-        },
-      ],
-
       "jsdoc/check-param-names": "off",
       "jsdoc/require-jsdoc": "off",
       "jsdoc/require-param": "off",


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Disabling `eslint-plugin-import` rules to allow us to update dependencies that depend on ESLint 10 (e.g., `@arcgis` deps). 