### PR TITLE
feat(panel): add closable dialog semantics and expand focus-trap coverage

### DIFF
--- a/packages/components/src/components/dialog/dialog.browser.e2e.tsx
+++ b/packages/components/src/components/dialog/dialog.browser.e2e.tsx
@@ -272,6 +272,13 @@ describe("internal panel semantics", () => {
 
     expect(internalPanelRole).toBe("article");
   });
+
+  it("disables internal panel focus trap", async () => {
+    await mount(<calcite-dialog heading="heading" open />);
+    const internalPanel = page.getBySelector(`calcite-panel.${CSS.panel}`);
+
+    await expect.element(internalPanel).toHaveAttribute("focus-trap-disabled");
+  });
 });
 
 describe("translation support", () => {

--- a/packages/components/src/components/dialog/dialog.browser.e2e.tsx
+++ b/packages/components/src/components/dialog/dialog.browser.e2e.tsx
@@ -262,6 +262,18 @@ describe("top layer placement", () => {
   });
 });
 
+describe("internal panel semantics", () => {
+  it("sets internal panel container role to article", async () => {
+    const { el } = await mount(<calcite-dialog heading="heading" open />);
+    const internalPanel = el.shadowRoot.querySelector<HTMLElement>(`calcite-panel.${CSS.panel}`);
+    const internalPanelRole = internalPanel?.shadowRoot
+      ?.querySelector(".container")
+      ?.getAttribute("role");
+
+    expect(internalPanelRole).toBe("article");
+  });
+});
+
 describe("translation support", () => {
   t9n(() => mount("calcite-dialog"));
 });

--- a/packages/components/src/components/dialog/dialog.tsx
+++ b/packages/components/src/components/dialog/dialog.tsx
@@ -830,6 +830,7 @@ export class Dialog extends LitElement implements OpenCloseComponentWithEl {
               class={CSS.panel}
               closable={!this.closeDisabled}
               description={description}
+              disableDialogRole={true}
               heading={heading}
               headingLevel={this.headingLevel}
               hidden={!this.opened}

--- a/packages/components/src/components/dialog/dialog.tsx
+++ b/packages/components/src/components/dialog/dialog.tsx
@@ -830,7 +830,7 @@ export class Dialog extends LitElement implements OpenCloseComponentWithEl {
               class={CSS.panel}
               closable={!this.closeDisabled}
               description={description}
-              disableDialogRole={true}
+              dialogRoleDisabled={true}
               heading={heading}
               headingLevel={this.headingLevel}
               hidden={!this.opened}

--- a/packages/components/src/components/dialog/dialog.tsx
+++ b/packages/components/src/components/dialog/dialog.tsx
@@ -831,6 +831,7 @@ export class Dialog extends LitElement implements OpenCloseComponentWithEl {
               closable={!this.closeDisabled}
               description={description}
               dialogRoleDisabled={true}
+              focusTrapDisabled={true}
               heading={heading}
               headingLevel={this.headingLevel}
               hidden={!this.opened}

--- a/packages/components/src/components/flow-item/flow-item.browser.e2e.tsx
+++ b/packages/components/src/components/flow-item/flow-item.browser.e2e.tsx
@@ -1,5 +1,5 @@
 import { h } from "@arcgis/lumina";
-import { describe } from "vitest";
+import { describe, expect, it } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import {
   defaults,
@@ -60,6 +60,14 @@ describe("defaults", () => {
       },
       {
         propertyName: "loading",
+        defaultValue: false,
+      },
+      {
+        propertyName: "focusTrap",
+        defaultValue: false,
+      },
+      {
+        propertyName: "focusTrapDisabled",
         defaultValue: false,
       },
       {
@@ -141,6 +149,14 @@ describe("reflects", () => {
         value: true,
       },
       {
+        propertyName: "focusTrap",
+        value: true,
+      },
+      {
+        propertyName: "focusTrapDisabled",
+        value: true,
+      },
+      {
         propertyName: "overlayPositioning",
         value: "fixed",
       },
@@ -176,6 +192,104 @@ describe("delegates to floating-ui-owner component", () => {
 
 describe("translation support", () => {
   t9n(() => mount("calcite-flow-item"), ["calcite-panel"]);
+});
+
+describe("internal panel", () => {
+  it("passes focusTrap to the internal panel", async () => {
+    const { el, component } = await mount(
+      <calcite-flow-item closable focusTrap selected>
+        content
+      </calcite-flow-item>,
+    );
+
+    await component.updateComplete;
+
+    const panel = el.shadowRoot.querySelector("calcite-panel");
+
+    expect(panel.focusTrap).toBe(true);
+  });
+
+  it("does not pass focusTrap to the internal panel by default", async () => {
+    const { el, component } = await mount(
+      <calcite-flow-item closable selected>
+        content
+      </calcite-flow-item>,
+    );
+
+    await component.updateComplete;
+
+    const panel = el.shadowRoot.querySelector("calcite-panel");
+
+    expect(panel.focusTrap).toBe(false);
+  });
+
+  it("passes focusTrapDisabled to the internal panel when not selected", async () => {
+    const { el, component } = await mount(
+      <calcite-flow-item closable focusTrap focusTrapDisabled>
+        content
+      </calcite-flow-item>,
+    );
+
+    await component.updateComplete;
+
+    const panel = el.shadowRoot.querySelector("calcite-panel");
+
+    expect(panel.focusTrapDisabled).toBe(true);
+  });
+
+  it("passes focusTrapDisabled to the internal panel when selected and explicitly disabled", async () => {
+    const { el, component } = await mount(
+      <calcite-flow-item closable focusTrap focusTrapDisabled selected>
+        content
+      </calcite-flow-item>,
+    );
+
+    await component.updateComplete;
+
+    const panel = el.shadowRoot.querySelector("calcite-panel");
+
+    expect(panel.focusTrapDisabled).toBe(true);
+  });
+
+  it("does not pass focusTrapDisabled to the internal panel when selected and not disabled", async () => {
+    const { el, component } = await mount(
+      <calcite-flow-item closable focusTrap selected>
+        content
+      </calcite-flow-item>,
+    );
+
+    await component.updateComplete;
+
+    const panel = el.shadowRoot.querySelector("calcite-panel");
+
+    expect(panel.focusTrapDisabled).toBe(false);
+  });
+
+  it("updates internal panel focusTrapDisabled when selected changes", async () => {
+    const { el, component } = await mount(
+      <calcite-flow-item closable focusTrap>
+        content
+      </calcite-flow-item>,
+    );
+    const flowItem = component as unknown as HTMLElement & { selected: boolean };
+
+    await component.updateComplete;
+
+    let panel = el.shadowRoot.querySelector("calcite-panel");
+    expect(panel.focusTrapDisabled).toBe(true);
+
+    flowItem.selected = true;
+    await component.updateComplete;
+
+    panel = el.shadowRoot.querySelector("calcite-panel");
+    expect(panel.focusTrapDisabled).toBe(false);
+
+    flowItem.selected = false;
+    await component.updateComplete;
+
+    panel = el.shadowRoot.querySelector("calcite-panel");
+    expect(panel.focusTrapDisabled).toBe(true);
+  });
 });
 
 describe("disabled", () => {

--- a/packages/components/src/components/flow-item/flow-item.tsx
+++ b/packages/components/src/components/flow-item/flow-item.tsx
@@ -116,6 +116,12 @@ export class FlowItem extends LitElement {
   /** When `true`, a busy indicator is displayed. */
   @property({ reflect: true }) loading = false;
 
+  /** When `true`, the component's internal panel will trap focus. */
+  @property({ reflect: true }) focusTrap = false;
+
+  /** When `true`, prevents focus trapping on the internal panel. */
+  @property({ reflect: true }) focusTrapDisabled = false;
+
   /** When `true`, the action menu items in the `header-menu-actions` slot are open. */
   @property({ reflect: true }) menuOpen = false;
 
@@ -311,9 +317,12 @@ export class FlowItem extends LitElement {
       menuOpen,
       messageOverrides,
       overlayPositioning,
+      selected,
       beforeClose,
       icon,
       iconFlipRtl,
+      focusTrap,
+      focusTrapDisabled,
     } = this;
     return (
       <this.interactiveContainer disabled={disabled}>
@@ -321,11 +330,13 @@ export class FlowItem extends LitElement {
           beforeClose={beforeClose}
           closable={closable}
           closed={closed}
-          collapseDirection={collapseDirection}
           collapsed={collapsed}
+          collapseDirection={collapseDirection}
           collapsible={collapsible}
           description={description}
           disabled={disabled}
+          focusTrap={focusTrap}
+          focusTrapDisabled={focusTrapDisabled || !selected}
           heading={heading}
           headingLevel={headingLevel}
           icon={icon}

--- a/packages/components/src/components/flow-item/flow-item.tsx
+++ b/packages/components/src/components/flow-item/flow-item.tsx
@@ -116,10 +116,10 @@ export class FlowItem extends LitElement {
   /** When `true`, a busy indicator is displayed. */
   @property({ reflect: true }) loading = false;
 
-  /** When `true`, the component's internal panel will trap focus. */
+  /** When `true`, the component's internal panel will trap focus. Focus trapping only activates when `selected` is `true`. */
   @property({ reflect: true }) focusTrap = false;
 
-  /** When `true`, prevents focus trapping on the internal panel. */
+  /** When `true`, prevents focus trapping on the internal panel. Focus trapping is also prevented when `selected` is `false`. */
   @property({ reflect: true }) focusTrapDisabled = false;
 
   /** When `true`, the action menu items in the `header-menu-actions` slot are open. */

--- a/packages/components/src/components/panel/panel.browser.e2e.tsx
+++ b/packages/components/src/components/panel/panel.browser.e2e.tsx
@@ -1,7 +1,7 @@
 import { h, Fragment, JsxNode } from "@arcgis/lumina";
 import { describe, expect, it } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { page } from "vitest/browser";
+import { page, userEvent } from "vitest/browser";
 import {
   defaults,
   reflects,
@@ -17,7 +17,7 @@ import {
 import { defaultEndMenuPlacement } from "../../utils/floating-ui";
 import { mockConsole } from "../../tests/utils/logging";
 import { scrolling } from "../../tests/browser/utils/content";
-import { CSS, SLOTS } from "./resources";
+import { CSS, IDS, SLOTS } from "./resources";
 
 export const scrollingHeightStyle = "height: 200px;";
 
@@ -74,6 +74,378 @@ export function renderScrollingContent(): JsxNode {
 
 mockConsole();
 
+describe("focusTrap", () => {
+  const getOutsideBefore = () => page.getByTestId("outside-before");
+  const getOutsideAfter = () => page.getByTestId("outside-after");
+  const getOutside = () => page.getByTestId("outside");
+  const getInsideOne = () => page.getByTestId("inside-1");
+  const getInsideTwo = () => page.getByTestId("inside-2");
+  const getPanel = () => page.getByTestId("panel");
+
+  async function setPanelProperty(property: "closable" | "closed", value: boolean): Promise<void> {
+    const panel = getPanel().element() as HTMLElement & {
+      closable?: boolean;
+      closed?: boolean;
+      updateComplete?: Promise<void>;
+    };
+
+    panel[property] = value;
+    await panel.updateComplete;
+  }
+
+  function expectFocusWithinPanel(): void {
+    const panel = getPanel().element() as HTMLElement;
+    const activeElement = document.activeElement;
+
+    expect(activeElement === panel || panel.contains(activeElement)).toBe(true);
+  }
+
+  it("traps focus when focusTrap=true", async () => {
+    await mount(
+      <div>
+        <button data-testid="outside-before">outside-before</button>
+        <calcite-panel closable data-testid="panel" focusTrap>
+          <button data-testid="inside-1">inside-1</button>
+          <button data-testid="inside-2">inside-2</button>
+        </calcite-panel>
+        <button data-testid="outside-after">outside-after</button>
+      </div>,
+    );
+
+    await (getPanel().element() as HTMLElement & { setFocus: () => Promise<void> }).setFocus();
+
+    for (let i = 0; i < 5; i++) {
+      await userEvent.keyboard("{Tab}");
+
+      await expect.element(getOutsideBefore()).not.toHaveFocus();
+      await expect.element(getOutsideAfter()).not.toHaveFocus();
+      expectFocusWithinPanel();
+    }
+  });
+
+  it("allows outside click when focusTrap=true", async () => {
+    await mount(
+      <div>
+        <calcite-panel closable data-testid="panel" focusTrap>
+          <button data-testid="inside-1">inside-1</button>
+        </calcite-panel>
+        <button data-testid="outside">outside</button>
+      </div>,
+    );
+
+    await userEvent.click(getInsideOne());
+    await userEvent.click(getOutside());
+
+    await expect.element(getOutside()).toHaveFocus();
+  });
+
+  it("deactivates focusTrap when panel becomes not closable", async () => {
+    await mount(
+      <div>
+        <button data-testid="outside-before">outside-before</button>
+        <calcite-panel closable data-testid="panel" focusTrap>
+          <button data-testid="inside-1">inside-1</button>
+          <button data-testid="inside-2">inside-2</button>
+        </calcite-panel>
+        <button data-testid="outside-after">outside-after</button>
+      </div>,
+    );
+
+    await userEvent.click(getInsideTwo());
+    await setPanelProperty("closable", false);
+
+    await userEvent.keyboard("{Tab}");
+
+    await expect.element(getOutsideAfter()).toHaveFocus();
+  });
+
+  it("reactivates focusTrap when panel becomes closable again", async () => {
+    await mount(
+      <div>
+        <button data-testid="outside-before">outside-before</button>
+        <calcite-panel closable data-testid="panel" focusTrap>
+          <button data-testid="inside-1">inside-1</button>
+          <button data-testid="inside-2">inside-2</button>
+        </calcite-panel>
+        <button data-testid="outside-after">outside-after</button>
+      </div>,
+    );
+
+    await userEvent.click(getInsideTwo());
+    await setPanelProperty("closable", false);
+
+    await userEvent.keyboard("{Tab}");
+    await expect.element(getOutsideAfter()).toHaveFocus();
+
+    await setPanelProperty("closable", true);
+    await userEvent.click(getInsideTwo());
+    await userEvent.keyboard("{Tab}");
+
+    await expect.element(getOutsideAfter()).not.toHaveFocus();
+    expectFocusWithinPanel();
+  });
+
+  it("deactivates focusTrap when panel becomes closed", async () => {
+    await mount(
+      <div>
+        <button data-testid="outside-before">outside-before</button>
+        <calcite-panel closable data-testid="panel" focusTrap>
+          <button data-testid="inside-1">inside-1</button>
+          <button data-testid="inside-2">inside-2</button>
+        </calcite-panel>
+        <button data-testid="outside-after">outside-after</button>
+      </div>,
+    );
+
+    await userEvent.click(getInsideTwo());
+    await setPanelProperty("closed", true);
+
+    await userEvent.keyboard("{Tab}");
+
+    await expect.element(getOutsideAfter()).toHaveFocus();
+  });
+
+  it("reactivates focusTrap when panel is reopened", async () => {
+    await mount(
+      <div>
+        <button data-testid="outside-before">outside-before</button>
+        <calcite-panel closable data-testid="panel" focusTrap>
+          <button data-testid="inside-1">inside-1</button>
+          <button data-testid="inside-2">inside-2</button>
+        </calcite-panel>
+        <button data-testid="outside-after">outside-after</button>
+      </div>,
+    );
+
+    await userEvent.click(getInsideTwo());
+    await setPanelProperty("closed", true);
+
+    await userEvent.keyboard("{Tab}");
+    await expect.element(getOutsideAfter()).toHaveFocus();
+
+    await setPanelProperty("closed", false);
+    await userEvent.click(getInsideTwo());
+    await userEvent.keyboard("{Tab}");
+
+    await expect.element(getOutsideAfter()).not.toHaveFocus();
+    expectFocusWithinPanel();
+  });
+
+  it("does not trap focus when focusTrapDisabled=true", async () => {
+    await mount(
+      <div>
+        <button data-testid="outside-before">outside-before</button>
+        <calcite-panel closable data-testid="panel" focusTrap focusTrapDisabled>
+          <button data-testid="inside-1">inside-1</button>
+          <button data-testid="inside-2">inside-2</button>
+        </calcite-panel>
+        <button data-testid="outside-after">outside-after</button>
+      </div>,
+    );
+
+    await userEvent.click(getInsideTwo());
+    await userEvent.keyboard("{Tab}");
+
+    await expect.element(getOutsideAfter()).toHaveFocus();
+  });
+});
+
+describe("closable Escape behavior", () => {
+  function getPanelEl(): HTMLElement & {
+    closed: boolean;
+    updateComplete?: Promise<void>;
+  } {
+    return page.getByTestId("panel").element() as HTMLElement & {
+      closed: boolean;
+      updateComplete?: Promise<void>;
+    };
+  }
+
+  function getContainerEl(): HTMLElement {
+    return getPanelEl().shadowRoot.querySelector(`.${CSS.container}`) as HTMLElement;
+  }
+
+  function getContentWrapperEl(): HTMLElement {
+    return getPanelEl().shadowRoot.querySelector(`.${CSS.contentWrapper}`) as HTMLElement;
+  }
+
+  function getCloseButtonEl(): HTMLElement {
+    return getPanelEl().shadowRoot.querySelector(`#${IDS.close}`) as HTMLElement;
+  }
+
+  it("closes on Escape when closable is true and focusTrap is false (scrollable)", async () => {
+    await mount(
+      <calcite-panel closable data-testid="panel" style={scrollingHeightStyle}>
+        {renderScrollingContent()}
+      </calcite-panel>,
+    );
+
+    const panel = getPanelEl();
+    const container = getContainerEl();
+    const contentWrapper = getContentWrapperEl();
+    let closeEventTimes = 0;
+
+    panel.addEventListener("calcitePanelClose", () => closeEventTimes++);
+
+    expect(panel.closed).toBe(false);
+    expect(container.hidden).toBe(false);
+
+    contentWrapper.focus();
+    await userEvent.keyboard("{Escape}");
+    await panel.updateComplete;
+
+    expect(panel.closed).toBe(true);
+    expect(container.hidden).toBe(true);
+    expect(closeEventTimes).toBe(1);
+  });
+
+  it("closes on Escape when closable and focusTrap are true (scrollable)", async () => {
+    await mount(
+      <calcite-panel closable data-testid="panel" focusTrap style={scrollingHeightStyle}>
+        {renderScrollingContent()}
+      </calcite-panel>,
+    );
+
+    const panel = getPanelEl();
+    const container = getContainerEl();
+    const contentWrapper = getContentWrapperEl();
+    let closeEventTimes = 0;
+
+    panel.addEventListener("calcitePanelClose", () => closeEventTimes++);
+
+    expect(panel.closed).toBe(false);
+    expect(container.hidden).toBe(false);
+
+    contentWrapper.focus();
+    await userEvent.keyboard("{Escape}");
+    await panel.updateComplete;
+
+    expect(panel.closed).toBe(true);
+    expect(container.hidden).toBe(true);
+    expect(closeEventTimes).toBe(1);
+  });
+
+  it("does not close on prevented Escape when closable is true and focusTrap is false", async () => {
+    await mount(
+      <calcite-panel closable data-testid="panel" style={scrollingHeightStyle}>
+        {renderScrollingContent()}
+      </calcite-panel>,
+    );
+
+    const panel = getPanelEl();
+    const container = getContainerEl();
+    const contentWrapper = getContentWrapperEl();
+    let closeEventTimes = 0;
+
+    panel.addEventListener("calcitePanelClose", () => closeEventTimes++);
+    panel.addEventListener(
+      "keydown",
+      (event) => {
+        if (event.key === "Escape") {
+          event.preventDefault();
+        }
+      },
+      { capture: true },
+    );
+
+    contentWrapper.focus();
+    await userEvent.keyboard("{Escape}");
+    await panel.updateComplete;
+
+    expect(panel.closed).toBe(false);
+    expect(container.hidden).toBe(false);
+    expect(closeEventTimes).toBe(0);
+  });
+
+  it("does not close on prevented Escape when closable and focusTrap are true", async () => {
+    await mount(
+      <calcite-panel closable data-testid="panel" focusTrap style={scrollingHeightStyle}>
+        {renderScrollingContent()}
+      </calcite-panel>,
+    );
+
+    const panel = getPanelEl();
+    const container = getContainerEl();
+    const contentWrapper = getContentWrapperEl();
+    let closeEventTimes = 0;
+
+    panel.addEventListener("calcitePanelClose", () => closeEventTimes++);
+    panel.addEventListener(
+      "keydown",
+      (event) => {
+        if (event.key === "Escape") {
+          event.preventDefault();
+        }
+      },
+      { capture: true },
+    );
+
+    contentWrapper.focus();
+    await userEvent.keyboard("{Escape}");
+    await panel.updateComplete;
+
+    expect(panel.closed).toBe(false);
+    expect(container.hidden).toBe(false);
+    expect(closeEventTimes).toBe(0);
+  });
+
+  it("closes on Escape when closable is true and focusTrap is false (non-scrollable)", async () => {
+    await mount(
+      <calcite-panel closable data-testid="panel">
+        non-scrolling content
+      </calcite-panel>,
+    );
+
+    const panel = getPanelEl();
+    const container = getContainerEl();
+    const closeButton = getCloseButtonEl();
+    const closeAction = closeButton as HTMLElement & { setFocus?: () => Promise<void> };
+    let closeEventTimes = 0;
+
+    panel.addEventListener("calcitePanelClose", () => closeEventTimes++);
+
+    expect(panel.closed).toBe(false);
+    expect(container.hidden).toBe(false);
+    expect(closeEventTimes).toBe(0);
+
+    await closeAction.setFocus?.();
+    await userEvent.keyboard("{Escape}");
+    await panel.updateComplete;
+
+    expect(panel.closed).toBe(true);
+    expect(container.hidden).toBe(true);
+    expect(closeEventTimes).toBe(1);
+  });
+
+  it("closes on Escape when closable and focusTrap are true (non-scrollable)", async () => {
+    await mount(
+      <calcite-panel closable data-testid="panel" focusTrap>
+        non-scrolling content
+      </calcite-panel>,
+    );
+
+    const panel = getPanelEl();
+    const container = getContainerEl();
+    const closeButton = getCloseButtonEl();
+    const closeAction = closeButton as HTMLElement & { setFocus?: () => Promise<void> };
+    let closeEventTimes = 0;
+
+    panel.addEventListener("calcitePanelClose", () => closeEventTimes++);
+
+    expect(panel.closed).toBe(false);
+    expect(container.hidden).toBe(false);
+    expect(closeEventTimes).toBe(0);
+
+    await closeAction.setFocus?.();
+    await userEvent.keyboard("{Escape}");
+    await panel.updateComplete;
+
+    expect(panel.closed).toBe(true);
+    expect(container.hidden).toBe(true);
+    expect(closeEventTimes).toBe(1);
+  });
+});
+
 describe("defaults", () => {
   defaults(
     () => mount("calcite-panel"),
@@ -120,6 +492,14 @@ describe("defaults", () => {
       },
       {
         propertyName: "iconFlipRtl",
+        defaultValue: false,
+      },
+      {
+        propertyName: "focusTrap",
+        defaultValue: false,
+      },
+      {
+        propertyName: "focusTrapDisabled",
         defaultValue: false,
       },
     ],
@@ -202,8 +582,52 @@ describe("reflects", () => {
         propertyName: "iconFlipRtl",
         value: "true",
       },
+      {
+        propertyName: "focusTrap",
+        value: true,
+      },
+      {
+        propertyName: "focusTrapDisabled",
+        value: true,
+      },
     ],
   );
+});
+
+describe("role", () => {
+  function getContainerRole(el: HTMLElement): string | null {
+    return (
+      el.shadowRoot.querySelector<HTMLElement>(`.${CSS.container}`)?.getAttribute("role") ?? null
+    );
+  }
+
+  it("sets container role to dialog when closable", async () => {
+    const { el } = await mount(<calcite-panel closable>content</calcite-panel>);
+
+    expect(getContainerRole(el)).toBe("dialog");
+    expect(el.getAttribute("role")).toBeNull();
+  });
+
+  it("does not set container role to dialog when not closable", async () => {
+    const { el } = await mount(<calcite-panel>content</calcite-panel>);
+
+    expect(getContainerRole(el)).toBeNull();
+    expect(el.getAttribute("role")).toBeNull();
+  });
+
+  it("updates container role when closable changes", async () => {
+    const { el, component } = await mount(<calcite-panel>content</calcite-panel>);
+
+    expect(getContainerRole(el)).toBeNull();
+
+    el.setAttribute("closable", "");
+    await component.updateComplete;
+    expect(getContainerRole(el)).toBe("dialog");
+
+    el.removeAttribute("closable");
+    await component.updateComplete;
+    expect(getContainerRole(el)).toBeNull();
+  });
 });
 
 describe("honors hidden attribute", () => {

--- a/packages/components/src/components/panel/panel.browser.e2e.tsx
+++ b/packages/components/src/components/panel/panel.browser.e2e.tsx
@@ -630,17 +630,17 @@ describe("role", () => {
     expect(getContainerRole(el)).toBe("article");
   });
 
-  it("uses article role when disableDialogRole is true", async () => {
+  it("uses article role when dialogRoleDisabled is true", async () => {
     const { el, component } = await mount(<calcite-panel closable>content</calcite-panel>);
     const panel = el as Panel["el"];
 
     expect(getContainerRole(el)).toBe("dialog");
 
-    panel.disableDialogRole = true;
+    panel.dialogRoleDisabled = true;
     await component.updateComplete;
     expect(getContainerRole(el)).toBe("article");
 
-    panel.disableDialogRole = false;
+    panel.dialogRoleDisabled = false;
     await component.updateComplete;
     expect(getContainerRole(el)).toBe("dialog");
   });

--- a/packages/components/src/components/panel/panel.browser.e2e.tsx
+++ b/packages/components/src/components/panel/panel.browser.e2e.tsx
@@ -608,17 +608,17 @@ describe("role", () => {
     expect(el.getAttribute("role")).toBeNull();
   });
 
-  it("does not set container role to dialog when not closable", async () => {
+  it("sets container role to article when not closable", async () => {
     const { el } = await mount(<calcite-panel>content</calcite-panel>);
 
-    expect(getContainerRole(el)).toBeNull();
+    expect(getContainerRole(el)).toBe("article");
     expect(el.getAttribute("role")).toBeNull();
   });
 
   it("updates container role when closable changes", async () => {
     const { el, component } = await mount(<calcite-panel>content</calcite-panel>);
 
-    expect(getContainerRole(el)).toBeNull();
+    expect(getContainerRole(el)).toBe("article");
 
     el.setAttribute("closable", "");
     await component.updateComplete;
@@ -626,7 +626,7 @@ describe("role", () => {
 
     el.removeAttribute("closable");
     await component.updateComplete;
-    expect(getContainerRole(el)).toBeNull();
+    expect(getContainerRole(el)).toBe("article");
   });
 });
 

--- a/packages/components/src/components/panel/panel.browser.e2e.tsx
+++ b/packages/components/src/components/panel/panel.browser.e2e.tsx
@@ -596,53 +596,73 @@ describe("reflects", () => {
 });
 
 describe("role", () => {
-  function getContainerRole(el: HTMLElement): string | null {
-    return (
-      el.shadowRoot.querySelector<HTMLElement>(`.${CSS.container}`)?.getAttribute("role") ?? null
-    );
-  }
+  const getDialog = () => page.getByRole("dialog");
+  const getArticle = () => page.getByRole("article");
 
   it("sets container role to dialog when closable", async () => {
     const { el } = await mount(<calcite-panel closable>content</calcite-panel>);
 
-    expect(getContainerRole(el)).toBe("dialog");
+    await expect.element(getDialog()).toBeInTheDocument();
     expect(el.getAttribute("role")).toBeNull();
   });
 
   it("sets container role to article when not closable", async () => {
     const { el } = await mount(<calcite-panel>content</calcite-panel>);
 
-    expect(getContainerRole(el)).toBe("article");
+    await expect.element(getArticle()).toBeInTheDocument();
     expect(el.getAttribute("role")).toBeNull();
   });
 
   it("updates container role when closable changes", async () => {
     const { el, component } = await mount(<calcite-panel>content</calcite-panel>);
 
-    expect(getContainerRole(el)).toBe("article");
+    await expect.element(getArticle()).toBeInTheDocument();
+    await expect.element(getDialog()).not.toBeInTheDocument();
 
     el.setAttribute("closable", "");
     await component.updateComplete;
-    expect(getContainerRole(el)).toBe("dialog");
+    await expect.element(getDialog()).toBeInTheDocument();
+    await expect.element(getArticle()).not.toBeInTheDocument();
 
     el.removeAttribute("closable");
     await component.updateComplete;
-    expect(getContainerRole(el)).toBe("article");
+    await expect.element(getArticle()).toBeInTheDocument();
+    await expect.element(getDialog()).not.toBeInTheDocument();
   });
 
   it("uses article role when dialogRoleDisabled is true", async () => {
     const { el, component } = await mount(<calcite-panel closable>content</calcite-panel>);
     const panel = el as Panel["el"];
 
-    expect(getContainerRole(el)).toBe("dialog");
+    await expect.element(getDialog()).toBeInTheDocument();
 
     panel.dialogRoleDisabled = true;
     await component.updateComplete;
-    expect(getContainerRole(el)).toBe("article");
+    await expect.element(getArticle()).toBeInTheDocument();
+    await expect.element(getDialog()).not.toBeInTheDocument();
 
     panel.dialogRoleDisabled = false;
     await component.updateComplete;
-    expect(getContainerRole(el)).toBe("dialog");
+    await expect.element(getDialog()).toBeInTheDocument();
+    await expect.element(getArticle()).not.toBeInTheDocument();
+  });
+
+  it("sets aria-live based on dialog role state", async () => {
+    const { el, component } = await mount(<calcite-panel closable>content</calcite-panel>);
+    const panel = el as Panel["el"];
+
+    await expect.element(getDialog()).toBeInTheDocument();
+    await expect.element(getDialog()).toHaveAttribute("aria-live", "polite");
+
+    panel.dialogRoleDisabled = true;
+    await component.updateComplete;
+    await expect.element(getArticle()).toBeInTheDocument();
+    await expect.element(getArticle()).not.toHaveAttribute("aria-live");
+
+    panel.dialogRoleDisabled = false;
+    await component.updateComplete;
+    await expect.element(getDialog()).toBeInTheDocument();
+    await expect.element(getDialog()).toHaveAttribute("aria-live", "polite");
   });
 });
 

--- a/packages/components/src/components/panel/panel.browser.e2e.tsx
+++ b/packages/components/src/components/panel/panel.browser.e2e.tsx
@@ -18,6 +18,7 @@ import { defaultEndMenuPlacement } from "../../utils/floating-ui";
 import { mockConsole } from "../../tests/utils/logging";
 import { scrolling } from "../../tests/browser/utils/content";
 import { CSS, IDS, SLOTS } from "./resources";
+import type { Panel } from "./panel";
 
 export const scrollingHeightStyle = "height: 200px;";
 
@@ -627,6 +628,21 @@ describe("role", () => {
     el.removeAttribute("closable");
     await component.updateComplete;
     expect(getContainerRole(el)).toBe("article");
+  });
+
+  it("uses article role when disableDialogRole is true", async () => {
+    const { el, component } = await mount(<calcite-panel closable>content</calcite-panel>);
+    const panel = el as Panel["el"];
+
+    expect(getContainerRole(el)).toBe("dialog");
+
+    panel.disableDialogRole = true;
+    await component.updateComplete;
+    expect(getContainerRole(el)).toBe("article");
+
+    panel.disableDialogRole = false;
+    await component.updateComplete;
+    expect(getContainerRole(el)).toBe("dialog");
   });
 });
 

--- a/packages/components/src/components/panel/panel.e2e.ts
+++ b/packages/components/src/components/panel/panel.e2e.ts
@@ -288,7 +288,7 @@ describe("accessible", () => {
 
   describe("collapsible and closable", () => {
     accessible(html`
-      <calcite-panel collapsible closable>
+      <calcite-panel collapsible closable heading="Panel">
         <calcite-action-bar slot="${SLOTS.actionBar}">
           <calcite-action-group>
             <calcite-action text="Add" icon="plus"></calcite-action>

--- a/packages/components/src/components/panel/panel.tsx
+++ b/packages/components/src/components/panel/panel.tsx
@@ -784,7 +784,7 @@ export class Panel extends LitElement {
         class={CSS.container}
         hidden={closed}
         ref={this.containerRef}
-        role={closable ? "dialog" : null}
+        role={closable ? "dialog" : "article"}
       >
         {this.renderHeaderNode()}
         {this.renderContent()}

--- a/packages/components/src/components/panel/panel.tsx
+++ b/packages/components/src/components/panel/panel.tsx
@@ -188,6 +188,13 @@ export class Panel extends LitElement {
   /** When `true`, prevents focus trapping. Focus trapping is also prevented when `closable` is `false` or `closed` is `true`. */
   @property({ reflect: true }) focusTrapDisabled = false;
 
+  /**
+   * Internal-only override to suppress dialog role semantics on the panel container.
+   *
+   * @private
+   */
+  @property() disableDialogRole = false;
+
   /** Specifies the component's fallback `menuPlacement` when it's initial or specified `menuPlacement` has insufficient space available. */
   @property() menuFlipPlacements: FlipPlacement[];
 
@@ -774,17 +781,18 @@ export class Panel extends LitElement {
   }
 
   override render(): JsxNode {
-    const { disabled, loading, closed, closable, heading, description } = this;
+    const { disabled, loading, closed, closable, heading, description, disableDialogRole } = this;
+    const useDialogRole = closable && !disableDialogRole;
 
     const panelNode = (
       <div
         ariaBusy={loading}
-        ariaDescription={closable ? description : null}
-        ariaLabel={closable ? heading : null}
+        ariaDescription={useDialogRole ? description : null}
+        ariaLabel={useDialogRole ? heading : null}
         class={CSS.container}
         hidden={closed}
         ref={this.containerRef}
-        role={closable ? "dialog" : "article"}
+        role={useDialogRole ? "dialog" : "article"}
       >
         {this.renderHeaderNode()}
         {this.renderContent()}

--- a/packages/components/src/components/panel/panel.tsx
+++ b/packages/components/src/components/panel/panel.tsx
@@ -789,6 +789,7 @@ export class Panel extends LitElement {
         ariaBusy={loading}
         ariaDescription={useDialogRole ? description : null}
         ariaLabel={useDialogRole ? heading : null}
+        ariaLive={useDialogRole ? "polite" : null}
         class={CSS.container}
         hidden={closed}
         ref={this.containerRef}

--- a/packages/components/src/components/panel/panel.tsx
+++ b/packages/components/src/components/panel/panel.tsx
@@ -182,10 +182,10 @@ export class Panel extends LitElement {
   /** When `true`, a busy indicator is displayed. */
   @property({ reflect: true }) loading = false;
 
-  /** When `true`, the component will trap focus. */
+  /** When `true`, the component will trap focus. Focus trapping only activates when `closable` is `true`, `closed` is `false`, and `focusTrapDisabled` is `false`. */
   @property({ reflect: true }) focusTrap = false;
 
-  /** When `true`, prevents focus trapping. */
+  /** When `true`, prevents focus trapping. Focus trapping is also prevented when `closable` is `false` or `closed` is `true`. */
   @property({ reflect: true }) focusTrapDisabled = false;
 
   /** Specifies the component's fallback `menuPlacement` when it's initial or specified `menuPlacement` has insufficient space available. */

--- a/packages/components/src/components/panel/panel.tsx
+++ b/packages/components/src/components/panel/panel.tsx
@@ -26,6 +26,7 @@ import { useSetFocus } from "../../controllers/useSetFocus";
 import { IconName } from "../icon/interfaces";
 import { styles as headerStyles } from "../../styles/component/header.scss";
 import { useInteractive } from "../../controllers/useInteractive";
+import { useFocusTrap } from "../../controllers/useFocusTrap";
 import T9nStrings from "./assets/t9n/messages.en.json";
 import { CSS, ICONS, IDS, SLOTS } from "./resources";
 import { styles } from "./panel.scss";
@@ -62,7 +63,7 @@ export class Panel extends LitElement {
 
   //#region Private Properties
 
-  private containerRef = createRef<HTMLElement>();
+  private containerRef = createRef<HTMLDivElement>();
 
   private panelScrollEl: HTMLElement;
 
@@ -78,6 +79,22 @@ export class Panel extends LitElement {
   private _closed = false;
 
   private focusSetter = useSetFocus<this>()(this);
+
+  private focusTrapController = useFocusTrap<this>({
+    triggerProp: "focusTrap",
+    focusTrapOptions: {
+      allowOutsideClick: true,
+      escapeDeactivates: (event) => {
+        if (!event.defaultPrevented) {
+          this.closed = true;
+          this.emitCloseEvent();
+          event.preventDefault();
+        }
+
+        return false;
+      },
+    },
+  })(this);
 
   private interactiveContainer = useInteractive(this);
 
@@ -164,6 +181,12 @@ export class Panel extends LitElement {
 
   /** When `true`, a busy indicator is displayed. */
   @property({ reflect: true }) loading = false;
+
+  /** When `true`, the component will trap focus. */
+  @property({ reflect: true }) focusTrap = false;
+
+  /** When `true`, prevents focus trapping. */
+  @property({ reflect: true }) focusTrapDisabled = false;
 
   /** Specifies the component's fallback `menuPlacement` when it's initial or specified `menuPlacement` has insufficient space available. */
   @property() menuFlipPlacements: FlipPlacement[];
@@ -270,6 +293,21 @@ export class Panel extends LitElement {
     }
   }
 
+  override updated(changes: PropertyValues<this>): void {
+    if (
+      changes.has("focusTrap") ||
+      changes.has("focusTrapDisabled") ||
+      changes.has("closable") ||
+      changes.has("closed")
+    ) {
+      if (this.focusTrap && !this.focusTrapDisabledOverride()) {
+        this.focusTrapController.activate();
+      } else {
+        this.focusTrapController.deactivate();
+      }
+    }
+  }
+
   override disconnectedCallback(): void {
     this.resizeObserver?.disconnect();
   }
@@ -319,11 +357,24 @@ export class Panel extends LitElement {
     this.calcitePanelClose.emit();
   }
 
+  /** When defined, provides a condition to disable focus trapping. When `true`, prevents focus trapping. */
+  focusTrapDisabledOverride(): boolean {
+    return this.focusTrapDisabled || !this.closable || this.closed;
+  }
+
   private panelKeyDownHandler(event: KeyboardEvent): void {
-    if (this.closable && event.key === "Escape" && !event.defaultPrevented) {
-      event.preventDefault();
-      this.emitCloseEvent();
+    if (event.key !== "Escape" || event.defaultPrevented || !this.closable || this.closed) {
+      return;
     }
+
+    const shouldHandleEscape = !this.focusTrap || this.focusTrapDisabled;
+
+    if (!shouldHandleEscape) {
+      return;
+    }
+
+    event.preventDefault();
+    this.emitCloseEvent();
   }
 
   private panelCloseHandler(event: CustomEvent<void>): void {
@@ -723,16 +774,24 @@ export class Panel extends LitElement {
   }
 
   override render(): JsxNode {
-    const { disabled, loading, closed } = this;
+    const { disabled, loading, closed, closable, heading, description } = this;
 
     const panelNode = (
-      <article ariaBusy={loading} class={CSS.container} hidden={closed} ref={this.containerRef}>
+      <div
+        ariaBusy={loading}
+        ariaDescription={closable ? description : null}
+        ariaLabel={closable ? heading : null}
+        class={CSS.container}
+        hidden={closed}
+        ref={this.containerRef}
+        role={closable ? "dialog" : null}
+      >
         {this.renderHeaderNode()}
         {this.renderContent()}
         {this.renderContentBottom()}
         {this.renderFooterNode()}
         <slot key="alerts" name={SLOTS.alerts} onSlotChange={this.handleAlertsSlotChange} />
-      </article>
+      </div>
     );
 
     return (

--- a/packages/components/src/components/panel/panel.tsx
+++ b/packages/components/src/components/panel/panel.tsx
@@ -193,7 +193,7 @@ export class Panel extends LitElement {
    *
    * @private
    */
-  @property() disableDialogRole = false;
+  @property() dialogRoleDisabled = false;
 
   /** Specifies the component's fallback `menuPlacement` when it's initial or specified `menuPlacement` has insufficient space available. */
   @property() menuFlipPlacements: FlipPlacement[];
@@ -781,8 +781,8 @@ export class Panel extends LitElement {
   }
 
   override render(): JsxNode {
-    const { disabled, loading, closed, closable, heading, description, disableDialogRole } = this;
-    const useDialogRole = closable && !disableDialogRole;
+    const { disabled, loading, closed, closable, heading, description, dialogRoleDisabled } = this;
+    const useDialogRole = closable && !dialogRoleDisabled;
 
     const panelNode = (
       <div

--- a/packages/components/src/controllers/useFocusTrap.browser.e2e.tsx
+++ b/packages/components/src/controllers/useFocusTrap.browser.e2e.tsx
@@ -38,7 +38,15 @@ class Test extends LitElement {
   }
 
   override render(): JsxNode {
-    return <div>{this.open ? <button onClick={this.onClick}>close me!</button> : null}</div>;
+    return (
+      <div>
+        {this.open ? (
+          <button onClick={this.onClick} type="button">
+            close me!
+          </button>
+        ) : null}
+      </div>
+    );
   }
 }
 
@@ -147,7 +155,15 @@ describe("focusTrapDisabledOverride", () => {
     }
 
     override render(): JsxNode {
-      return <div>{this.open ? <button onClick={this.onClick}>close me!</button> : null}</div>;
+      return (
+        <div>
+          {this.open ? (
+            <button onClick={this.onClick} type="button">
+              close me!
+            </button>
+          ) : null}
+        </div>
+      );
     }
   }
 
@@ -174,6 +190,86 @@ describe("focusTrapDisabledOverride", () => {
 
     expect(activateSpy).toHaveBeenCalledTimes(0);
   });
+
+  it("does not activate when focusTrapDisabled becomes false and triggerProp is false", async () => {
+    class FocusTrapDisabledTriggerGuard extends LitElement {
+      @property() open = false;
+
+      @property() focusTrapDisabled = false;
+
+      focusTrap = useFocusTrap<this>({
+        triggerProp: "open",
+      })(this);
+
+      override updated(changes: PropertyValues<this>): void {
+        if (changes.has("open")) {
+          if (this.open) {
+            this.focusTrap.activate();
+          } else {
+            this.focusTrap.deactivate();
+          }
+        }
+      }
+
+      override render(): JsxNode {
+        return <button type="button">trap target</button>;
+      }
+    }
+
+    const { el, component } = await mount(FocusTrapDisabledTriggerGuard);
+
+    expect(component.focusTrap._instance).toBeUndefined();
+
+    el.focusTrapDisabled = true;
+    await component.updateComplete;
+
+    el.focusTrapDisabled = false;
+    await component.updateComplete;
+
+    expect(component.focusTrap._instance).toBeUndefined();
+  });
+
+  it("activates when focusTrapDisabled becomes false and triggerProp is true", async () => {
+    class FocusTrapDisabledTriggerEnabled extends LitElement {
+      @property() open = false;
+
+      @property() focusTrapDisabled = false;
+
+      focusTrap = useFocusTrap<this>({
+        triggerProp: "open",
+      })(this);
+
+      override updated(changes: PropertyValues<this>): void {
+        if (changes.has("open")) {
+          if (this.open) {
+            this.focusTrap.activate();
+          } else {
+            this.focusTrap.deactivate();
+          }
+        }
+      }
+
+      override render(): JsxNode {
+        return <button type="button">trap target</button>;
+      }
+    }
+
+    const { el, component } = await mount(FocusTrapDisabledTriggerEnabled);
+
+    el.open = true;
+    await component.updateComplete;
+
+    el.focusTrapDisabled = true;
+    await component.updateComplete;
+
+    expect(component.focusTrap._instance).toBeDefined();
+    const activateSpy = vi.spyOn(component.focusTrap._instance!, "activate");
+
+    el.focusTrapDisabled = false;
+    await component.updateComplete;
+
+    expect(activateSpy).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("focusTrapOptions", () => {
@@ -195,7 +291,11 @@ describe("focusTrapOptions", () => {
       // open handling intentionally ignored to simplify test
 
       override render(): JsxNode {
-        return <button data-testid="inside-button">close me!</button>;
+        return (
+          <button data-testid="inside-button" type="button">
+            close me!
+          </button>
+        );
       }
     };
   }
@@ -355,7 +455,9 @@ describe("focusTrapOptions", () => {
           return this.open ? (
             <div>
               <slot />
-              <button ref={this.#buttonRef}>close</button>
+              <button ref={this.#buttonRef} type="button">
+                close
+              </button>
             </div>
           ) : null;
         }
@@ -420,7 +522,7 @@ describe("focusTrapOptions", () => {
         }
 
         override render(): JsxNode {
-          return this.open ? <button>close me!</button> : null;
+          return this.open ? <button type="button">close me!</button> : null;
         }
       }
 

--- a/packages/components/src/controllers/useFocusTrap.ts
+++ b/packages/components/src/controllers/useFocusTrap.ts
@@ -226,7 +226,7 @@ export const useFocusTrap = <T extends FocusTrapComponent>(
 
     controller.onUpdate((changes) => {
       if (component.hasUpdated && changes.has("focusTrapDisabled")) {
-        if (component.focusTrapDisabled) {
+        if (component.focusTrapDisabled || !component[options.triggerProp]) {
           utils.deactivate();
         } else {
           utils.activate();


### PR DESCRIPTION
**Related Issue:** #6951

### Summary
This PR improves accessibility and focus behavior for panel-based workflows

### Why
This aligns with issue #6951 guidance to improve assistive-technology structure for closable panel workflows while keeping behavior flexible and non-breaking.

### What Changed

#### Panel accessibility
- Added conditional `role="dialog"` when `closable` is true.
- Applied dialog semantics to the internal rendered container
- Added dialog naming context for closable usage through aria labeling fields used in panel rendering.
- Updated related accessibility coverage.

#### Panel focus trap behavior
- Added/updated focus-trap behavior coverage for:
  - trapping when enabled
  - deactivation when closed/not-closable
  - reactivation when reopened/re-closable
  - disabled focus trap behavior
- Added browser coverage for Escape-path behavior combinations:
  - closable + focusTrap false/true (scrollable and non-scrollable)
  - prevented Escape behavior with and without focusTrap

#### Flow-item integration
- Added `focusTrap` and `focusTrapDisabled` properties.
- Forwarded properties to internal panel.
- Added selected-state gating behavior for forwarded `focusTrapDisabled`.
- Added browser tests for pass-through and dynamic selected transitions.

#### Example

https://codepen.io/driskull/pen/zxozLxM