### PR TITLE
fix(list): reset sticky heading offset when filter is disabled

### DIFF
--- a/packages/components/src/components/list/list.browser.e2e.tsx
+++ b/packages/components/src/components/list/list.browser.e2e.tsx
@@ -281,6 +281,50 @@ describe("sticky group heading with filter", () => {
 
     expect(filterZIndex).toBeGreaterThan(stickyGroupZIndex);
   });
+
+  it("removes sticky heading offset when filter is disabled", async () => {
+    const { el } = await mount<List>(
+      <calcite-list filter-enabled style="height: 160px; overflow-y: auto;">
+        <calcite-list-item-group heading="Group A">
+          <calcite-list-item label="A1" value="a1" />
+          <calcite-list-item label="A2" value="a2" />
+          <calcite-list-item label="A3" value="a3" />
+          <calcite-list-item label="A4" value="a4" />
+          <calcite-list-item label="A5" value="a5" />
+          <calcite-list-item label="A6" value="a6" />
+          <calcite-list-item label="A7" value="a7" />
+          <calcite-list-item label="A8" value="a8" />
+        </calcite-list-item-group>
+        <calcite-list-item-group heading="Group B">
+          <calcite-list-item label="B1" value="b1" />
+          <calcite-list-item label="B2" value="b2" />
+          <calcite-list-item label="B3" value="b3" />
+          <calcite-list-item label="B4" value="b4" />
+        </calcite-list-item-group>
+      </calcite-list>,
+    );
+
+    const list = el as HTMLElement;
+    const stickyContainer = page
+      .getBySelector(`calcite-list-item-group .${listItemGroupCSS.container}`)
+      .first()
+      .element();
+
+    list.scrollTop = scrollTopValue;
+    await afterNextFrame();
+
+    const filterInput = page.getBySelector("calcite-list calcite-filter").element();
+    const filterHeight = filterInput.getBoundingClientRect().height;
+    const topWithFilter = stickyContainer.getBoundingClientRect().top;
+
+    el.filterEnabled = false;
+    await new Promise((resolve) => setTimeout(resolve, DEBOUNCE.filter + 1));
+    await afterNextTask();
+    await afterNextFrame();
+
+    const topWithoutFilter = stickyContainer.getBoundingClientRect().top;
+    expect(topWithFilter - topWithoutFilter).toBeGreaterThanOrEqual(filterHeight - 2);
+  });
 });
 
 describe("group filtering", () => {

--- a/packages/components/src/components/list/list.browser.e2e.tsx
+++ b/packages/components/src/components/list/list.browser.e2e.tsx
@@ -312,13 +312,13 @@ describe("sticky group heading with filter", () => {
 
     list.scrollTop = scrollTopValue;
     await afterNextFrame();
+    expect(list.scrollTop).toBeGreaterThan(0);
 
     const filterInput = page.getBySelector("calcite-list calcite-filter").element();
     const filterHeight = filterInput.getBoundingClientRect().height;
     const topWithFilter = stickyContainer.getBoundingClientRect().top;
 
     el.filterEnabled = false;
-    await new Promise((resolve) => setTimeout(resolve, DEBOUNCE.filter + 1));
     await afterNextTask();
     await afterNextFrame();
 

--- a/packages/components/src/components/list/list.tsx
+++ b/packages/components/src/components/list/list.tsx
@@ -566,7 +566,7 @@ export class List extends LitElement {
   }
 
   private updateFilterRowHeight(): void {
-    this.filterRowHeight = (this.filterEnabled && this.filterContainerEl?.clientHeight) ?? 0;
+    this.filterRowHeight = this.filterEnabled ? (this.filterContainerEl?.clientHeight ?? 0) : 0;
   }
 
   private handleListItemChange(): void {

--- a/packages/components/src/components/list/list.tsx
+++ b/packages/components/src/components/list/list.tsx
@@ -566,7 +566,7 @@ export class List extends LitElement {
   }
 
   private updateFilterRowHeight(): void {
-    this.filterRowHeight = this.filterEnabled ? (this.filterContainerEl?.clientHeight ?? 0) : 0;
+    this.filterRowHeight = this.filterContainerEl?.clientHeight ?? 0;
   }
 
   private handleListItemChange(): void {

--- a/packages/components/src/components/list/list.tsx
+++ b/packages/components/src/components/list/list.tsx
@@ -472,6 +472,7 @@ export class List extends LitElement {
   //#region Private Methods
 
   private updateListItems(): void {
+    this.updateFilterRowHeight();
     this.updateGroupItems();
 
     const {
@@ -565,7 +566,7 @@ export class List extends LitElement {
   }
 
   private updateFilterRowHeight(): void {
-    this.filterRowHeight = this.filterContainerEl?.clientHeight ?? 0;
+    this.filterRowHeight = (this.filterEnabled && this.filterContainerEl?.clientHeight) ?? 0;
   }
 
   private handleListItemChange(): void {


### PR DESCRIPTION
**Related Issue:** #14502

## Summary
This PR fixes a list filtering offset issue by ensuring the filter row height is recalculated during list item updates and reset when filtering is disabled.  
It also adds a browser regression test to prevent sticky group headings from retaining filter offset after toggling filtering off.

## Why
When filtering was disabled after being enabled, sticky list-item-group heading positioning could still reflect the prior filter row offset. This caused incorrect sticky spacing.