### PR TITLE
fix(combobox): keep active selection unchanged when expanded and collapsed with keyboard

### DIFF
--- a/packages/components/src/components/combobox/combobox.browser.e2e.tsx
+++ b/packages/components/src/components/combobox/combobox.browser.e2e.tsx
@@ -1105,4 +1105,48 @@ describe("keyboard interaction", () => {
     await expect.element(el).toHaveFocus();
     expect(keyDownHandler.mock.lastCall![0]).toHaveProperty("defaultPrevented", true);
   });
+
+  it("Escape close + Space reopen keeps active item anchored to the selected item", async () => {
+    await mount<Combobox>(() => (
+      <calcite-combobox selection-mode="single">
+        <calcite-combobox-item heading="one" id="one" selected value="one" />
+        <calcite-combobox-item heading="two" id="two" value="two" />
+      </calcite-combobox>
+    ));
+
+    const floatingUI = page.getBySelector(`calcite-combobox .${CSS.floatingUIContainer}`);
+    await userEvent.keyboard("{Tab}{Space}");
+    await expect.element(floatingUI).toBeVisible();
+
+    const itemOne = page.getBySelector("#one").element() as ComboboxItem["el"];
+    const itemTwo = page.getBySelector("#two").element() as ComboboxItem["el"];
+
+    expect(itemOne.selected).toBe(true);
+    expect(itemTwo.selected).toBe(false);
+
+    let activeItem = page.getBySelector("calcite-combobox-item[active]");
+    await expect.element(activeItem).toHaveProperty("value", "one");
+
+    await userEvent.keyboard("{Escape}");
+    await expect.element(floatingUI).not.toBeVisible();
+
+    await userEvent.keyboard("{Space}");
+    await expect.element(floatingUI).toBeVisible();
+
+    activeItem = page.getBySelector("calcite-combobox-item[active]");
+    await expect.element(activeItem).toHaveProperty("value", "one");
+    expect(itemOne.selected).toBe(true);
+    expect(itemTwo.selected).toBe(false);
+
+    await userEvent.keyboard("{Escape}");
+    await expect.element(floatingUI).not.toBeVisible();
+
+    await userEvent.keyboard("{Space}");
+    await expect.element(floatingUI).toBeVisible();
+
+    activeItem = page.getBySelector("calcite-combobox-item[active]");
+    await expect.element(activeItem).toHaveProperty("value", "one");
+    expect(itemOne.selected).toBe(true);
+    expect(itemTwo.selected).toBe(false);
+  });
 });

--- a/packages/components/src/components/combobox/combobox.browser.e2e.tsx
+++ b/packages/components/src/components/combobox/combobox.browser.e2e.tsx
@@ -861,6 +861,15 @@ describe("active item when opened", () => {
 });
 
 describe("keyboard interactions", async () => {
+  it("does not throw when pressing Space then Enter with no items", async () => {
+    const { el } = await mount<Combobox>(<calcite-combobox />);
+
+    await el.setFocus();
+    await userEvent.keyboard("{Space}{Enter}");
+
+    expect(el.open).toBe(false);
+  });
+
   it("should delete the first focused chip on Enter key in multi-selection mode", async () => {
     const { el } = await mount<Combobox>(
       <calcite-combobox allow-custom-values placeholder="Select a field">

--- a/packages/components/src/components/combobox/combobox.browser.e2e.tsx
+++ b/packages/components/src/components/combobox/combobox.browser.e2e.tsx
@@ -1106,50 +1106,6 @@ describe("keyboard interaction", () => {
     expect(keyDownHandler.mock.lastCall![0]).toHaveProperty("defaultPrevented", true);
   });
 
-  it("Escape close + Space reopen keeps active item anchored to the selected item", async () => {
-    await mount<Combobox>(() => (
-      <calcite-combobox selection-mode="single">
-        <calcite-combobox-item heading="one" id="one" selected value="one" />
-        <calcite-combobox-item heading="two" id="two" value="two" />
-      </calcite-combobox>
-    ));
-
-    const floatingUI = page.getBySelector(`calcite-combobox .${CSS.floatingUIContainer}`);
-    await userEvent.keyboard("{Tab}{Space}");
-    await expect.element(floatingUI).toBeVisible();
-
-    const itemOne = page.getBySelector("#one").element() as ComboboxItem["el"];
-    const itemTwo = page.getBySelector("#two").element() as ComboboxItem["el"];
-
-    expect(itemOne.selected).toBe(true);
-    expect(itemTwo.selected).toBe(false);
-
-    let activeItem = page.getBySelector("calcite-combobox-item[active]");
-    await expect.element(activeItem).toHaveProperty("value", "one");
-
-    await userEvent.keyboard("{Escape}");
-    await expect.element(floatingUI).not.toBeVisible();
-
-    await userEvent.keyboard("{Space}");
-    await expect.element(floatingUI).toBeVisible();
-
-    activeItem = page.getBySelector("calcite-combobox-item[active]");
-    await expect.element(activeItem).toHaveProperty("value", "one");
-    expect(itemOne.selected).toBe(true);
-    expect(itemTwo.selected).toBe(false);
-
-    await userEvent.keyboard("{Escape}");
-    await expect.element(floatingUI).not.toBeVisible();
-
-    await userEvent.keyboard("{Space}");
-    await expect.element(floatingUI).toBeVisible();
-
-    activeItem = page.getBySelector("calcite-combobox-item[active]");
-    await expect.element(activeItem).toHaveProperty("value", "one");
-    expect(itemOne.selected).toBe(true);
-    expect(itemTwo.selected).toBe(false);
-  });
-
   it("Escape close + Space reopen keeps Select All active after toggling selection", async () => {
     await mount<Combobox>(() => (
       <calcite-combobox select-all-enabled selection-mode="multiple">

--- a/packages/components/src/components/combobox/combobox.browser.e2e.tsx
+++ b/packages/components/src/components/combobox/combobox.browser.e2e.tsx
@@ -888,7 +888,7 @@ describe("keyboard interactions", async () => {
 
     await el.setFocus();
     await userEvent.keyboard("{ArrowLeft}");
-    await userEvent.keyboard("{Enter}");
+    await userEvent.keyboard("{Space}");
 
     expect(el.selectedItems).toHaveLength(1);
     expect(el.selectedItems[0]).toBe(selectedItem1.element());
@@ -913,7 +913,7 @@ describe("keyboard interactions", async () => {
     await el.setFocus();
     await userEvent.keyboard("{ArrowLeft}");
     await userEvent.keyboard("{ArrowLeft}");
-    await userEvent.keyboard("{Enter}");
+    await userEvent.keyboard("{Space}");
 
     expect(el.selectedItems).toHaveLength(1);
     expect(el.selectedItems[0]).toBe(selectedItem2.element());
@@ -1148,5 +1148,83 @@ describe("keyboard interaction", () => {
     await expect.element(activeItem).toHaveProperty("value", "one");
     expect(itemOne.selected).toBe(true);
     expect(itemTwo.selected).toBe(false);
+  });
+
+  it("Escape close + Space reopen keeps Select All active after toggling selection", async () => {
+    await mount<Combobox>(() => (
+      <calcite-combobox select-all-enabled selection-mode="multiple">
+        <calcite-combobox-item heading="one" id="one" value="one" />
+        <calcite-combobox-item heading="two" id="two" value="two" />
+        <calcite-combobox-item heading="three" id="three" value="three" />
+      </calcite-combobox>
+    ));
+
+    const floatingUI = page.getBySelector(`calcite-combobox .${CSS.floatingUIContainer}`);
+    await userEvent.keyboard("{Tab}{Space}");
+    await expect.element(floatingUI).toBeVisible();
+
+    let activeItem = page.getBySelector("calcite-combobox-item[active]");
+    await expect.element(activeItem).toHaveProperty("label", "Select all");
+
+    await userEvent.keyboard("{Enter}");
+
+    await expect.element(page.getBySelector("#one")).toHaveProperty("selected", true);
+    await expect.element(page.getBySelector("#two")).toHaveProperty("selected", true);
+    await expect.element(page.getBySelector("#three")).toHaveProperty("selected", true);
+
+    await userEvent.keyboard("{Escape}");
+    await expect.element(floatingUI).not.toBeVisible();
+
+    await userEvent.keyboard("{Space}");
+    await expect.element(floatingUI).toBeVisible();
+
+    activeItem = page.getBySelector("calcite-combobox-item[active]");
+    await expect.element(activeItem).toHaveProperty("label", "Select all");
+
+    await userEvent.keyboard("{Enter}");
+
+    await expect.element(page.getBySelector("#one")).toHaveProperty("selected", false);
+    await expect.element(page.getBySelector("#two")).toHaveProperty("selected", false);
+    await expect.element(page.getBySelector("#three")).toHaveProperty("selected", false);
+  });
+
+  it("Escape close + Space reopen keeps long-list scroll location and active item", async () => {
+    const items = Array.from({ length: 60 }, (_, i) => (
+      <calcite-combobox-item
+        heading={`item-${i + 1}`}
+        id={`item-${i + 1}`}
+        value={`item-${i + 1}`}
+      />
+    ));
+
+    await mount<Combobox>(() => (
+      <calcite-combobox selection-mode="multiple">{items}</calcite-combobox>
+    ));
+
+    const floatingUI = page.getBySelector(`calcite-combobox .${CSS.floatingUIContainer}`);
+    await userEvent.keyboard("{Tab}{Space}");
+    await expect.element(floatingUI).toBeVisible();
+
+    for (let i = 0; i < 30; i++) {
+      await userEvent.keyboard("{ArrowDown}");
+    }
+
+    const listContainer = page
+      .getBySelector(`calcite-combobox .${CSS.listContainer}`)
+      .element() as HTMLDivElement;
+    const activeValueBeforeClose = (
+      page.getBySelector("calcite-combobox-item[active]").element() as ComboboxItem["el"]
+    ).value;
+    const scrollTopBeforeClose = listContainer.scrollTop;
+
+    expect(scrollTopBeforeClose).toBeGreaterThan(0);
+
+    const activeValueAfterReopen = (
+      page.getBySelector("calcite-combobox-item[active]").element() as ComboboxItem["el"]
+    ).value;
+    const scrollTopAfterReopen = listContainer.scrollTop;
+
+    expect(activeValueAfterReopen).toBe(activeValueBeforeClose);
+    expect(Math.abs(scrollTopAfterReopen - scrollTopBeforeClose)).toBeLessThanOrEqual(1);
   });
 });

--- a/packages/components/src/components/combobox/combobox.e2e.ts
+++ b/packages/components/src/components/combobox/combobox.e2e.ts
@@ -1111,6 +1111,42 @@ describe("keyboard navigation in all selection-display mode", () => {
     expect(firstFocusedGroupItem).toBeTruthy();
   });
 
+  it("Escape close + Space reopen keeps active item anchored to the selected item", async () => {
+    const inputEl = await page.find(`#myCombobox >>> input`);
+    await inputEl.focus();
+    await page.waitForChanges();
+
+    await page.keyboard.press("ArrowDown");
+    await page.waitForChanges();
+    await page.keyboard.press("Enter");
+    await page.waitForChanges();
+
+    const itemOne = await page.find("#one");
+    const itemTwo = await page.find("#two");
+    expect(await itemOne.getProperty("selected")).toBe(true);
+    expect(await itemTwo.getProperty("selected")).toBe(false);
+
+    await page.keyboard.press("Escape");
+    await page.waitForChanges();
+    await page.keyboard.press("Space");
+    await page.waitForChanges();
+
+    const firstActiveItemAfterReopen = await page.find(`#one >>> .${ComboboxItemCSS.active}`);
+    expect(firstActiveItemAfterReopen).toBeTruthy();
+    expect(await itemOne.getProperty("selected")).toBe(true);
+    expect(await itemTwo.getProperty("selected")).toBe(false);
+
+    await page.keyboard.press("Escape");
+    await page.waitForChanges();
+    await page.keyboard.press("Space");
+    await page.waitForChanges();
+
+    const firstActiveItemAfterSecondReopen = await page.find(`#one >>> .${ComboboxItemCSS.active}`);
+    expect(firstActiveItemAfterSecondReopen).toBeTruthy();
+    expect(await itemOne.getProperty("selected")).toBe(true);
+    expect(await itemTwo.getProperty("selected")).toBe(false);
+  });
+
   it("when the combobox is focused & closed, Page up/down (fn arrow up/down) scrolls up and down the page", async () => {
     await page.addStyleTag({
       // set body to overflow so we can test the scroll functionality;

--- a/packages/components/src/components/combobox/combobox.e2e.ts
+++ b/packages/components/src/components/combobox/combobox.e2e.ts
@@ -1111,42 +1111,6 @@ describe("keyboard navigation in all selection-display mode", () => {
     expect(firstFocusedGroupItem).toBeTruthy();
   });
 
-  it("Escape close + Space reopen keeps active item anchored to the selected item", async () => {
-    const inputEl = await page.find(`#myCombobox >>> input`);
-    await inputEl.focus();
-    await page.waitForChanges();
-
-    await page.keyboard.press("ArrowDown");
-    await page.waitForChanges();
-    await page.keyboard.press("Enter");
-    await page.waitForChanges();
-
-    const itemOne = await page.find("#one");
-    const itemTwo = await page.find("#two");
-    expect(await itemOne.getProperty("selected")).toBe(true);
-    expect(await itemTwo.getProperty("selected")).toBe(false);
-
-    await page.keyboard.press("Escape");
-    await page.waitForChanges();
-    await page.keyboard.press("Space");
-    await page.waitForChanges();
-
-    const firstActiveItemAfterReopen = await page.find(`#one >>> .${ComboboxItemCSS.active}`);
-    expect(firstActiveItemAfterReopen).toBeTruthy();
-    expect(await itemOne.getProperty("selected")).toBe(true);
-    expect(await itemTwo.getProperty("selected")).toBe(false);
-
-    await page.keyboard.press("Escape");
-    await page.waitForChanges();
-    await page.keyboard.press("Space");
-    await page.waitForChanges();
-
-    const firstActiveItemAfterSecondReopen = await page.find(`#one >>> .${ComboboxItemCSS.active}`);
-    expect(firstActiveItemAfterSecondReopen).toBeTruthy();
-    expect(await itemOne.getProperty("selected")).toBe(true);
-    expect(await itemTwo.getProperty("selected")).toBe(false);
-  });
-
   it("when the combobox is focused & closed, Page up/down (fn arrow up/down) scrolls up and down the page", async () => {
     await page.addStyleTag({
       // set body to overflow so we can test the scroll functionality;

--- a/packages/components/src/components/combobox/combobox.tsx
+++ b/packages/components/src/components/combobox/combobox.tsx
@@ -914,7 +914,7 @@ export class Combobox extends LitElement implements LabelableComponent, Floating
         if (!this.textInputRef.value.value && !event.defaultPrevented) {
           if (!this.open) {
             this.open = true;
-            this.shiftActiveItemIndex(1);
+            this.ensureRecentSelectedItemIsActive();
           }
           event.preventDefault();
         }

--- a/packages/components/src/components/combobox/combobox.tsx
+++ b/packages/components/src/components/combobox/combobox.tsx
@@ -912,7 +912,7 @@ export class Combobox extends LitElement implements LabelableComponent, Floating
         break;
       case " ":
         if (!this.textInputRef.value.value && !event.defaultPrevented) {
-          if (!this.open) {
+          if (!this.open && this.keyboardNavItems.length) {
             this.open = true;
             this.ensureRecentSelectedItemIsActive();
           }
@@ -1067,11 +1067,15 @@ export class Combobox extends LitElement implements LabelableComponent, Floating
   }
 
   private ensureRecentSelectedItemIsActive(): void {
-    const { selectedItems } = this;
-    const targetIndex =
-      selectedItems.length === 0 ? 0 : this.items.indexOf(selectedItems[selectedItems.length - 1]);
+    const { selectedItems, keyboardNavItems } = this;
+    const selectedItem = selectedItems[selectedItems.length - 1];
+    const targetIndex = selectedItem
+      ? keyboardNavItems.indexOf(selectedItem)
+      : keyboardNavItems.length
+        ? 0
+        : -1;
 
-    this.updateActiveItemIndex(targetIndex);
+    this.updateActiveItemIndex(targetIndex > -1 ? targetIndex : keyboardNavItems.length ? 0 : -1);
   }
 
   private hideChip(chipEl: Chip["el"]): void {

--- a/packages/components/src/components/combobox/combobox.tsx
+++ b/packages/components/src/components/combobox/combobox.tsx
@@ -1002,7 +1002,7 @@ export class Combobox extends LitElement implements LabelableComponent, Floating
 
     // scrolling at next tick seems to work best to ensure selected item is immediately focused on open
     // changes from https://github.com/Esri/calcite-design-system/issues/10703 might help improve this
-    setTimeout(() => this.scrollToActiveOrSelectedItem(true), 0);
+    setTimeout(() => this.scrollToActiveOrSelectedItem(this.activeItemIndex < 0), 0);
   }
 
   onOpen(): void {
@@ -1067,7 +1067,13 @@ export class Combobox extends LitElement implements LabelableComponent, Floating
   }
 
   private ensureRecentSelectedItemIsActive(): void {
-    const { selectedItems, keyboardNavItems } = this;
+    const { activeItemIndex, selectedItems, keyboardNavItems } = this;
+
+    if (activeItemIndex > -1 && keyboardNavItems[activeItemIndex]) {
+      this.updateActiveItemIndex(activeItemIndex);
+      return;
+    }
+
     const selectedItem = selectedItems[selectedItems.length - 1];
     const targetIndex = selectedItem
       ? keyboardNavItems.indexOf(selectedItem)


### PR DESCRIPTION
**Related Issue:** #12816

## Summary
1. When using keyboard (esc + space) to close and expand the dropdown, the selection focus moved an item down each time. It remains unchanged now.

2. Ensures users don’t lose place in long lists after keyboard close/reopen by preserving both active anchor and visual scroll context.

3. Expands test coverage.

