### PR TITLE
fix(select): match chevron alignment to combobox

### DIFF
--- a/packages/components/src/components/date-picker-month-header/date-picker-month-header.scss
+++ b/packages/components/src/components/date-picker-month-header/date-picker-month-header.scss
@@ -6,7 +6,6 @@
 // --calcite-internal-select-block-size
 // --calcite-internal-select-font-weight
 // --calcite-internal-select-icon-container-padding-inline
-// --calcite-internal-select-icon-container-padding-inline-end
 // --calcite-internal-select-line-height
 // --calcite-internal-select-spacing-block
 
@@ -153,7 +152,6 @@
 
   --calcite-internal-select-spacing-block: var(--calcite-spacing-xxs);
   --calcite-internal-select-icon-container-padding-inline: var(--calcite-spacing-xxs);
-  --calcite-internal-select-icon-container-padding-inline-end: var(--calcite-spacing-xxs);
   --calcite-internal-select-line-height: var(--calcite-font-line-height-fixed-lg);
   --calcite-internal-select-font-weight: var(--calcite-font-weight-medium);
 }
@@ -165,7 +163,6 @@
 
     --calcite-internal-select-spacing-block: var(--calcite-spacing-base);
     --calcite-internal-select-icon-container-padding-inline: var(--calcite-spacing-base);
-    --calcite-internal-select-icon-container-padding-inline-end: var(--calcite-spacing-base);
     --calcite-internal-select-block-size: #{core.$calcite-size-24};
     --calcite-internal-select-line-height: var(--calcite-font-line-height-fixed-base);
   }
@@ -188,7 +185,6 @@
 
     --calcite-internal-select-spacing-block: var(--calcite-spacing-sm);
     --calcite-internal-select-icon-container-padding-inline: var(--calcite-spacing-sm);
-    --calcite-internal-select-icon-container-padding-inline-end: var(--calcite-spacing-sm);
     --calcite-internal-select-block-size: #{core.$calcite-size-44};
     --calcite-internal-select-line-height: var(--calcite-font-line-height-fixed-xl);
   }

--- a/packages/components/src/components/date-picker-month-header/date-picker-month-header.scss
+++ b/packages/components/src/components/date-picker-month-header/date-picker-month-header.scss
@@ -8,6 +8,7 @@
 // --calcite-internal-select-icon-container-padding-inline
 // --calcite-internal-select-line-height
 // --calcite-internal-select-spacing-block
+// --calcite-internal-select-spacing-inline
 
 @use "../../styles/includes";
 @use "@esri/calcite-design-tokens/dist/scss/core";
@@ -144,7 +145,7 @@
 .month-select {
   --calcite-select-internal-border-width: 0;
   --calcite-select-internal-icon-border-inline-end-width: 0;
-  --calcite-select-spacing-inline: var(--calcite-spacing-xxs);
+  --calcite-internal-select-spacing-inline: var(--calcite-spacing-xxs);
   --calcite-select-font-size: var(--calcite-date-picker-month-select-font-size, var(--calcite-font-size-md));
   --calcite-select-text-color: var(--calcite-date-picker-month-select-text-color, var(--calcite-color-text-1));
   --calcite-select-icon-color: var(--calcite-date-picker-month-select-icon-color);
@@ -158,7 +159,7 @@
 
 :host([scale="s"]) .month-year-container {
   .month-select {
-    --calcite-select-spacing-inline: var(--calcite-spacing-base);
+    --calcite-internal-select-spacing-inline: var(--calcite-spacing-base);
     --calcite-select-font-size: var(--calcite-date-picker-month-select-font-size, var(--calcite-font-size));
 
     --calcite-internal-select-spacing-block: var(--calcite-spacing-base);
@@ -180,7 +181,7 @@
 
 :host([scale="l"]) .month-year-container {
   .month-select {
-    --calcite-select-spacing-inline: var(--calcite-spacing-sm);
+    --calcite-internal-select-spacing-inline: var(--calcite-spacing-sm);
     --calcite-select-font-size: var(--calcite-date-picker-month-select-font-size, var(--calcite-font-size-lg));
 
     --calcite-internal-select-spacing-block: var(--calcite-spacing-sm);

--- a/packages/components/src/components/date-picker-month-header/date-picker-month-header.scss
+++ b/packages/components/src/components/date-picker-month-header/date-picker-month-header.scss
@@ -6,6 +6,7 @@
 // --calcite-internal-select-block-size
 // --calcite-internal-select-font-weight
 // --calcite-internal-select-icon-container-padding-inline
+// --calcite-internal-select-icon-container-padding-inline-end
 // --calcite-internal-select-line-height
 // --calcite-internal-select-spacing-block
 
@@ -152,6 +153,7 @@
 
   --calcite-internal-select-spacing-block: var(--calcite-spacing-xxs);
   --calcite-internal-select-icon-container-padding-inline: var(--calcite-spacing-xxs);
+  --calcite-internal-select-icon-container-padding-inline-end: var(--calcite-spacing-xxs);
   --calcite-internal-select-line-height: var(--calcite-font-line-height-fixed-lg);
   --calcite-internal-select-font-weight: var(--calcite-font-weight-medium);
 }
@@ -163,6 +165,7 @@
 
     --calcite-internal-select-spacing-block: var(--calcite-spacing-base);
     --calcite-internal-select-icon-container-padding-inline: var(--calcite-spacing-base);
+    --calcite-internal-select-icon-container-padding-inline-end: var(--calcite-spacing-base);
     --calcite-internal-select-block-size: #{core.$calcite-size-24};
     --calcite-internal-select-line-height: var(--calcite-font-line-height-fixed-base);
   }
@@ -185,6 +188,7 @@
 
     --calcite-internal-select-spacing-block: var(--calcite-spacing-sm);
     --calcite-internal-select-icon-container-padding-inline: var(--calcite-spacing-sm);
+    --calcite-internal-select-icon-container-padding-inline-end: var(--calcite-spacing-sm);
     --calcite-internal-select-block-size: #{core.$calcite-size-44};
     --calcite-internal-select-line-height: var(--calcite-font-line-height-fixed-xl);
   }

--- a/packages/components/src/components/select/select.scss
+++ b/packages/components/src/components/select/select.scss
@@ -20,7 +20,6 @@
 // --calcite-internal-select-block-size
 // --calcite-internal-select-font-size
 // --calcite-internal-select-icon-container-padding-inline
-// --calcite-internal-select-icon-container-padding-inline-end
 
 @use "../../styles/includes";
 @use "@esri/calcite-design-tokens/dist/scss/core";
@@ -49,23 +48,20 @@
 :host([scale="s"]) {
   --calcite-internal-select-font-size: theme("fontSize.n2h");
   --calcite-select-spacing-inline: var(--calcite-space-sm) var(--calcite-space-2xl);
-  --calcite-internal-select-icon-container-padding-inline: var(--calcite-space-sm);
-  --calcite-internal-select-icon-container-padding-inline-end: var(--calcite-space-2xs);
+  --calcite-internal-select-icon-container-padding-inline: var(--calcite-space-2xs);
   --calcite-internal-select-block-size: #{core.$calcite-size-24};
 }
 
 :host([scale="m"]) {
   --calcite-internal-select-font-size: theme("fontSize.n1h");
   --calcite-select-spacing-inline: var(--calcite-space-md) var(--calcite-space-3xl);
-  --calcite-internal-select-icon-container-padding-inline: var(--calcite-space-md);
-  --calcite-internal-select-icon-container-padding-inline-end: var(--calcite-space-sm);
+  --calcite-internal-select-icon-container-padding-inline: var(--calcite-space-sm);
 }
 
 :host([scale="l"]) {
   --calcite-internal-select-font-size: theme("fontSize.0h");
   --calcite-select-spacing-inline: var(--calcite-space-lg) var(--calcite-space-4xl);
-  --calcite-internal-select-icon-container-padding-inline: var(--calcite-space-lg);
-  --calcite-internal-select-icon-container-padding-inline-end: var(--calcite-space-sm-plus);
+  --calcite-internal-select-icon-container-padding-inline: var(--calcite-space-sm-plus);
   --calcite-internal-select-block-size: #{core.$calcite-size-44};
 }
 
@@ -122,8 +118,8 @@ select:disabled {
   border-end-end-radius: var(--calcite-select-corner-radius, var(--calcite-corner-radius-none));
   border-color: var(--calcite-select-border-color, var(--calcite-color-border-input));
   border-inline-width: 0 var(--calcite-select-internal-icon-border-inline-end-width, var(--calcite-border-width-sm));
-  padding-inline-start: var(--calcite-internal-select-icon-container-padding-inline);
-  padding-inline-end: var(--calcite-internal-select-icon-container-padding-inline-end);
+  padding-inline: var(--calcite-internal-select-icon-container-padding-inline);
+
   .icon {
     color: var(--calcite-select-icon-color, var(--calcite-color-text-3));
   }

--- a/packages/components/src/components/select/select.scss
+++ b/packages/components/src/components/select/select.scss
@@ -20,6 +20,7 @@
 // --calcite-internal-select-block-size
 // --calcite-internal-select-font-size
 // --calcite-internal-select-icon-container-padding-inline
+// --calcite-internal-select-icon-container-padding-inline-end
 
 @use "../../styles/includes";
 @use "@esri/calcite-design-tokens/dist/scss/core";
@@ -47,21 +48,24 @@
 
 :host([scale="s"]) {
   --calcite-internal-select-font-size: theme("fontSize.n2h");
-  --calcite-select-spacing-inline: theme("spacing.2") theme("spacing.8");
-  --calcite-internal-select-icon-container-padding-inline: var(--calcite-spacing-sm);
+  --calcite-select-spacing-inline: var(--calcite-space-sm) var(--calcite-space-2xl);
+  --calcite-internal-select-icon-container-padding-inline: var(--calcite-space-sm);
+  --calcite-internal-select-icon-container-padding-inline-end: var(--calcite-space-2xs);
   --calcite-internal-select-block-size: #{core.$calcite-size-24};
 }
 
 :host([scale="m"]) {
   --calcite-internal-select-font-size: theme("fontSize.n1h");
-  --calcite-select-spacing-inline: theme("spacing.3") theme("spacing.10");
-  --calcite-internal-select-icon-container-padding-inline: var(--calcite-spacing-md);
+  --calcite-select-spacing-inline: var(--calcite-space-md) var(--calcite-space-3xl);
+  --calcite-internal-select-icon-container-padding-inline: var(--calcite-space-md);
+  --calcite-internal-select-icon-container-padding-inline-end: var(--calcite-space-sm);
 }
 
 :host([scale="l"]) {
   --calcite-internal-select-font-size: theme("fontSize.0h");
-  --calcite-select-spacing-inline: theme("spacing.4") theme("spacing.12");
-  --calcite-internal-select-icon-container-padding-inline: var(--calcite-spacing-lg);
+  --calcite-select-spacing-inline: var(--calcite-space-lg) var(--calcite-space-4xl);
+  --calcite-internal-select-icon-container-padding-inline: var(--calcite-space-lg);
+  --calcite-internal-select-icon-container-padding-inline-end: var(--calcite-space-sm-plus);
   --calcite-internal-select-block-size: #{core.$calcite-size-44};
 }
 
@@ -118,7 +122,8 @@ select:disabled {
   border-end-end-radius: var(--calcite-select-corner-radius, var(--calcite-corner-radius-none));
   border-color: var(--calcite-select-border-color, var(--calcite-color-border-input));
   border-inline-width: 0 var(--calcite-select-internal-icon-border-inline-end-width, var(--calcite-border-width-sm));
-  padding-inline: var(--calcite-internal-select-icon-container-padding-inline);
+  padding-inline-start: var(--calcite-internal-select-icon-container-padding-inline);
+  padding-inline-end: var(--calcite-internal-select-icon-container-padding-inline-end);
   .icon {
     color: var(--calcite-select-icon-color, var(--calcite-color-text-3));
   }

--- a/packages/components/src/components/select/select.scss
+++ b/packages/components/src/components/select/select.scss
@@ -20,6 +20,7 @@
 // --calcite-internal-select-block-size
 // --calcite-internal-select-font-size
 // --calcite-internal-select-icon-container-padding-inline
+// --calcite-internal-select-spacing-inline
 
 @use "../../styles/includes";
 @use "@esri/calcite-design-tokens/dist/scss/core";
@@ -47,20 +48,20 @@
 
 :host([scale="s"]) {
   --calcite-internal-select-font-size: theme("fontSize.n2h");
-  --calcite-select-spacing-inline: var(--calcite-space-sm) var(--calcite-space-2xl);
+  --calcite-internal-select-spacing-inline: var(--calcite-space-sm) var(--calcite-space-2xl);
   --calcite-internal-select-icon-container-padding-inline: var(--calcite-space-2xs);
   --calcite-internal-select-block-size: #{core.$calcite-size-24};
 }
 
 :host([scale="m"]) {
   --calcite-internal-select-font-size: theme("fontSize.n1h");
-  --calcite-select-spacing-inline: var(--calcite-space-md) var(--calcite-space-3xl);
+  --calcite-internal-select-spacing-inline: var(--calcite-space-md) var(--calcite-space-3xl);
   --calcite-internal-select-icon-container-padding-inline: var(--calcite-space-sm);
 }
 
 :host([scale="l"]) {
   --calcite-internal-select-font-size: theme("fontSize.0h");
-  --calcite-select-spacing-inline: var(--calcite-space-lg) var(--calcite-space-4xl);
+  --calcite-internal-select-spacing-inline: var(--calcite-space-lg) var(--calcite-space-4xl);
   --calcite-internal-select-icon-container-padding-inline: var(--calcite-space-sm-plus);
   --calcite-internal-select-block-size: #{core.$calcite-size-44};
 }
@@ -92,7 +93,7 @@
   color: var(--calcite-select-text-color, var(--calcite-color-text-2));
   border-color: var(--calcite-select-border-color, var(--calcite-color-border-input));
   border-width: var(--calcite-select-internal-border-width, var(--calcite-border-width-sm));
-  padding-inline: var(--calcite-select-spacing-inline);
+  padding-inline: var(--calcite-internal-select-spacing-inline);
   padding-block: var(--calcite-internal-select-spacing-block);
   border-inline-end-width: 0;
   line-height: var(--calcite-internal-select-line-height, normal);


### PR DESCRIPTION
**Related Issue:** #14398

## Summary
To maintain alignment with Combobox:

- Updates `--calcite-internal-select-icon-container-padding-inline` at each scale to correct alignment with other components.
- Updates `--calcite-select-spacing-inline` at each scale to account for this change.

<img width="472" height="307" alt="CleanShot 2026-05-11 at 16 38 01@2x" src="https://github.com/user-attachments/assets/a3a2ee44-2a1c-45e8-9ee5-0d6108d8b68c" />

