### PR TITLE
fix(list): remove interactive states for `interaction-mode=static`

### DIFF
--- a/packages/components/src/components/list-item/list-item.e2e.ts
+++ b/packages/components/src/components/list-item/list-item.e2e.ts
@@ -15,14 +15,14 @@ it("displays hover class", async () => {
   expect(await page.find(`calcite-list-item >>> .${CSS.containerHover}`)).not.toBeNull();
 });
 
-it("displays hover class as fallback when selection-mode !== none and interaction-mode === static and selection-appearance === border", async () => {
+it("does not display hover class as fallback when selection-mode !== none and interaction-mode === static and selection-appearance === border", async () => {
   const page = await newE2EPage();
   await page.setContent(
     `<calcite-list-item selection-mode="single" interaction-mode="static" selection-appearance="border"></calcite-list-item>`,
   );
   await page.waitForChanges();
 
-  expect(await page.find(`calcite-list-item >>> .${CSS.containerHover}`)).not.toBeNull();
+  expect(await page.find(`calcite-list-item >>> .${CSS.containerHover}`)).toBeNull();
 });
 
 it("does not display hover class when selection-mode === none and interaction-mode === static", async () => {

--- a/packages/components/src/components/list-item/list-item.e2e.ts
+++ b/packages/components/src/components/list-item/list-item.e2e.ts
@@ -1,4 +1,4 @@
-import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
+import { E2EPage, newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import { themed } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
@@ -7,11 +7,17 @@ import { CSS } from "./resources";
 
 mockConsole();
 
+async function assertItemTextSelection(page: E2EPage, expectedValue: "none" | "auto"): Promise<void> {
+  const contentContainer = await page.find(`calcite-list-item >>> .${CSS.contentContainer}`);
+  expect(await contentContainer.getComputedStyle()).toHaveProperty("user-select", expectedValue);
+}
+
 it("displays hover class", async () => {
   const page = await newE2EPage();
   await page.setContent(`<calcite-list-item interaction-mode="interactive"></calcite-list-item>`);
   await page.waitForChanges();
 
+  await assertItemTextSelection(page, "none");
   expect(await page.find(`calcite-list-item >>> .${CSS.containerHover}`)).not.toBeNull();
 });
 
@@ -22,6 +28,7 @@ it("does not display hover class as fallback when selection-mode !== none and in
   );
   await page.waitForChanges();
 
+  await assertItemTextSelection(page, "auto");
   expect(await page.find(`calcite-list-item >>> .${CSS.containerHover}`)).toBeNull();
 });
 
@@ -30,6 +37,7 @@ it("does not display hover class when selection-mode === none and interaction-mo
   await page.setContent(`<calcite-list-item selection-mode="none" interaction-mode="static"></calcite-list-item>`);
   await page.waitForChanges();
 
+  await assertItemTextSelection(page, "auto");
   expect(await page.find(`calcite-list-item >>> .${CSS.containerHover}`)).toBeNull();
 });
 
@@ -40,6 +48,7 @@ it("does not display hover class when selection-mode !== none and interaction-mo
   );
   await page.waitForChanges();
 
+  await assertItemTextSelection(page, "auto");
   expect(await page.find(`calcite-list-item >>> .${CSS.containerHover}`)).toBeNull();
 });
 

--- a/packages/components/src/components/list-item/list-item.scss
+++ b/packages/components/src/components/list-item/list-item.scss
@@ -105,12 +105,6 @@
   color: var(--calcite-list-icon-color, var(--calcite-color-border-input));
 }
 
-:host(:not([disabled]):not([selected])) .container:hover .selection-container--single {
-  color: var(--calcite-list-icon-color, var(--calcite-color-border-input));
-}
-
-:host([selected]:hover) .selection-container,
-:host([selected]:hover) .selection-container--single,
 :host([selected]) .selection-container {
   color: var(--calcite-list-icon-color, var(--calcite-color-brand));
 }
@@ -136,6 +130,21 @@
 }
 
 :host(:not([interaction-mode="static"])) {
+  &:not([disabled]):not([selected]) .container:hover .selection-container--single {
+    color: var(--calcite-list-icon-color, var(--calcite-color-border-input));
+  }
+
+  &:not([disabled]) .expanded-container:hover {
+    color: var(--calcite-list-icon-color, var(--calcite-color-text-1));
+  }
+
+  &[selected]:hover {
+    .selection-container,
+    .selection-container--single {
+      color: var(--calcite-list-icon-color, var(--calcite-color-brand));
+    }
+  }
+
   .content-container {
     user-select: none;
   }
@@ -147,6 +156,13 @@
 
   .container:active {
     background-color: var(--calcite-list-background-color-press, var(--calcite-color-foreground-3));
+  }
+
+  .icon {
+    &:hover,
+    &:active {
+      color: var(--calcite-color-text-1);
+    }
   }
 }
 
@@ -184,11 +200,6 @@
 .icon {
   align-self: center;
   color: var(--calcite-list-icon-color, var(--calcite-color-text-3));
-
-  &:hover,
-  &:active {
-    color: var(--calcite-color-text-1);
-  }
 }
 
 .actions-start,
@@ -399,10 +410,6 @@
 .expanded-container {
   color: var(--calcite-list-icon-color, var(--calcite-color-text-3));
   padding-inline: var(--calcite-spacing-xxs);
-}
-
-:host(:not([disabled])) .expanded-container:hover {
-  color: var(--calcite-list-icon-color, var(--calcite-color-text-1));
 }
 
 .actions-start,

--- a/packages/components/src/components/list-item/list-item.scss
+++ b/packages/components/src/components/list-item/list-item.scss
@@ -60,15 +60,6 @@
   }
 }
 
-.container--hover:hover {
-  @apply cursor-pointer;
-  background-color: var(--calcite-list-background-color-hover, var(--calcite-color-foreground-2));
-}
-
-.container:active {
-  background-color: var(--calcite-list-background-color-press, var(--calcite-color-foreground-3));
-}
-
 .container--border {
   position: relative;
 
@@ -133,8 +124,7 @@
 }
 
 .content-container {
-  @apply select-none
-    flex
+  @apply flex
     flex-auto
     font-normal
     items-stretch;
@@ -143,6 +133,21 @@
 
 .content-container--unavailable {
   @apply opacity-disabled;
+}
+
+:host(:not([interaction-mode="static"])) {
+  .content-container {
+    user-select: none;
+  }
+
+  .container--hover:hover {
+    cursor: pointer;
+    background-color: var(--calcite-list-background-color-hover, var(--calcite-color-foreground-2));
+  }
+
+  .container:active {
+    background-color: var(--calcite-list-background-color-press, var(--calcite-color-foreground-3));
+  }
 }
 
 .row,

--- a/packages/components/src/components/list-item/list-item.tsx
+++ b/packages/components/src/components/list-item/list-item.tsx
@@ -1048,12 +1048,7 @@ export class ListItem extends LitElement implements SortableComponentItem {
     const contentContainerWrapperBordered = bordered && !hasContentBottom;
     const showSelectionBorder = selectionMode !== "none" && selectionAppearance === "border";
     const showSelectionHighlight = selectionMode !== "none" && selectionAppearance === "highlight";
-
-    const containerInteractive =
-      interactionMode === "interactive" ||
-      (interactionMode === "static" &&
-        selectionMode !== "none" &&
-        selectionAppearance === "border");
+    const containerInteractive = interactionMode === "interactive";
 
     return (
       <this.interactiveContainer disabled={disabled}>

--- a/packages/components/src/components/list-item/list-item.tsx
+++ b/packages/components/src/components/list-item/list-item.tsx
@@ -159,7 +159,7 @@ export class ListItem extends LitElement implements SortableComponentItem {
    *
    * @private
    */
-  @property() interactionMode: InteractionMode = null;
+  @property({ reflect: true }) interactionMode: InteractionMode = null;
 
   /** Specifies an accessible label for the component, displays above the `description`. */
   @property() label: string;


### PR DESCRIPTION
**Related Issue:** #12542 

## Summary

In addition to removing interactive states in static interaction mode, text is now selectable in this mode.