### PR TITLE
fix(tabs): ensure tabs and titles are loaded before syncing ARIA state

### DIFF
--- a/packages/components/src/components/tabs/tabs.browser.e2e.tsx
+++ b/packages/components/src/components/tabs/tabs.browser.e2e.tsx
@@ -1,8 +1,9 @@
 import { h, Fragment } from "@arcgis/lumina";
-import { describe } from "vitest";
+import { describe, expect, it } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import { JsxNode } from "@arcgis/lumina";
 import { defaults, reflects, hidden, renders } from "../../tests/commonTests/browser";
+import type { Tabs } from "./tabs";
 
 describe("defaults", () => {
   defaults(
@@ -49,4 +50,27 @@ function createTabsContent(): JsxNode {
 
 describe("renders", () => {
   renders(() => mount(<calcite-tabs>{createTabsContent()}</calcite-tabs>), { display: "flex" });
+});
+
+it("does not throw when adding tab and tab-title with tab ID after initialization", async () => {
+  async function runTest(): Promise<void> {
+    const { el: tabsEl, reRender } = await mount<Tabs>(
+      <calcite-tabs>
+        <calcite-tab-nav id="tab-nav" slot="title-group" />
+      </calcite-tabs>,
+    );
+
+    const tabNavEl = document.querySelector("calcite-tab-nav")!;
+    const tabTitle = document.createElement("calcite-tab-title");
+    const tab = document.createElement("calcite-tab");
+    tabTitle.tab = "test";
+    tab.tab = "test";
+
+    tabNavEl.append(tabTitle);
+    tabsEl.append(tab);
+
+    await reRender();
+  }
+
+  await expect(runTest()).resolves.toBeUndefined();
 });

--- a/packages/components/src/components/tabs/tabs.browser.e2e.tsx
+++ b/packages/components/src/components/tabs/tabs.browser.e2e.tsx
@@ -60,7 +60,7 @@ it("does not throw when adding tab and tab-title with tab ID after initializatio
       </calcite-tabs>,
     );
 
-    const tabNavEl = document.querySelector("calcite-tab-nav")!;
+    const tabNavEl = tabsEl.querySelector("#tab-nav")!;
     const tabTitle = document.createElement("calcite-tab-title");
     const tab = document.createElement("calcite-tab");
     tabTitle.tab = "test";

--- a/packages/components/src/components/tabs/tabs.browser.e2e.tsx
+++ b/packages/components/src/components/tabs/tabs.browser.e2e.tsx
@@ -1,9 +1,8 @@
 import { h, Fragment } from "@arcgis/lumina";
-import { describe, expect, it } from "vitest";
+import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import { JsxNode } from "@arcgis/lumina";
 import { defaults, reflects, hidden, renders } from "../../tests/commonTests/browser";
-import type { Tabs } from "./tabs";
 
 describe("defaults", () => {
   defaults(
@@ -50,27 +49,4 @@ function createTabsContent(): JsxNode {
 
 describe("renders", () => {
   renders(() => mount(<calcite-tabs>{createTabsContent()}</calcite-tabs>), { display: "flex" });
-});
-
-it("does not throw when adding tab and tab-title with tab ID after initialization", async () => {
-  async function runTest(): Promise<void> {
-    const { el: tabsEl, reRender } = await mount<Tabs>(
-      <calcite-tabs>
-        <calcite-tab-nav id="tab-nav" slot="title-group" />
-      </calcite-tabs>,
-    );
-
-    const tabNavEl = tabsEl.querySelector("#tab-nav")!;
-    const tabTitle = document.createElement("calcite-tab-title");
-    const tab = document.createElement("calcite-tab");
-    tabTitle.tab = "test";
-    tab.tab = "test";
-
-    tabNavEl.append(tabTitle);
-    tabsEl.append(tab);
-
-    await reRender();
-  }
-
-  await expect(runTest()).resolves.toBeUndefined();
 });

--- a/packages/components/src/components/tabs/tabs.dynamic-tab-addition.isolated.browser.e2e.tsx
+++ b/packages/components/src/components/tabs/tabs.dynamic-tab-addition.isolated.browser.e2e.tsx
@@ -1,0 +1,44 @@
+import { h } from "@arcgis/lumina";
+import { expect, it } from "vitest";
+import { mount } from "@arcgis/lumina-compiler/testing";
+import type { Tabs } from "./tabs";
+
+/**
+ * ⚠️Do not add tests to this file ⚠️
+ * This test needs to run in its own iframe to ensure lazy loading remains part of the test setup.
+ */
+it("does not throw when adding tab and tab-title with tab ID after initialization", async () => {
+  let unhandledRejection: unknown;
+
+  const handleUnhandledRejection = (event: PromiseRejectionEvent): void => {
+    event.preventDefault();
+    unhandledRejection = event.reason;
+  };
+
+  window.addEventListener("unhandledrejection", handleUnhandledRejection);
+
+  try {
+    const { el: tabsEl } = await mount<Tabs>(
+      <calcite-tabs>
+        <calcite-tab-nav id="tab-nav" slot="title-group" />
+      </calcite-tabs>,
+    );
+
+    const tabNavEl = tabsEl.querySelector("#tab-nav")!;
+    const tabTitle = document.createElement("calcite-tab-title");
+    const tab = document.createElement("calcite-tab");
+
+    tabTitle.tab = "test";
+    tab.tab = "test";
+
+    tabNavEl.append(tabTitle);
+    tabsEl.append(tab);
+
+    await tabTitle.componentOnReady();
+    await tab.componentOnReady();
+
+    expect(unhandledRejection).toBeUndefined();
+  } finally {
+    window.removeEventListener("unhandledrejection", handleUnhandledRejection);
+  }
+});

--- a/packages/components/src/components/tabs/tabs.dynamic-tab-addition.isolated.browser.e2e.tsx
+++ b/packages/components/src/components/tabs/tabs.dynamic-tab-addition.isolated.browser.e2e.tsx
@@ -10,27 +10,27 @@ import type { Tabs } from "./tabs";
 it("does not throw when adding tab and tab-title with tab ID after initialization", async () => {
   let unhandledRejection: unknown;
 
-  const handleUnhandledRejection = (event: PromiseRejectionEvent): void => {
+  function handleUnhandledRejection(event: PromiseRejectionEvent): void {
     event.preventDefault();
     unhandledRejection = event.reason;
-  };
+  }
 
   window.addEventListener("unhandledrejection", handleUnhandledRejection);
 
+  const { el: tabsEl } = await mount<Tabs>(
+    <calcite-tabs>
+      <calcite-tab-nav id="tab-nav" slot="title-group" />
+    </calcite-tabs>,
+  );
+
+  const tabNavEl = tabsEl.querySelector("#tab-nav")!;
+  const tabTitle = document.createElement("calcite-tab-title");
+  const tab = document.createElement("calcite-tab");
+
+  tabTitle.tab = "test";
+  tab.tab = "test";
+
   try {
-    const { el: tabsEl } = await mount<Tabs>(
-      <calcite-tabs>
-        <calcite-tab-nav id="tab-nav" slot="title-group" />
-      </calcite-tabs>,
-    );
-
-    const tabNavEl = tabsEl.querySelector("#tab-nav")!;
-    const tabTitle = document.createElement("calcite-tab-title");
-    const tab = document.createElement("calcite-tab");
-
-    tabTitle.tab = "test";
-    tab.tab = "test";
-
     tabNavEl.append(tabTitle);
     tabsEl.append(tab);
 

--- a/packages/components/src/components/tabs/tabs.tsx
+++ b/packages/components/src/components/tabs/tabs.tsx
@@ -129,6 +129,7 @@ export class Tabs extends LitElement {
     let tabIds;
     let titleIds;
     const tabs = getSlotAssignedElements<Tab["el"]>(this.slotRef.value, "calcite-tab");
+    await Promise.all([...tabs, ...this.titles].map((tabOrTitle) => tabOrTitle.componentOnReady()));
 
     // determine if we are using `tab` based or `index` based tab identifiers.
     if (tabs.some((el) => el.tab) || this.titles.some((el) => el.tab)) {


### PR DESCRIPTION
**Related Issue:** #13954 

## Summary

Fixes an issue caused by initialization of `tab` and `tab-title`s added after initialization. This issue is only reproducible when the added components use the `tab` prop and they begin lazy-loading.

**Note**: this introduces an isolated test file as the test depends on the `tabs` set of components to be in an unloaded state. This guarantees the test runs in an isolated iframe and provides proper coverage.