### PR TITLE
fix(block): independently style icons based on CSS tokens

### DIFF
--- a/packages/components/src/components/block/block.e2e.ts
+++ b/packages/components/src/components/block/block.e2e.ts
@@ -307,21 +307,19 @@ describe("theme", () => {
           shadowSelector: `.${CSS.description}`,
           targetProp: "color",
         },
-        "--calcite-block-icon-color": [
-          {
-            shadowSelector: `.${CSS.iconStart}`,
-            targetProp: "color",
-          },
-          {
-            shadowSelector: `.${CSS.iconEnd}`,
-            targetProp: "color",
-          },
-          {
-            shadowSelector: `.${CSS.toggleIcon}`,
-            targetProp: "color",
-          },
-        ],
-        "--calcite-block-icon-color-hover": {
+        "--calcite-block-icon-start-color": {
+          shadowSelector: `.${CSS.iconStart}`,
+          targetProp: "color",
+        },
+        "--calcite-block-icon-end-color": {
+          shadowSelector: `.${CSS.iconEnd}`,
+          targetProp: "color",
+        },
+        "--calcite-block-expandable-icon-color": {
+          shadowSelector: `.${CSS.toggleIcon}`,
+          targetProp: "color",
+        },
+        "--calcite-block-expandable-icon-color-hover": {
           shadowSelector: `.${CSS.toggleIcon}`,
           targetProp: "color",
           state: "hover",
@@ -359,6 +357,25 @@ describe("theme", () => {
           shadowSelector: `.${CSS.heading}`,
           targetProp: "color",
           state: { press: { attribute: "class", value: CSS.heading } },
+        },
+        "--calcite-block-icon-color": [
+          {
+            shadowSelector: `.${CSS.iconStart}`,
+            targetProp: "color",
+          },
+          {
+            shadowSelector: `.${CSS.iconEnd}`,
+            targetProp: "color",
+          },
+          {
+            shadowSelector: `.${CSS.toggleIcon}`,
+            targetProp: "color",
+          },
+        ],
+        "--calcite-block-icon-color-hover": {
+          shadowSelector: `.${CSS.toggleIcon}`,
+          targetProp: "color",
+          state: "hover",
         },
       },
     );

--- a/packages/components/src/components/block/block.e2e.ts
+++ b/packages/components/src/components/block/block.e2e.ts
@@ -315,11 +315,11 @@ describe("theme", () => {
           shadowSelector: `.${CSS.iconEnd}`,
           targetProp: "color",
         },
-        "--calcite-block-expandable-icon-color": {
+        "--calcite-block-collapsible-icon-color": {
           shadowSelector: `.${CSS.toggleIcon}`,
           targetProp: "color",
         },
-        "--calcite-block-expandable-icon-color-hover": {
+        "--calcite-block-collapsible-icon-color-hover": {
           shadowSelector: `.${CSS.toggleIcon}`,
           targetProp: "color",
           state: "hover",

--- a/packages/components/src/components/block/block.scss
+++ b/packages/components/src/components/block/block.scss
@@ -13,8 +13,8 @@
  * @prop --calcite-block-padding: [Deprecated] in v3.3.0, removal target v6.0.0 - Use `--calcite-block-content-space` instead. Specifies the padding of the component's `default` slot.
  * @prop --calcite-block-text-color:[Deprecated] in v3.3.0, removal target v6.0.0 - Specifies the component's text color.
  * @prop --calcite-block-description-text-color: Specifies the component's `description` text color.
- * @prop --calcite-block-icon-color: [Deprecated] - Use `--calcite-block-expandable-icon-color`, `--calcite-block-icon-start-color` and `--calcite-block-icon-end-color` instead. Specifies the component's `collapsible` icon, `iconStart` and `iconEnd` color.
- * @prop --calcite-block-icon-color-hover: [Deprecated] - Use `--calcite-block-expandable-icon-color-hover` instead. Specifies the component's `collapsible` icon color when hovered.
+ * @prop --calcite-block-icon-color: [Deprecated] in v3.3.0, removal target v7.0.0 - Use `--calcite-block-expandable-icon-color`, `--calcite-block-icon-start-color` and `--calcite-block-icon-end-color` instead. Specifies the component's `collapsible` icon, `iconStart` and `iconEnd` color.
+ * @prop --calcite-block-icon-color-hover: [Deprecated] in v3.3.0, removal target v7.0.0 - Use `--calcite-block-expandable-icon-color-hover` instead. Specifies the component's `collapsible` icon color when hovered.
  * @prop --calcite-block-icon-start-color: Specifies the component's `iconStart` color.
  * @prop --calcite-block-icon-end-color: Specifies the component's `iconEnd` color.
  * @prop --calcite-block-expandable-icon-color: Specifies the component's `collapsible` icon color.

--- a/packages/components/src/components/block/block.scss
+++ b/packages/components/src/components/block/block.scss
@@ -13,12 +13,12 @@
  * @prop --calcite-block-padding: [Deprecated] in v3.3.0, removal target v6.0.0 - Use `--calcite-block-content-space` instead. Specifies the padding of the component's `default` slot.
  * @prop --calcite-block-text-color:[Deprecated] in v3.3.0, removal target v6.0.0 - Specifies the component's text color.
  * @prop --calcite-block-description-text-color: Specifies the component's `description` text color.
- * @prop --calcite-block-icon-color: [Deprecated] in v3.3.0, removal target v7.0.0 - Use `--calcite-block-expandable-icon-color`, `--calcite-block-icon-start-color` and `--calcite-block-icon-end-color` instead. Specifies the component's `collapsible` icon, `iconStart` and `iconEnd` color.
- * @prop --calcite-block-icon-color-hover: [Deprecated] in v3.3.0, removal target v7.0.0 - Use `--calcite-block-expandable-icon-color-hover` instead. Specifies the component's `collapsible` icon color when hovered.
+ * @prop --calcite-block-icon-color: [Deprecated] in v5.1.0, removal target v7.0.0 - Use `--calcite-block-collapsible-icon-color`, `--calcite-block-icon-start-color` and `--calcite-block-icon-end-color` instead. Specifies the component's `collapsible` icon, `iconStart` and `iconEnd` color.
+ * @prop --calcite-block-icon-color-hover: [Deprecated] in v5.1.0, removal target v7.0.0 - Use `--calcite-block-collapsible-icon-color-hover` instead. Specifies the component's `collapsible` icon color when hovered.
  * @prop --calcite-block-icon-start-color: Specifies the component's `iconStart` color.
  * @prop --calcite-block-icon-end-color: Specifies the component's `iconEnd` color.
- * @prop --calcite-block-expandable-icon-color: Specifies the component's `collapsible` icon color.
- * @prop --calcite-block-expandable-icon-color-hover: Specifies the component's `collapsible` icon color when hovered.
+ * @prop --calcite-block-collapsible-icon-color: Specifies the component's `collapsible` icon color.
+ * @prop --calcite-block-collapsible-icon-color-hover: Specifies the component's `collapsible` icon color when hovered.
  */
 
 // AUTO-GENERATED — do not modify. Changes will be overwritten.
@@ -264,12 +264,12 @@ calcite-sort-handle {
   self-center
   justify-self-end
   ease-in-out;
-  color: var(--calcite-block-expandable-icon-color, var(--calcite-block-icon-color, var(--calcite-color-text-3)));
+  color: var(--calcite-block-collapsible-icon-color, var(--calcite-block-icon-color, var(--calcite-color-text-3)));
 }
 
 .toggle:hover .toggle-icon {
   color: var(
-    --calcite-block-expandable-icon-color-hover,
+    --calcite-block-collapsible-icon-color-hover,
     var(--calcite-block-icon-color-hover, var(--calcite-color-text-1))
   );
 }

--- a/packages/components/src/components/block/block.scss
+++ b/packages/components/src/components/block/block.scss
@@ -13,8 +13,12 @@
  * @prop --calcite-block-padding: [Deprecated] in v3.3.0, removal target v6.0.0 - Use `--calcite-block-content-space` instead. Specifies the padding of the component's `default` slot.
  * @prop --calcite-block-text-color:[Deprecated] in v3.3.0, removal target v6.0.0 - Specifies the component's text color.
  * @prop --calcite-block-description-text-color: Specifies the component's `description` text color.
- * @prop --calcite-block-icon-color: Specifies the component's `collapsible` icon, `iconStart` and `iconEnd` color.
- * @prop --calcite-block-icon-color-hover: Specifies the component's `collapsible` icon color when hovered.
+ * @prop --calcite-block-icon-color: [Deprecated] - Use `--calcite-block-expandable-icon-color`, `--calcite-block-icon-start-color` and `--calcite-block-icon-end-color` instead. Specifies the component's `collapsible` icon, `iconStart` and `iconEnd` color.
+ * @prop --calcite-block-icon-color-hover: [Deprecated] - Use `--calcite-block-expandable-icon-color-hover` instead. Specifies the component's `collapsible` icon color when hovered.
+ * @prop --calcite-block-icon-start-color: Specifies the component's `iconStart` color.
+ * @prop --calcite-block-icon-end-color: Specifies the component's `iconEnd` color.
+ * @prop --calcite-block-expandable-icon-color: Specifies the component's `collapsible` icon color.
+ * @prop --calcite-block-expandable-icon-color-hover: Specifies the component's `collapsible` icon color when hovered.
  */
 
 // AUTO-GENERATED — do not modify. Changes will be overwritten.
@@ -151,9 +155,12 @@
   grid-template-areas: "handle header icon-end menu actions-end";
 }
 
-.icon--start,
+.icon--start {
+  color: var(--calcite-block-icon-start-color, var(--calcite-block-icon-color, var(--calcite-color-text-3)));
+}
+
 .icon--end {
-  color: var(--calcite-block-icon-color, var(--calcite-color-text-3));
+  color: var(--calcite-block-icon-end-color, var(--calcite-block-icon-color, var(--calcite-color-text-3)));
 }
 
 .actions-end {
@@ -257,11 +264,14 @@ calcite-sort-handle {
   self-center
   justify-self-end
   ease-in-out;
-  color: var(--calcite-block-icon-color, var(--calcite-color-text-3));
+  color: var(--calcite-block-expandable-icon-color, var(--calcite-block-icon-color, var(--calcite-color-text-3)));
 }
 
 .toggle:hover .toggle-icon {
-  color: var(--calcite-block-icon-color-hover, var(--calcite-color-text-1));
+  color: var(
+    --calcite-block-expandable-icon-color-hover,
+    var(--calcite-block-icon-color-hover, var(--calcite-color-text-1))
+  );
 }
 
 .container {
@@ -304,9 +314,12 @@ calcite-action-menu {
     color: var(--calcite-block-description-text-color, var(--calcite-color-text-2));
   }
 
-  .icon--start,
+  .icon--start {
+    color: var(--calcite-block-icon-start-color, var(--calcite-block-icon-color, var(--calcite-color-text-1)));
+  }
+
   .icon--end {
-    color: var(--calcite-block-icon-color, var(--calcite-color-text-1));
+    color: var(--calcite-block-icon-end-color, var(--calcite-block-icon-color, var(--calcite-color-text-1)));
   }
 
   .content {

--- a/packages/components/src/custom-theme/block.ts
+++ b/packages/components/src/custom-theme/block.ts
@@ -11,6 +11,10 @@ export const blockTokens = {
   calciteBlockDescriptionTextColor: "",
   calciteBlockIconColor: "",
   calciteBlockIconColorHover: "",
+  calciteBlockIconStartColor: "",
+  calciteBlockIconEndColor: "",
+  calciteBlockExpandableIconColor: "",
+  calciteBlockExpandableIconColorHover: "",
 };
 
 export const block = html` <calcite-block

--- a/packages/components/src/custom-theme/block.ts
+++ b/packages/components/src/custom-theme/block.ts
@@ -13,8 +13,8 @@ export const blockTokens = {
   calciteBlockIconColorHover: "",
   calciteBlockIconStartColor: "",
   calciteBlockIconEndColor: "",
-  calciteBlockExpandableIconColor: "",
-  calciteBlockExpandableIconColorHover: "",
+  calciteBlockCollapsibleIconColor: "",
+  calciteBlockCollapsibleIconColorHover: "",
 };
 
 export const block = html` <calcite-block


### PR DESCRIPTION
**Related Issue:** [#12128](https://github.com/Esri/calcite-design-system/issues/12128)

## Summary

- Add the following CSS tokens to be able to independently style icons:
`--calcite-block-icon-start-color`, `--calcite-block-icon-end-color`, `--calcite-block-expandable-icon-color` and `--calcite-block-expandable-icon-color-hover`.

deprecate(block): deprecate `--calcite-block-icon-color` and `--calcite-block-icon-color-hover` CSS tokens.