### PR TITLE
chore(release-please): remove Stylelint plugin from release-please manifest

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -4,6 +4,5 @@
   "packages/design-tokens": "4.0.0",
   "packages/ui-icons": "4.4.0",
   "packages/eslint-plugin-components": "2.0.3",
-  "packages/tailwind-preset": "1.1.0",
-  "packages/stylelint-plugin-components": "0.0.1"
+  "packages/tailwind-preset": "1.1.0"
 }


### PR DESCRIPTION
**Related Issue:** #13677

## Summary

Removes the custom Stylelint Components plugin from the `release-please-manifest` so it is not included as part of releases.
