### PR TITLE
fix(block): update icon CSS token name

### DIFF
--- a/packages/components/src/components/block/block.e2e.ts
+++ b/packages/components/src/components/block/block.e2e.ts
@@ -307,11 +307,11 @@ describe("theme", () => {
           shadowSelector: `.${CSS.description}`,
           targetProp: "color",
         },
-        "--calcite-block-icon-start-color": {
+        "--calcite-block-start-icon-color": {
           shadowSelector: `.${CSS.iconStart}`,
           targetProp: "color",
         },
-        "--calcite-block-icon-end-color": {
+        "--calcite-block-end-icon-color": {
           shadowSelector: `.${CSS.iconEnd}`,
           targetProp: "color",
         },

--- a/packages/components/src/components/block/block.scss
+++ b/packages/components/src/components/block/block.scss
@@ -13,10 +13,10 @@
  * @prop --calcite-block-padding: [Deprecated] in v3.3.0, removal target v6.0.0 - Use `--calcite-block-content-space` instead. Specifies the padding of the component's `default` slot.
  * @prop --calcite-block-text-color:[Deprecated] in v3.3.0, removal target v6.0.0 - Specifies the component's text color.
  * @prop --calcite-block-description-text-color: Specifies the component's `description` text color.
- * @prop --calcite-block-icon-color: [Deprecated] in v5.1.0, removal target v7.0.0 - Use `--calcite-block-collapsible-icon-color`, `--calcite-block-icon-start-color` and `--calcite-block-icon-end-color` instead. Specifies the component's `collapsible` icon, `iconStart` and `iconEnd` color.
+ * @prop --calcite-block-icon-color: [Deprecated] in v5.1.0, removal target v7.0.0 - Use `--calcite-block-collapsible-icon-color`, `--calcite-block-start-icon-color` and `--calcite-block-end-icon-color` instead. Specifies the component's `collapsible` icon, `iconStart` and `iconEnd` color.
  * @prop --calcite-block-icon-color-hover: [Deprecated] in v5.1.0, removal target v7.0.0 - Use `--calcite-block-collapsible-icon-color-hover` instead. Specifies the component's `collapsible` icon color when hovered.
- * @prop --calcite-block-icon-start-color: Specifies the component's `iconStart` color.
- * @prop --calcite-block-icon-end-color: Specifies the component's `iconEnd` color.
+ * @prop --calcite-block-start-icon-color: Specifies the component's `iconStart` color.
+ * @prop --calcite-block-end-icon-color: Specifies the component's `iconEnd` color.
  * @prop --calcite-block-collapsible-icon-color: Specifies the component's `collapsible` icon color.
  * @prop --calcite-block-collapsible-icon-color-hover: Specifies the component's `collapsible` icon color when hovered.
  */
@@ -156,11 +156,11 @@
 }
 
 .icon--start {
-  color: var(--calcite-block-icon-start-color, var(--calcite-block-icon-color, var(--calcite-color-text-3)));
+  color: var(--calcite-block-start-icon-color, var(--calcite-block-icon-color, var(--calcite-color-text-3)));
 }
 
 .icon--end {
-  color: var(--calcite-block-icon-end-color, var(--calcite-block-icon-color, var(--calcite-color-text-3)));
+  color: var(--calcite-block-end-icon-color, var(--calcite-block-icon-color, var(--calcite-color-text-3)));
 }
 
 .actions-end {
@@ -315,11 +315,11 @@ calcite-action-menu {
   }
 
   .icon--start {
-    color: var(--calcite-block-icon-start-color, var(--calcite-block-icon-color, var(--calcite-color-text-1)));
+    color: var(--calcite-block-start-icon-color, var(--calcite-block-icon-color, var(--calcite-color-text-1)));
   }
 
   .icon--end {
-    color: var(--calcite-block-icon-end-color, var(--calcite-block-icon-color, var(--calcite-color-text-1)));
+    color: var(--calcite-block-end-icon-color, var(--calcite-block-icon-color, var(--calcite-color-text-1)));
   }
 
   .content {


### PR DESCRIPTION
**Related Issue:** [#12128](https://github.com/Esri/calcite-design-system/issues/12128)

## Summary
Update `--calcite-block-icon-start-color` and `--calcite-block-icon-end-color` to `--calcite-block-start-icon-color` and `--calcite-block-end-icon-color`.
