### PR TITLE
fix(date-picker): update selected day text color fallback

### DIFF
--- a/packages/components/src/components/date-picker-day/date-picker-day.scss
+++ b/packages/components/src/components/date-picker-day/date-picker-day.scss
@@ -105,7 +105,7 @@
 :host([selected]) .day {
   @apply font-medium;
   background-color: var(--calcite-date-picker-day-background-color-selected, var(--calcite-color-brand));
-  color: var(--calcite-date-picker-day-text-color-selected, var(--calcite-color-foreground-1));
+  color: var(--calcite-date-picker-day-text-color-selected, var(--calcite-color-text-inverse));
 }
 
 :host([range-hover]:not([selected])) {


### PR DESCRIPTION
**Related Issue:** #14055

## Summary

- updates selected day text color fallback from `foreground.1` to `text.inverse`
  - default in light mode: `#ffffff` -> `#ffffff` (unchanged)
  - default in dark mode: `#2b2b2b` -> `#141414`