### PR TITLE
fix(color-picker): add visible opacity label for accessibility

### DIFF
--- a/packages/components/src/components/color-picker-hex-input/color-picker-hex-input.scss
+++ b/packages/components/src/components/color-picker-hex-input/color-picker-hex-input.scss
@@ -5,7 +5,7 @@
 }
 
 .container {
-  @apply flex w-full items-center flex-nowrap;
+  @apply flex w-full items-end flex-nowrap;
 }
 
 .hex-input {

--- a/packages/components/src/components/color-picker-hex-input/color-picker-hex-input.tsx
+++ b/packages/components/src/components/color-picker-hex-input/color-picker-hex-input.tsx
@@ -432,6 +432,7 @@ export class ColorPickerHexInput extends LitElement {
           <calcite-input-number
             class={CSS.opacityInput}
             key="opacity-input"
+            label={messages?.opacity}
             labelText={messages?.opacity}
             max={OPACITY_LIMITS.max}
             maxLength={3}

--- a/packages/components/src/components/color-picker-hex-input/color-picker-hex-input.tsx
+++ b/packages/components/src/components/color-picker-hex-input/color-picker-hex-input.tsx
@@ -417,12 +417,12 @@ export class ColorPickerHexInput extends LitElement {
           class={CSS.hexInput}
           label={messages?.hex || hexLabel}
           maxLength={this.alphaChannel ? 8 : 6}
-          onKeyDown={this.onInputKeyDown}
-          onPaste={this.onHexInputPaste}
           oncalciteInputTextChange={this.onHexInputChange}
           oncalciteInputTextInput={this.onHexInputInput}
           oncalciteInternalInputTextBlur={this.onHexInputBlur}
           oncalciteInternalInputTextFocus={this.onInputFocus}
+          onKeyDown={this.onInputKeyDown}
+          onPaste={this.onHexInputPaste}
           prefixText="#"
           ref={this.hexInputRef}
           scale={inputScale}
@@ -432,16 +432,16 @@ export class ColorPickerHexInput extends LitElement {
           <calcite-input-number
             class={CSS.opacityInput}
             key="opacity-input"
-            label={messages?.opacity}
+            labelText={messages?.opacity}
             max={OPACITY_LIMITS.max}
             maxLength={3}
             min={OPACITY_LIMITS.min}
             numberButtonType="none"
             numberingSystem={this.numberingSystem}
-            onKeyDown={this.onInputKeyDown}
             oncalciteInputNumberInput={this.onOpacityInputInput}
             oncalciteInternalInputNumberBlur={this.onOpacityInputBlur}
             oncalciteInternalInputNumberFocus={this.onInputFocus}
+            onKeyDown={this.onInputKeyDown}
             ref={this.opacityInputRef}
             scale={inputScale}
             suffixText="%"

--- a/packages/components/src/components/color-picker/color-picker.browser.e2e.tsx
+++ b/packages/components/src/components/color-picker/color-picker.browser.e2e.tsx
@@ -110,6 +110,9 @@ describe("opacity label", () => {
     await mount(<calcite-color-picker alpha-channel />);
 
     await expect.element(page.getByText("Opacity")).toBeVisible();
+
+    const opacityInput = page.getByRole("textbox", { name: "Opacity" });
+    await expect.element(opacityInput).toHaveAttribute("aria-label", "Opacity");
   });
 });
 

--- a/packages/components/src/components/color-picker/color-picker.browser.e2e.tsx
+++ b/packages/components/src/components/color-picker/color-picker.browser.e2e.tsx
@@ -105,6 +105,14 @@ describe("renders", () => {
   renders(() => mount("calcite-color-picker"), { display: "inline-block" });
 });
 
+describe("opacity label", () => {
+  it("renders a visible opacity label when alpha channel is enabled", async () => {
+    await mount(<calcite-color-picker alpha-channel />);
+
+    await expect.element(page.getByText("Opacity")).toBeVisible();
+  });
+});
+
 describe("translation support", () => {
   t9n(() => mount("calcite-color-picker"));
 });


### PR DESCRIPTION
**Related Issue:** #13540

## Summary
Fixes CAL-AMP49 by giving the Color Picker’s opacity field a visible, persistent label instead of only an accessible name. The opacity input now uses the existing internal label pattern, so its label is programmatically associated with the field and meets WC AG 2.5.3. 

Adds browser coverage to verify the label is rendered in the shipped Color Picker path.
