### PR TITLE
fix(tree): restore tabbing through items

### DIFF
--- a/packages/components/src/components/tree/tree.browser.e2e.tsx
+++ b/packages/components/src/components/tree/tree.browser.e2e.tsx
@@ -1,8 +1,9 @@
 import { h } from "@arcgis/lumina";
-import { describe } from "vitest";
+import { describe, it, expect } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import { defaults, hidden, renders } from "../../tests/commonTests/browser";
 import { mockConsole } from "../../tests/utils/logging";
+import { page, userEvent } from "vitest/browser";
 
 mockConsole();
 
@@ -40,4 +41,29 @@ describe("renders", () => {
       ),
     { display: "block" },
   );
+});
+
+it("is focusable after making a selection across trees with slotted items", async () => {
+  await mount(
+    <calcite-tree>
+      <calcite-tree-item>
+        should be focused first
+        <calcite-action
+          data-testid="action"
+          icon="banana"
+          slot="actions-end"
+          text="should be focused second"
+          text-enabled
+        />
+      </calcite-tree-item>
+    </calcite-tree>,
+  );
+  const item = page.getByText("should be focused first");
+  const action = page.getByTestId("action");
+
+  await userEvent.keyboard("{Tab}");
+  await expect.element(item).toHaveFocus();
+
+  await userEvent.keyboard("{Tab}");
+  await expect.element(action).toHaveFocus();
 });

--- a/packages/components/src/components/tree/tree.tsx
+++ b/packages/components/src/components/tree/tree.tsx
@@ -114,7 +114,7 @@ export class Tree extends LitElement {
         this.el.querySelector<TreeItem["el"]>("calcite-tree-item[selected]:not([disabled])") ||
         this.el.querySelector<TreeItem["el"]>("calcite-tree-item:not([disabled])");
 
-      focusElement(focusTarget);
+      focusElement(focusTarget, true, "focusable");
     }
   }
 


### PR DESCRIPTION
**Related Issue:** #13938

## Summary

Fixes a regression from https://github.com/Esri/calcite-design-system/pull/11943 that prevented items from being tabbed through if they contained focusable elements.