### PR TITLE
test(alert): add coverage for close button visibility during auto-close timeout 

### DIFF
--- a/packages/components/src/components/alert/alert.browser.e2e.tsx
+++ b/packages/components/src/components/alert/alert.browser.e2e.tsx
@@ -1,5 +1,5 @@
 import { h } from "@arcgis/lumina";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import { page, userEvent } from "vitest/browser";
 import {
@@ -11,7 +11,7 @@ import {
   topLayer,
   openClose,
 } from "../../tests/commonTests/browser";
-import { DURATIONS } from "./resources";
+import { CSS, DURATIONS } from "./resources";
 import { alertQueueTimeoutMs } from "./AlertManager";
 import type { Alert } from "./alert";
 
@@ -67,41 +67,44 @@ describe("translation support", () => {
   t9n(() => mount("calcite-alert"));
 });
 
+afterEach(() => {
+  vi.useRealTimers();
+});
+
 it("retains close button during auto-close delay and closes when clicked", async () => {
   vi.useFakeTimers();
 
-  try {
-    await mount(
-      <div>
-        <calcite-button id="button">open alert</calcite-button>
-        <calcite-alert auto-close icon id="alert" kind="success" label="this is a success" />
-      </div>,
-    );
+  await mount(
+    <calcite-alert
+      auto-close
+      auto-close-duration="medium"
+      icon
+      id="alert"
+      kind="success"
+      label="this is a success"
+    />,
+  );
 
-    const openButton = page.getBySelector("#button");
-    const alert = page.getBySelector("#alert").element() as Alert["el"];
+  const alert = page.getBySelector("#alert").element() as Alert["el"];
+  alert.open = true;
 
-    openButton.element()?.addEventListener("click", () => {
-      alert.open = true;
-    });
+  vi.advanceTimersByTime(alertQueueTimeoutMs);
 
-    await userEvent.click(openButton);
-    vi.advanceTimersByTime(alertQueueTimeoutMs);
+  expect(alert.open).toBe(true);
 
-    expect(alert.open).toBe(true);
+  let closeButton = page.getBySelector(`#alert .${CSS.close}`);
+  await expect.element(closeButton).toBeVisible();
 
-    let closeButton = page.getBySelector("#alert .close");
-    await expect.element(closeButton).toBeVisible();
+  vi.advanceTimersByTime(DURATIONS.medium / 2);
 
-    vi.advanceTimersByTime(DURATIONS.medium / 2);
+  closeButton = page.getBySelector(`#alert .${CSS.close}`);
+  await expect.element(closeButton).toBeVisible();
 
-    closeButton = page.getBySelector("#alert .close");
-    await expect.element(closeButton).toBeVisible();
+  vi.advanceTimersByTime(DURATIONS.medium / 2 - 1);
 
-    await userEvent.click(closeButton);
+  closeButton = page.getBySelector(`#alert .${CSS.close}`);
+  await expect.element(closeButton).toBeVisible();
+  await userEvent.click(closeButton);
 
-    expect(alert.open).toBe(false);
-  } finally {
-    vi.useRealTimers();
-  }
+  expect(alert.open).toBe(false);
 });

--- a/packages/components/src/components/alert/alert.browser.e2e.tsx
+++ b/packages/components/src/components/alert/alert.browser.e2e.tsx
@@ -1,6 +1,7 @@
 import { h } from "@arcgis/lumina";
-import { describe } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
+import { page, userEvent } from "vitest/browser";
 import {
   defaults,
   reflects,
@@ -10,6 +11,9 @@ import {
   topLayer,
   openClose,
 } from "../../tests/commonTests/browser";
+import { DURATIONS } from "./resources";
+import { alertQueueTimeoutMs } from "./AlertManager";
+import type { Alert } from "./alert";
 
 describe("defaults", () => {
   defaults(
@@ -61,4 +65,43 @@ describe("top layer placement", () => {
 
 describe("translation support", () => {
   t9n(() => mount("calcite-alert"));
+});
+
+it("retains close button during auto-close delay and closes when clicked", async () => {
+  vi.useFakeTimers();
+
+  try {
+    await mount(
+      <div>
+        <calcite-button id="button">open alert</calcite-button>
+        <calcite-alert auto-close icon id="alert" kind="success" label="this is a success" />
+      </div>,
+    );
+
+    const openButton = page.getBySelector("#button");
+    const alert = page.getBySelector("#alert").element() as Alert["el"];
+
+    openButton.element()?.addEventListener("click", () => {
+      alert.open = true;
+    });
+
+    await userEvent.click(openButton);
+    vi.advanceTimersByTime(alertQueueTimeoutMs);
+
+    expect(alert.open).toBe(true);
+
+    let closeButton = page.getBySelector("#alert .close");
+    await expect.element(closeButton).toBeVisible();
+
+    vi.advanceTimersByTime(DURATIONS.medium / 2);
+
+    closeButton = page.getBySelector("#alert .close");
+    await expect.element(closeButton).toBeVisible();
+
+    await userEvent.click(closeButton);
+
+    expect(alert.open).toBe(false);
+  } finally {
+    vi.useRealTimers();
+  }
 });

--- a/packages/components/src/components/alert/alert.e2e.ts
+++ b/packages/components/src/components/alert/alert.e2e.ts
@@ -520,6 +520,24 @@ describe("auto-close behavior", () => {
     expect(buttonClose).toBeTruthy();
   });
 
+  it("retains close button during auto-close delay and closes when clicked", async () => {
+    await button.click();
+    await page.waitForTimeout(alertQueueTimeoutMs);
+
+    expect(await alert.isVisible()).toBe(true);
+    expect(buttonClose).toBeTruthy();
+    expect(await buttonClose.isVisible()).toBe(true);
+
+    await page.waitForTimeout(DURATIONS.medium / 2);
+
+    buttonClose = await page.find(`#alert >>> .${CSS.close}`);
+    expect(buttonClose).toBeTruthy();
+    expect(await buttonClose.isVisible()).toBe(true);
+
+    await buttonClose.click();
+    await page.waitForSelector("#alert", { visible: false });
+  });
+
   it("pauses on mouseOver and resumes on mouseLeave", async () => {
     await button.click();
 

--- a/packages/components/src/components/alert/alert.e2e.ts
+++ b/packages/components/src/components/alert/alert.e2e.ts
@@ -520,24 +520,6 @@ describe("auto-close behavior", () => {
     expect(buttonClose).toBeTruthy();
   });
 
-  it("retains close button during auto-close delay and closes when clicked", async () => {
-    await button.click();
-    await page.waitForTimeout(alertQueueTimeoutMs);
-
-    expect(await alert.isVisible()).toBe(true);
-    expect(buttonClose).toBeTruthy();
-    expect(await buttonClose.isVisible()).toBe(true);
-
-    await page.waitForTimeout(DURATIONS.medium / 2);
-
-    buttonClose = await page.find(`#alert >>> .${CSS.close}`);
-    expect(buttonClose).toBeTruthy();
-    expect(await buttonClose.isVisible()).toBe(true);
-
-    await buttonClose.click();
-    await page.waitForSelector("#alert", { visible: false });
-  });
-
   it("pauses on mouseOver and resumes on mouseLeave", async () => {
     await button.click();
 


### PR DESCRIPTION
**Related Issue:** #9122

## Summary
Adds a test to assert it retains close button during auto-close delay and closes when clicked.