### PR TITLE
test: remove old assertions using `HYDRATED_ATTR` in favor of `renders`

### DIFF
--- a/packages/components/src/components/alert/alert.e2e.ts
+++ b/packages/components/src/components/alert/alert.e2e.ts
@@ -2,7 +2,7 @@
 import { newE2EPage, E2EPage, E2EElement } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it, beforeEach } from "vitest";
 import { html } from "../../../support/formatting";
-import { accessible, HYDRATED_ATTR } from "../../tests/commonTests";
+import { accessible } from "../../tests/commonTests";
 import { getElementXY, skipAnimations } from "../../tests/utils/puppeteer";
 import { themed } from "../../tests/commonTests";
 import { CSS, DURATIONS } from "./resources";
@@ -73,10 +73,8 @@ it("renders with an icon", async () => {
     ${alertContent}
     </calcite-alert>`);
 
-  const element = await page.find("calcite-alert");
   const close = await page.find(`calcite-alert >>> .${CSS.close}`);
   const icon = await page.find(`calcite-alert >>> .${CSS.icon}`);
-  expect(element).toHaveAttribute(HYDRATED_ATTR);
   expect(close).not.toBeNull();
   expect(icon).not.toBeNull();
 });

--- a/packages/components/src/components/button/button.browser.e2e.tsx
+++ b/packages/components/src/components/button/button.browser.e2e.tsx
@@ -1,6 +1,17 @@
 import { mount } from "@arcgis/lumina-compiler/testing";
 import { describe } from "vitest";
-import { defaults, focusable, hidden, t9n, disabled } from "../../tests/commonTests/browser";
+import {
+  defaults,
+  focusable,
+  hidden,
+  t9n,
+  disabled,
+  renders,
+} from "../../tests/commonTests/browser";
+
+describe("renders", () => {
+  renders(() => mount("calcite-button"), { display: "inline-block" });
+});
 
 describe("defaults", () => {
   defaults(

--- a/packages/components/src/components/button/button.e2e.ts
+++ b/packages/components/src/components/button/button.e2e.ts
@@ -1,7 +1,7 @@
 // @ts-strict-ignore
 import { newE2EPage, E2EElement } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
-import { accessible, HYDRATED_ATTR, labelable, themed } from "../../tests/commonTests";
+import { accessible, labelable, themed } from "../../tests/commonTests";
 import { GlobalTestProps } from "../../tests/utils/interfaces";
 import { html } from "../../../support/formatting";
 import { CSS } from "./resources";
@@ -42,7 +42,6 @@ it("renders as a button with default props", async () => {
   const iconEnd = await page.find(`calcite-button >>> .${CSS.iconEnd}`);
   const loader = await page.find(`calcite-button >>> .${CSS.buttonLoader} calcite-loader`);
 
-  expect(element).toHaveAttribute(HYDRATED_ATTR);
   expect(element).toEqualAttribute("kind", "brand");
   expect(element).toEqualAttribute("appearance", "solid");
   expect(element).toEqualAttribute("scale", "m");
@@ -115,7 +114,6 @@ it("renders as a link with default props", async () => {
   const iconEnd = await page.find(`calcite-button >>> .${CSS.iconEnd}`);
   const loader = await page.find(`calcite-button >>> .${CSS.buttonLoader} calcite-loader`);
 
-  expect(element).toHaveAttribute(HYDRATED_ATTR);
   expect(element).toEqualAttribute("kind", "brand");
   expect(element).toEqualAttribute("appearance", "solid");
   expect(element).toEqualAttribute("scale", "m");
@@ -172,7 +170,6 @@ it("renders as a button with requested props", async () => {
   const iconEnd = await page.find(`calcite-button >>> .${CSS.iconEnd}`);
   const loader = await page.find(`calcite-button >>> .${CSS.buttonLoader} calcite-loader`);
 
-  expect(element).toHaveAttribute(HYDRATED_ATTR);
   expect(element).toEqualAttribute("kind", "danger");
   expect(element).toEqualAttribute("appearance", "outline");
   expect(element).toEqualAttribute("scale", "l");
@@ -196,7 +193,6 @@ it("renders as a link with requested props", async () => {
   const iconEnd = await page.find(`calcite-button >>> .${CSS.iconEnd}`);
   const loader = await page.find(`calcite-button >>> .${CSS.buttonLoader} calcite-loader`);
 
-  expect(element).toHaveAttribute(HYDRATED_ATTR);
   expect(element).toEqualAttribute("kind", "danger");
   expect(element).toEqualAttribute("appearance", "outline");
   expect(element).toEqualAttribute("scale", "l");
@@ -213,13 +209,11 @@ it("passes attributes to rendered child link", async () => {
   await page.setContent(
     `<calcite-button rel="noopener noreferrer" target="_blank" href="google.com">Continue</calcite-button>`,
   );
-  const element = await page.find("calcite-button");
   const elementAsButton = await page.find("calcite-button >>> button");
   const elementAsLink = await page.find("calcite-button >>> a");
   const iconStart = await page.find(`calcite-button >>> .${CSS.iconStart}`);
   const iconEnd = await page.find(`calcite-button >>> .${CSS.iconEnd}`);
   const loader = await page.find(`calcite-button >>> .${CSS.buttonLoader} calcite-loader`);
-  expect(element).toHaveAttribute(HYDRATED_ATTR);
   expect(elementAsLink).not.toBeNull();
   expect(elementAsButton).toBeNull();
   expect(elementAsLink).toEqualAttribute("href", "google.com");
@@ -233,13 +227,11 @@ it("passes attributes to rendered child link", async () => {
 it("passes attributes to rendered child button", async () => {
   const page = await newE2EPage();
   await page.setContent(`<calcite-button type="reset" name="my-name">Continue</calcite-button>`);
-  const element = await page.find("calcite-button");
   const elementAsButton = await page.find("calcite-button >>> button");
   const elementAsLink = await page.find("calcite-button >>> a");
   const iconStart = await page.find(`calcite-button >>> .${CSS.iconStart}`);
   const iconEnd = await page.find(`calcite-button >>> .${CSS.iconEnd}`);
   const loader = await page.find(`calcite-button >>> .${CSS.buttonLoader} calcite-loader`);
-  expect(element).toHaveAttribute(HYDRATED_ATTR);
   expect(elementAsLink).toBeNull();
   expect(elementAsButton).not.toBeNull();
   expect(elementAsButton).toEqualAttribute("type", "reset");
@@ -252,13 +244,11 @@ it("passes attributes to rendered child button", async () => {
 it("renders with an icon-start", async () => {
   const page = await newE2EPage();
   await page.setContent(`<calcite-button icon-start='plus'>Continue</calcite-button>`);
-  const element = await page.find("calcite-button");
   const elementAsButton = await page.find("calcite-button >>> button");
   const elementAsLink = await page.find("calcite-button >>> a");
   const iconStart = await page.find(`calcite-button >>> .${CSS.iconStart}`);
   const iconEnd = await page.find(`calcite-button >>> .${CSS.iconEnd}`);
   const loader = await page.find(`calcite-button >>> .${CSS.buttonLoader} calcite-loader`);
-  expect(element).toHaveAttribute(HYDRATED_ATTR);
   expect(elementAsLink).toBeNull();
   expect(elementAsButton).not.toBeNull();
   expect(iconStart).not.toBeNull();
@@ -269,13 +259,11 @@ it("renders with an icon-start", async () => {
 it("renders with an icon-end", async () => {
   const page = await newE2EPage();
   await page.setContent(`<calcite-button icon-end='plus'>Continue</calcite-button>`);
-  const element = await page.find("calcite-button");
   const elementAsButton = await page.find("calcite-button >>> button");
   const elementAsLink = await page.find("calcite-button >>> a");
   const iconStart = await page.find(`calcite-button >>> .${CSS.iconStart}`);
   const iconEnd = await page.find(`calcite-button >>> .${CSS.iconEnd}`);
   const loader = await page.find(`calcite-button >>> .${CSS.buttonLoader} calcite-loader`);
-  expect(element).toHaveAttribute(HYDRATED_ATTR);
   expect(elementAsLink).toBeNull();
   expect(elementAsButton).not.toBeNull();
   expect(iconStart).toBeNull();
@@ -286,13 +274,11 @@ it("renders with an icon-end", async () => {
 it("renders with an icon-start and icon-end", async () => {
   const page = await newE2EPage();
   await page.setContent(`<calcite-button icon-start='plus' icon-end='plus'>Continue</calcite-button>`);
-  const element = await page.find("calcite-button");
   const elementAsButton = await page.find("calcite-button >>> button");
   const elementAsLink = await page.find("calcite-button >>> a");
   const iconStart = await page.find(`calcite-button >>> .${CSS.iconStart}`);
   const iconEnd = await page.find(`calcite-button >>> .${CSS.iconEnd}`);
   const loader = await page.find(`calcite-button >>> .${CSS.buttonLoader} calcite-loader`);
-  expect(element).toHaveAttribute(HYDRATED_ATTR);
   expect(elementAsLink).toBeNull();
   expect(elementAsButton).not.toBeNull();
   expect(iconStart).not.toBeNull();
@@ -318,13 +304,11 @@ it("renders hidden icon when both icon and loader are requested, no text", async
 it("renders with a loader and an icon-start when both icon-start and loader are requested", async () => {
   const page = await newE2EPage();
   await page.setContent(`<calcite-button loading icon-start='plus'>Continue</calcite-button>`);
-  const element = await page.find("calcite-button");
   const elementAsButton = await page.find("calcite-button >>> button");
   const elementAsLink = await page.find("calcite-button >>> a");
   const iconStart = await page.find(`calcite-button >>> .${CSS.iconStart}`);
   const iconEnd = await page.find(`calcite-button >>> .${CSS.iconEnd}`);
   const loader = await page.find(`calcite-button >>> .${CSS.buttonLoader} calcite-loader`);
-  expect(element).toHaveAttribute(HYDRATED_ATTR);
   expect(elementAsLink).toBeNull();
   expect(elementAsButton).not.toBeNull();
   expect(iconStart).not.toBeNull();
@@ -335,13 +319,11 @@ it("renders with a loader and an icon-start when both icon-start and loader are 
 it("renders with a loader and an icon-end when both icon-end and loader are requested", async () => {
   const page = await newE2EPage();
   await page.setContent(`<calcite-button loading icon-end='plus'>Continue</calcite-button>`);
-  const element = await page.find("calcite-button");
   const elementAsButton = await page.find("calcite-button >>> button");
   const elementAsLink = await page.find("calcite-button >>> a");
   const iconStart = await page.find(`calcite-button >>> .${CSS.iconStart}`);
   const iconEnd = await page.find(`calcite-button >>> .${CSS.iconEnd}`);
   const loader = await page.find(`calcite-button >>> .${CSS.buttonLoader} calcite-loader`);
-  expect(element).toHaveAttribute(HYDRATED_ATTR);
   expect(elementAsLink).toBeNull();
   expect(elementAsButton).not.toBeNull();
   expect(iconStart).toBeNull();
@@ -352,13 +334,11 @@ it("renders with a loader and an icon-end when both icon-end and loader are requ
 it("renders with a loader and an icon-start and icon-end when all are requested", async () => {
   const page = await newE2EPage();
   await page.setContent(`<calcite-button loading icon-start='plus' icon-end='plus'>Continue</calcite-button>`);
-  const element = await page.find("calcite-button");
   const elementAsButton = await page.find("calcite-button >>> button");
   const elementAsLink = await page.find("calcite-button >>> a");
   const iconStart = await page.find(`calcite-button >>> .${CSS.iconStart}`);
   const iconEnd = await page.find(`calcite-button >>> .${CSS.iconEnd}`);
   const loader = await page.find(`calcite-button >>> .${CSS.buttonLoader} calcite-loader`);
-  expect(element).toHaveAttribute(HYDRATED_ATTR);
   expect(elementAsLink).toBeNull();
   expect(elementAsButton).not.toBeNull();
   expect(iconStart).not.toBeNull();

--- a/packages/components/src/components/checkbox/checkbox.browser.e2e.tsx
+++ b/packages/components/src/components/checkbox/checkbox.browser.e2e.tsx
@@ -7,9 +7,14 @@ import {
   formAssociated,
   hidden,
   internalLabel,
+  renders,
   t9n,
 } from "../../tests/commonTests/browser";
 import { defaultValidity } from "../../tests/commonTests/browser/defaults";
+
+describe("renders", () => {
+  renders(() => mount("calcite-checkbox"), { display: "inline-flex" });
+});
 
 describe("defaults", () => {
   defaults(

--- a/packages/components/src/components/checkbox/checkbox.e2e.ts
+++ b/packages/components/src/components/checkbox/checkbox.e2e.ts
@@ -1,7 +1,7 @@
 // @ts-strict-ignore
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
-import { accessible, HYDRATED_ATTR, labelable, themed } from "../../tests/commonTests";
+import { accessible, labelable, themed } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 import { Scale } from "../interfaces";
 import { Direction } from "../../utils/dom";
@@ -28,7 +28,6 @@ it("renders with correct default attributes", async () => {
 
   const calciteCheckbox = await page.find("calcite-checkbox");
 
-  expect(calciteCheckbox).toHaveAttribute(HYDRATED_ATTR);
   expect(calciteCheckbox).not.toHaveAttribute("checked");
   expect(calciteCheckbox).not.toHaveAttribute("indeterminate");
 });

--- a/packages/components/src/components/switch/switch.browser.e2e.tsx
+++ b/packages/components/src/components/switch/switch.browser.e2e.tsx
@@ -6,7 +6,12 @@ import {
   formAssociated,
   hidden,
   internalLabel,
+  renders,
 } from "../../tests/commonTests/browser";
+
+describe("renders", () => {
+  renders(() => mount("calcite-switch"), { display: "inline-block" });
+});
 
 describe("honors hidden attribute", () => {
   hidden(() => mount("calcite-switch"));

--- a/packages/components/src/components/switch/switch.e2e.ts
+++ b/packages/components/src/components/switch/switch.e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
-import { accessible, HYDRATED_ATTR, labelable, themed } from "../../tests/commonTests";
+import { accessible, labelable, themed } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 import type { Switch } from "./switch";
 import { CSS } from "./resources";
@@ -11,7 +11,6 @@ it("renders with correct default attributes", async () => {
 
   const calciteSwitch = await page.find("calcite-switch");
 
-  expect(calciteSwitch).toHaveAttribute(HYDRATED_ATTR);
   expect(calciteSwitch).toHaveAttribute("checked");
 });
 

--- a/packages/components/src/components/tab-title/tab-title.e2e.ts
+++ b/packages/components/src/components/tab-title/tab-title.e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage, E2EPage, E2EElement } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it, beforeEach } from "vitest";
-import { HYDRATED_ATTR, themed } from "../../tests/commonTests";
+import { themed } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 import { CSS } from "./resources";
 
@@ -43,10 +43,8 @@ const closeSelector = `calcite-tab-title >>> .${CSS.close}`;
 it("renders with an icon-start", async () => {
   const page = await newE2EPage();
   await page.setContent(`<calcite-tab-title icon-start='plus'>Text</calcite-tab-title>`);
-  const element = await page.find("calcite-tab-title");
   const iconStart = await page.find(iconStartSelector);
   const iconEnd = await page.find(iconEndSelector);
-  expect(element).toHaveAttribute(HYDRATED_ATTR);
   expect(iconStart).not.toBeNull();
   expect(iconEnd).toBeNull();
 });
@@ -54,10 +52,8 @@ it("renders with an icon-start", async () => {
 it("renders with an icon-end", async () => {
   const page = await newE2EPage();
   await page.setContent(`<calcite-tab-title icon-end='plus'>Text</calcite-tab-title>`);
-  const element = await page.find("calcite-tab-title");
   const iconStart = await page.find(iconStartSelector);
   const iconEnd = await page.find(iconEndSelector);
-  expect(element).toHaveAttribute(HYDRATED_ATTR);
   expect(iconStart).toBeNull();
   expect(iconEnd).not.toBeNull();
 });
@@ -65,10 +61,8 @@ it("renders with an icon-end", async () => {
 it("renders with an icon-start and icon-end", async () => {
   const page = await newE2EPage();
   await page.setContent(`<calcite-tab-title icon-start='plus' icon-end='plus'>Text</calcite-tab-title>`);
-  const element = await page.find("calcite-tab-title");
   const iconStart = await page.find(iconStartSelector);
   const iconEnd = await page.find(iconEndSelector);
-  expect(element).toHaveAttribute(HYDRATED_ATTR);
   expect(iconStart).not.toBeNull();
   expect(iconEnd).not.toBeNull();
 });
@@ -110,7 +104,6 @@ describe("basic closing behavior", () => {
 
     let containerElOne = await page.find(`calcite-tab-title[id='one']`);
     const closeOne = await page.find(`calcite-tab-title[id='one'] >>> .${CSS.close}`);
-    expect(containerElOne).toHaveAttribute(HYDRATED_ATTR);
 
     await closeOne.click();
     await page.waitForChanges();


### PR DESCRIPTION
**Related Issue:** #9166

## Summary
Removed direct HYDRATED_ATTR assertions and related imports from legacy e2e tests and added explicit renders coverage to browser suites where it was missing.

HYDRATED_ATTR direct assertions are legacy boilerplate and are better covered through the shared renders helper, which centralizes hydration and render-state checks and improves consistency across component browser suites.