### PR TITLE
chore(release-please): set `last-release-sha` to `5.0.2` commit

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
   "tag-separator": "@",
+  "last-release-sha": "c5e128e02f08e37bccfdc1d872f062669d9e09c0",
   "draft-pull-request": true,
   "include-v-in-tag": false,
   "commit-search-depth": 1000,


### PR DESCRIPTION
**Related Issue:** n/a

## Summary

Fixes the release automation for 2026 R2 by setting the `last-release-sha` release-please config option to the `5.0.2` release commit.
