### PR TITLE
feat(label): skip label focus behavior if click event is canceled

### DIFF
--- a/packages/components/src/components/label/label.tsx
+++ b/packages/components/src/components/label/label.tsx
@@ -74,7 +74,7 @@ export class Label extends LitElement {
 
   // #region Private Methods
   private labelClickHandler(event: MouseEvent): void {
-    if (window.getSelection()?.type === "Range") {
+    if (window.getSelection()?.type === "Range" || event.defaultPrevented) {
       return;
     }
 

--- a/packages/components/src/utils/label.browser.spec.tsx
+++ b/packages/components/src/utils/label.browser.spec.tsx
@@ -93,6 +93,7 @@ describe("connectLabel/disconnectLabel", () => {
       );
       const labelable =
         document.querySelector<WithManager<LabelableComponent>>("labelable-component");
+      vi.spyOn(labelable.manager.component, "onLabelClick");
       const interceptor = page.getByTestId("interceptor");
       const clickHandler = vi.fn((event: MouseEvent) => event.preventDefault());
       interceptor.element().addEventListener("click", clickHandler, { once: true });
@@ -101,6 +102,7 @@ describe("connectLabel/disconnectLabel", () => {
 
       await userEvent.click(interceptor);
 
+      expect(labelable.manager.component.onLabelClick).toHaveBeenCalledTimes(0);
       await expect.element(labelable).not.toHaveFocus();
       expect(clickHandler).toHaveBeenCalledTimes(1);
       expect(clickHandler.mock.lastCall[0]).toHaveProperty("defaultPrevented", true);

--- a/packages/components/src/utils/label.browser.spec.tsx
+++ b/packages/components/src/utils/label.browser.spec.tsx
@@ -6,6 +6,7 @@ import { createRef } from "lit/directives/ref.js";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import { html } from "lit";
 import type { Label } from "../components/label/label";
+import { page, userEvent } from "vitest/browser";
 
 class LabelableComponent extends LitElement {
   static tagName = "labelable-component";
@@ -74,6 +75,35 @@ describe("connectLabel/disconnectLabel", () => {
 
       expect(labelable.manager.component.onLabelClick).toHaveBeenCalledTimes(0);
       await expect.element(labelable).not.toHaveFocus();
+
+      labelable.remove();
+
+      expect(labelable.manager.component.labelEl).toBeNull();
+    });
+
+    it("supports cancellation", async () => {
+      const { el } = await mount(
+        html`
+          <calcite-label>
+            <div data-testid="interceptor">label</div>
+            <labelable-component data-testid="labelable"></labelable-component>
+          </calcite-label>
+        `,
+        { dynamicComponents: [LabelableComponent] },
+      );
+      const labelable =
+        document.querySelector<WithManager<LabelableComponent>>("labelable-component");
+      const interceptor = page.getByTestId("interceptor");
+      const clickHandler = vi.fn((event: MouseEvent) => event.preventDefault());
+      interceptor.element().addEventListener("click", clickHandler, { once: true });
+
+      expect(labelable.manager.component.labelEl).toBe(el);
+
+      await userEvent.click(interceptor);
+
+      await expect.element(labelable).not.toHaveFocus();
+      expect(clickHandler).toHaveBeenCalledTimes(1);
+      expect(clickHandler.mock.lastCall[0]).toHaveProperty("defaultPrevented", true);
 
       labelable.remove();
 


### PR DESCRIPTION
**Related Issue:** #11100 

## Summary

Enhance label to ignore canceled events.