### PR TITLE
fix(list): ensure filter input displays over sticky headers

### DIFF
--- a/packages/components/src/components/list/list.browser.e2e.tsx
+++ b/packages/components/src/components/list/list.browser.e2e.tsx
@@ -18,6 +18,7 @@ import { afterNextFrame, afterNextTask } from "../../tests/utils/timing";
 import { waitForEvent } from "../../tests/commonTests/browser/utils";
 import { DEBOUNCE } from "../../utils/resources";
 import { List } from "./list";
+import { CSS as listCSS } from "./resources";
 
 const scrollTopValue = 120;
 
@@ -250,6 +251,35 @@ describe("sticky group heading with filter", () => {
     // allow a small tolerance for sub-pixel differences
     const tolerance = 2;
     expect(stickyRect.top).toBeGreaterThanOrEqual(filterRect.bottom - tolerance);
+  });
+
+  it("keeps the filter container stacked above sticky list-item-group headings", async () => {
+    await mount(
+      <calcite-list filter-enabled style="height: 160px; overflow-y: auto;">
+        <calcite-list-item-group heading="Group A">
+          <calcite-list-item label="A1" value="a1" />
+          <calcite-list-item label="A2" value="a2" />
+          <calcite-list-item label="A3" value="a3" />
+          <calcite-list-item label="A4" value="a4" />
+          <calcite-list-item label="A5" value="a5" />
+          <calcite-list-item label="A6" value="a6" />
+          <calcite-list-item label="A7" value="a7" />
+          <calcite-list-item label="A8" value="a8" />
+        </calcite-list-item-group>
+      </calcite-list>,
+    );
+
+    const filterContainer = page.getBySelector(`calcite-list .${listCSS.sticky}`).element();
+
+    const stickyGroupContainer = page
+      .getBySelector(`calcite-list-item-group .${listItemGroupCSS.container}`)
+      .first()
+      .element();
+
+    const filterZIndex = Number.parseInt(getComputedStyle(filterContainer).zIndex, 10);
+    const stickyGroupZIndex = Number.parseInt(getComputedStyle(stickyGroupContainer).zIndex, 10);
+
+    expect(filterZIndex).toBeGreaterThan(stickyGroupZIndex);
   });
 });
 

--- a/packages/components/src/components/list/list.scss
+++ b/packages/components/src/components/list/list.scss
@@ -63,8 +63,8 @@
 
 .sticky-pos {
   @apply sticky
-  top-0
-  z-sticky;
+  top-0;
+  z-index: calc(var(--calcite-z-index-sticky) + 1);
   background-color: var(--calcite-list-background-color, var(--calcite-color-foreground-1));
 }
 


### PR DESCRIPTION
**Related Issue:** #14324

### Changes
- Updates list sticky filter styling to explicitly stack above sticky slotted group headers.
- Adds a browser E2E test that verifies the filter container has a higher z-index than the sticky list-item-group heading container.

### Why
When both features are present, sticky list-item-group headings could render above the filter container. This change locks in the expected layering behavior and prevents regressions.