### PR TITLE
fix(action-bar, action-pad): ensure actions remain tabbable when tabbed through

### DIFF
--- a/packages/components/src/components/action-bar/action-bar.browser.e2e.tsx
+++ b/packages/components/src/components/action-bar/action-bar.browser.e2e.tsx
@@ -17,6 +17,7 @@ import { mockConsole } from "../../tests/utils/logging";
 import { DEBOUNCE } from "../../utils/resources";
 import { SLOTS } from "./resources";
 import { ActionBar } from "./action-bar";
+import { html } from "lit";
 
 mockConsole();
 
@@ -286,4 +287,33 @@ describe("overflowing actions", () => {
     await expect.element(triggerActions.nth(1)).toBeInViewport();
     await expect.element(triggerActions.nth(2)).toBeInViewport();
   });
+});
+
+it("keeps actions tabbable when tabbing out", async () => {
+  await mount(html`
+    <calcite-action-bar expand-disabled>
+      <calcite-action text="first" icon="number-circle-1"></calcite-action>
+      <calcite-action text="second" icon="number-circle-2"></calcite-action>
+    </calcite-action-bar>
+    <calcite-action text="third" icon="number-circle-3"></calcite-action>
+  `);
+  const actions = page.getBySelector("calcite-action");
+
+  await userEvent.keyboard("{Tab}");
+  await expect.element(actions.nth(0)).toHaveFocus();
+
+  await userEvent.keyboard("{Tab}");
+  await expect.element(actions.nth(2)).toHaveFocus();
+
+  await userEvent.keyboard("{Tab}");
+  expect(document.body).toHaveFocus();
+
+  await userEvent.keyboard("{Shift>}{Tab}{Shift/}");
+  await expect.element(actions.nth(2)).toHaveFocus();
+
+  await userEvent.keyboard("{Shift>}{Tab}{Shift/}");
+  await expect.element(actions.nth(0)).toHaveFocus();
+
+  await userEvent.keyboard("{Shift>}{Tab}{Shift/}");
+  expect(document.body).toHaveFocus();
 });

--- a/packages/components/src/components/action-bar/action-bar.tsx
+++ b/packages/components/src/components/action-bar/action-bar.tsx
@@ -501,8 +501,8 @@ export class ActionBar extends LitElement {
     this.actions.forEach((action) => {
       const tabIndex = !action.disabled && action === active ? 0 : -1;
 
-      // intentionally using setAttribute to avoid reflecting -1 so default browser behavior will occur
       if (tabIndex === 0) {
+        // action's internal button is tabbable by default, so we remove the attribute to avoid an extra tabbable element
         action.removeAttribute("tabindex");
       } else {
         action.tabIndex = tabIndex;

--- a/packages/components/src/components/action-bar/action-bar.tsx
+++ b/packages/components/src/components/action-bar/action-bar.tsx
@@ -2,6 +2,7 @@ import { debounce } from "es-toolkit";
 import { PropertyValues } from "lit";
 import {
   createEvent,
+  h,
   JsxNode,
   LitElement,
   method,

--- a/packages/components/src/components/action-bar/action-bar.tsx
+++ b/packages/components/src/components/action-bar/action-bar.tsx
@@ -1,18 +1,18 @@
 import { debounce } from "es-toolkit";
 import { PropertyValues } from "lit";
 import {
-  LitElement,
-  property,
   createEvent,
-  h,
-  method,
-  state,
   JsxNode,
+  LitElement,
+  method,
+  property,
+  state,
   ToEvents,
 } from "@arcgis/lumina";
 import { createRef } from "lit/directives/ref.js";
 import { useDirection } from "@arcgis/lumina/controllers";
 import {
+  focusElementInGroup,
   getStylePixelValue,
   slotChangeGetAssignedElements,
   slotChangeHasAssignedElement,
@@ -30,7 +30,6 @@ import { useSetFocus } from "../../controllers/useSetFocus";
 import { Action } from "../action/action";
 import { isAction } from "../action/resources";
 import { getOverflowCount } from "../../utils/overflow";
-import { focusElementInGroup } from "../../utils/dom";
 import { type ActionMenu } from "../action-menu/action-menu";
 import T9nStrings from "./assets/t9n/messages.en.json";
 import { CSS, SLOTS } from "./resources";
@@ -469,7 +468,7 @@ export class ActionBar extends LitElement {
     const actions = this.actions.filter((action) => !action.disabled);
     const current = document.activeElement;
 
-    if (!isAction(current)) {
+    if (!isAction(current) || !actions.includes(current)) {
       return;
     }
 
@@ -499,8 +498,15 @@ export class ActionBar extends LitElement {
   }
 
   private setActionTabIndexes(active: Action["el"]): void {
-    this.actions.forEach((action: Action["el"]) => {
-      action.tabIndex = !action.disabled && action === active ? 0 : -1;
+    this.actions.forEach((action) => {
+      const tabIndex = !action.disabled && action === active ? 0 : -1;
+
+      // intentionally using setAttribute to avoid reflecting -1 so default browser behavior will occur
+      if (tabIndex === 0) {
+        action.removeAttribute("tabindex");
+      } else {
+        action.tabIndex = tabIndex;
+      }
     });
   }
 
@@ -521,9 +527,9 @@ export class ActionBar extends LitElement {
         collapseText={messages.collapse}
         direction={this.direction}
         el={el}
+        expanded={expanded}
         expandLabel={messages.expandLabel}
         expandText={messages.expand}
-        expanded={expanded}
         position={position}
         ref={this.setExpandToggleEl}
         scale={scale}

--- a/packages/components/src/components/action-pad/action-pad.browser.e2e.tsx
+++ b/packages/components/src/components/action-pad/action-pad.browser.e2e.tsx
@@ -1,5 +1,5 @@
 import { h } from "@arcgis/lumina";
-import { userEvent } from "vitest/browser";
+import { page, userEvent } from "vitest/browser";
 import { describe, it, expect } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import {
@@ -14,6 +14,7 @@ import {
 } from "../../tests/commonTests/browser";
 import { mockConsole } from "../../tests/utils/logging";
 import { SLOTS } from "./resources";
+import { html } from "lit";
 
 mockConsole();
 
@@ -188,4 +189,33 @@ describe("selection-modes", () => {
     expect(action3.active).toBe(false);
     expect(action4.active).toBe(false);
   });
+});
+
+it("keeps actions tabbable when tabbing out", async () => {
+  await mount(html`
+    <calcite-action-pad expand-disabled>
+      <calcite-action text="first" icon="number-circle-1"></calcite-action>
+      <calcite-action text="second" icon="number-circle-2"></calcite-action>
+    </calcite-action-pad>
+    <calcite-action text="third" icon="number-circle-3"></calcite-action>
+  `);
+  const actions = page.getBySelector("calcite-action");
+
+  await userEvent.keyboard("{Tab}");
+  await expect.element(actions.nth(0)).toHaveFocus();
+
+  await userEvent.keyboard("{Tab}");
+  await expect.element(actions.nth(2)).toHaveFocus();
+
+  await userEvent.keyboard("{Tab}");
+  expect(document.body).toHaveFocus();
+
+  await userEvent.keyboard("{Shift>}{Tab}{Shift/}");
+  await expect.element(actions.nth(2)).toHaveFocus();
+
+  await userEvent.keyboard("{Shift>}{Tab}{Shift/}");
+  await expect.element(actions.nth(0)).toHaveFocus();
+
+  await userEvent.keyboard("{Shift>}{Tab}{Shift/}");
+  expect(document.body).toHaveFocus();
 });

--- a/packages/components/src/components/action-pad/action-pad.tsx
+++ b/packages/components/src/components/action-pad/action-pad.tsx
@@ -252,7 +252,7 @@ export class ActionPad extends LitElement {
     const actions = this.actions.filter((action) => !action.disabled);
     const current = document.activeElement;
 
-    if (!isAction(current)) {
+    if (!isAction(current) || !actions.includes(current)) {
       return;
     }
 
@@ -287,9 +287,16 @@ export class ActionPad extends LitElement {
     });
   }
 
-  private updateTabIndexOfItems(target: Action["el"]): void {
-    this.actions.forEach((item: Action["el"]) => {
-      item.tabIndex = target !== item ? -1 : 0;
+  private updateTabIndexOfItems(active: Action["el"]): void {
+    this.actions.forEach((action) => {
+      const tabIndex = !action.disabled && action === active ? 0 : -1;
+
+      if (tabIndex === 0) {
+        // action's internal button is tabbable by default, so we remove the attribute to avoid an extra tabbable element
+        action.removeAttribute("tabindex");
+      } else {
+        action.tabIndex = tabIndex;
+      }
     });
   }
 
@@ -327,9 +334,9 @@ export class ActionPad extends LitElement {
         collapseText={messages.collapse}
         direction={this.direction}
         el={el}
+        expanded={expanded}
         expandLabel={messages.expandLabel}
         expandText={messages.expand}
-        expanded={expanded}
         position={position}
         scale={scale}
         toggle={toggleExpand}


### PR DESCRIPTION
**Related Issue:** #14133

## Summary

Updates `action-bar` and `action-pad` to only update its action's tab indices if they are tabbing within the component.

**Note**: this also tweaks the `tabIndex` logic to only set it when making actions non-tabbable since they are tabbable by default. 
