### PR TITLE
refactor(segmented-control-item): remove non-applicable `--calcite-segmented-control-border-color`

### DIFF
--- a/packages/components/src/components/segmented-control-item/segmented-control-item.e2e.ts
+++ b/packages/components/src/components/segmented-control-item/segmented-control-item.e2e.ts
@@ -111,10 +111,6 @@ describe("theme", () => {
       shadowSelector: `.${CSS.label}`,
       targetProp: "backgroundColor",
     },
-    "--calcite-segmented-control-border-color": {
-      shadowSelector: `.${CSS.label}`,
-      targetProp: "borderColor",
-    },
     "--calcite-segmented-control-shadow": {
       shadowSelector: `.${CSS.label}`,
       targetProp: "boxShadow",

--- a/packages/components/src/components/segmented-control-item/segmented-control-item.scss
+++ b/packages/components/src/components/segmented-control-item/segmented-control-item.scss
@@ -5,7 +5,6 @@
  *
  * @prop --calcite-segmented-control-color: Specifies the component's color.
  * @prop --calcite-segmented-control-background-color: Specifies the component's background color.
- * @prop --calcite-segmented-control-border-color: Specifies the component's border color.
  * @prop --calcite-segmented-control-shadow: Specifies the component's shadow.
  * @prop --calcite-segmented-control-icon-color: Specifies the icons's color.
  */

--- a/packages/components/src/components/segmented-control-item/segmented-control-item.scss
+++ b/packages/components/src/components/segmented-control-item/segmented-control-item.scss
@@ -39,7 +39,6 @@
   color: var(--calcite-segmented-control-color, var(--calcite-color-text-3));
   background-color: var(--calcite-segmented-control-background-color);
   box-shadow: var(--calcite-segmented-control-shadow);
-  border-color: var(--calcite-segmented-control-border-color);
   transition:
     background-color var(--calcite-internal-animation-timing-fast) ease-in-out,
     border-color var(--calcite-internal-animation-timing-fast) ease-in-out,
@@ -82,14 +81,12 @@
 :host([checked]) .label {
   @apply cursor-default;
   background-color: var(--calcite-segmented-control-background-color, var(--calcite-color-brand));
-  border-color: var(--calcite-segmented-control-border-color, var(--calcite-color-brand));
   color: var(--calcite-segmented-control-color, var(--calcite-color-text-inverse));
 }
 
 :host([checked]) .label--outline,
 :host([checked]) .label--outline-fill {
   background-color: var(--calcite-segmented-control-background-color, var(--calcite-color-foreground-1));
-  border-color: var(--calcite-segmented-control-border-color, var(--calcite-color-brand));
   box-shadow: var(--calcite-segmented-control-shadow, inset 0 0 0 1px var(--calcite-color-brand));
   color: var(--calcite-segmented-control-color, var(--calcite-color-brand));
 }

--- a/packages/components/src/components/segmented-control-item/segmented-control-item.scss
+++ b/packages/components/src/components/segmented-control-item/segmented-control-item.scss
@@ -24,9 +24,7 @@
     self-stretch
     font-normal
     focus-base;
-  transition:
-    background-color var(--calcite-internal-animation-timing-fast) ease-in-out,
-    border-color var(--calcite-animation-timing) ease-in-out;
+  transition: background-color var(--calcite-internal-animation-timing-fast) ease-in-out;
 }
 
 .label {
@@ -41,7 +39,6 @@
   box-shadow: var(--calcite-segmented-control-shadow);
   transition:
     background-color var(--calcite-internal-animation-timing-fast) ease-in-out,
-    border-color var(--calcite-internal-animation-timing-fast) ease-in-out,
     color var(--calcite-internal-animation-timing-fast) ease-in-out;
 }
 


### PR DESCRIPTION
**Related Issue:** #14451

## Summary
Remove --calcite-segmented-control-border-color from Segmented Control Item page. 

Note: `--calcite-segmented-control-border-color` does not need to be deprecated since the token still exists on the Segmented Control page. It does not apply to Segmented Control Item.