### PR TITLE
fix(sheet): restore shadow

### DIFF
--- a/packages/components/src/components/sheet/sheet.scss
+++ b/packages/components/src/components/sheet/sheet.scss
@@ -111,19 +111,19 @@
   );
 }
 
-:host([display-mode="overlay"][position="inline-start"]) .container {
+:host([display-mode="overlay"][position="inline-start"]) .content {
   box-shadow: var(--calcite-scrim-shadow-inline-start-internal);
 }
 
-:host([display-mode="overlay"][position="inline-end"]) .container {
+:host([display-mode="overlay"][position="inline-end"]) .content {
   box-shadow: var(--calcite-scrim-shadow-inline-end-internal);
 }
 
-:host([display-mode="overlay"][position="block-start"]) .container {
+:host([display-mode="overlay"][position="block-start"]) .content {
   box-shadow: var(--calcite-scrim-shadow-block-start-internal);
 }
 
-:host([display-mode="overlay"][position="block-end"]) .container {
+:host([display-mode="overlay"][position="block-end"]) .content {
   box-shadow: var(--calcite-scrim-shadow-block-end-internal);
 }
 

--- a/packages/components/src/components/sheet/sheet.stories.ts
+++ b/packages/components/src/components/sheet/sheet.stories.ts
@@ -165,3 +165,16 @@ export const darkModeFloatRTL = (): string =>
   </div>`;
 
 darkModeFloatRTL.parameters = { themes: modesDarkDefault };
+
+export const shadowAcrossModesAndPositions = (): string => html`
+  <style>
+    :root {
+      --calcite-sheet-scrim-background: transparent;
+      --calcite-sheet-shadow: 0 8px 24px blue;
+    }
+  </style>
+  <calcite-sheet label="overlay + block" open position="block-start">${panelHTML}</calcite-sheet>
+  <calcite-sheet display-mode="float" label="float + block" open position="block-end">${panelHTML}</calcite-sheet>
+  <calcite-sheet label="overlay + inline" open position="inline-start">${panelHTML}</calcite-sheet>
+  <calcite-sheet display-mode="float" label="float + inline" open position="inline-end">${panelHTML}</calcite-sheet>
+`;


### PR DESCRIPTION
**Related Issue:** #14362 

## Summary

Fixes regression from https://github.com/Esri/calcite-design-system/pull/12904 by moving shadow styles to container within top layer.

### Notes

* existing tests provide coverage
* this seems to be an improvement and leads to consistent shadow styles as previously the shadow would appear below the scrim instead of above.

Compare rendering of the following shadow: `0 8px 24px blue`

**before**

<img width="698" height="477" alt="Screenshot 2026-05-15 at 10 55 44 AM" src="https://github.com/user-attachments/assets/4e8a81b3-d99c-4fe0-912c-3482183c226f" />

**after**

<img width="673" height="472" alt="Screenshot 2026-05-15 at 10 56 10 AM" src="https://github.com/user-attachments/assets/1e25a68d-cafa-4332-994b-c494b516d5dc" />