### PR TITLE
fix(combobox): ensure custom values are appended to value regardless of DOM order

### DIFF
--- a/packages/components/src/components/combobox/combobox.browser.e2e.tsx
+++ b/packages/components/src/components/combobox/combobox.browser.e2e.tsx
@@ -730,6 +730,7 @@ describe("item selection", () => {
     await expect.element(customItem).toHaveProperty("heading", "K");
 
     expect(el).toHaveProperty("selectedItems", expect.objectContaining({ length: 1 }));
+    expect(el.value).toEqual("K");
     await expect.element(customItem).toHaveProperty("selected", true);
     expect(comboboxChangeHandler).toHaveBeenCalledTimes(1);
   });
@@ -748,18 +749,24 @@ describe("item selection", () => {
     await userEvent.click(el);
     await userEvent.type(el, "K{Enter}");
 
-    const customItem = page.getByLabelText("K");
-    const item1 = page.getByLabelText("one");
+    const items = page.getBySelector("calcite-combobox-item");
+    const chips = page.getBySelector("calcite-chip");
 
-    await expect.element(customItem).toHaveProperty("heading", "K");
-
-    expect(el).toHaveProperty("selectedItems", expect.objectContaining({ length: 1 }));
-    await expect.element(customItem).toHaveProperty("selected", true);
-    await expect.element(item1).toHaveProperty("selected", false);
+    expect(el.selectedItems.map((item) => item.value)).toEqual(["K"]);
+    expect(el.value).toEqual("K");
     expect(comboboxChangeHandler).toHaveBeenCalledTimes(1);
+
+    expect(items).toHaveLength(4);
+    await expect.element(items.nth(0)).toHaveProperty("heading", "K");
+    await expect.element(items.nth(0)).toHaveProperty("selected", true);
+    await expect.element(items.nth(1)).toHaveProperty("selected", false);
+    await expect.element(items.nth(2)).toHaveProperty("selected", false);
+    await expect.element(items.nth(3)).toHaveProperty("selected", false);
+
+    expect(chips).toHaveLength(0);
   });
 
-  it.skip("should auto-select new custom values in multiple selection mode", async () => {
+  it("should auto-select new custom values in multiple selection mode", async () => {
     const { el } = await mount<Combobox>(
       <calcite-combobox allow-custom-values>
         <calcite-combobox-item heading="one" id="one" selected value="one" />
@@ -773,20 +780,24 @@ describe("item selection", () => {
     await userEvent.click(el);
     await userEvent.type(el, "K{Enter}{Escape}");
 
-    const customItem = page.getBySelector("calcite-combobox-item:first-child");
-    const item1 = page.getByLabelText("one", { exact: true });
-    const item2 = page.getByLabelText("two").getByText("two");
+    const items = page.getBySelector("calcite-combobox-item");
     const chips = page.getBySelector("calcite-chip");
 
-    await expect.element(customItem).toHaveProperty("heading", "K");
-
-    expect(el).toHaveProperty("selectedItems", expect.objectContaining({ length: 3 }));
-    expect(chips).toHaveLength(2);
-    await expect.element(chips.elements()[2]).toHaveTextContent("K");
-    await expect.element(customItem).toHaveProperty("selected", true);
-    await expect.element(item1).toHaveProperty("selected", true);
-    await expect.element(item2).toHaveProperty("selected", true);
+    expect(el.selectedItems.map((item) => item.value)).toEqual(["one", "two", "K"]);
+    expect(el.value).toEqual(["one", "two", "K"]);
     expect(comboboxChangeHandler).toHaveBeenCalledTimes(1);
+
+    expect(items).toHaveLength(4);
+    await expect.element(items.nth(0)).toHaveProperty("heading", "K");
+    await expect.element(items.nth(0)).toHaveProperty("selected", true);
+    await expect.element(items.nth(1)).toHaveProperty("selected", true);
+    await expect.element(items.nth(2)).toHaveProperty("selected", true);
+    await expect.element(items.nth(3)).toHaveProperty("selected", false);
+
+    expect(chips).toHaveLength(3);
+    await expect.element(chips.nth(0)).toHaveTextContent("one");
+    await expect.element(chips.nth(1)).toHaveTextContent("two");
+    await expect.element(chips.nth(2)).toHaveTextContent("K");
   });
 
   it("updates the value immediately after selecting an item programmatically", async () => {

--- a/packages/components/src/components/combobox/combobox.tsx
+++ b/packages/components/src/components/combobox/combobox.tsx
@@ -71,6 +71,77 @@ declare global {
   }
 }
 
+function orderByPrevious<T>(items: T[], previousItems: T[]): T[] {
+  if (items.length < 2 || previousItems.length === 0) {
+    return items;
+  }
+
+  const previousItemOrder = new Map(previousItems.map((item, index) => [item, index]));
+
+  return [...items].sort((a, b) => {
+    const aOrder = previousItemOrder.get(a);
+    const bOrder = previousItemOrder.get(b);
+
+    if (aOrder !== undefined && bOrder !== undefined) {
+      return aOrder - bOrder;
+    }
+
+    if (aOrder !== undefined) {
+      return -1;
+    }
+
+    if (bOrder !== undefined) {
+      return 1;
+    }
+
+    return 0;
+  });
+}
+
+function consumeValue(counts: Map<string, number>, value: string): boolean {
+  const count = counts.get(value) ?? 0;
+
+  if (count === 0) {
+    return false;
+  }
+
+  if (count === 1) {
+    counts.delete(value);
+  } else {
+    counts.set(value, count - 1);
+  }
+
+  return true;
+}
+
+function orderValuesByPrevious(selectedValues: string[], previousValues: string[]): string[] {
+  if (selectedValues.length < 2 || previousValues.length === 0) {
+    return selectedValues;
+  }
+
+  const selectedValueCounts = new Map<string, number>();
+
+  selectedValues.forEach((value) => {
+    selectedValueCounts.set(value, (selectedValueCounts.get(value) ?? 0) + 1);
+  });
+
+  const orderedSelectedValues = previousValues.filter((value) =>
+    consumeValue(selectedValueCounts, value),
+  );
+
+  if (orderedSelectedValues.length === 0) {
+    return selectedValues;
+  }
+
+  selectedValues.forEach((value) => {
+    if (consumeValue(selectedValueCounts, value)) {
+      orderedSelectedValues.push(value);
+    }
+  });
+
+  return orderedSelectedValues;
+}
+
 /**
  * @slot - A slot for adding `calcite-combobox-item`s.
  * @slot label-content - A slot for rendering content next to the component's `labelText`.
@@ -170,21 +241,8 @@ export class Combobox extends LitElement implements LabelableComponent, Floating
       return match ? [match] : [];
     }
 
-    return (
-      this.allItems
-        .filter(
-          (item) =>
-            item.selected && (this.selectionMode !== "ancestors" || !hasActiveChildren(item)),
-        )
-        /** Preserve order of entered tags */
-        .sort((a, b) => {
-          const aIdx = this.selectedItems.indexOf(a);
-          const bIdx = this.selectedItems.indexOf(b);
-          if (aIdx > -1 && bIdx > -1) {
-            return aIdx - bIdx;
-          }
-          return bIdx - aIdx;
-        })
+    return this.allItems.filter(
+      (item) => item.selected && (this.selectionMode !== "ancestors" || !hasActiveChildren(item)),
     );
   };
 
@@ -814,6 +872,10 @@ export class Combobox extends LitElement implements LabelableComponent, Floating
     }
   }
 
+  private updateSelectedItems(): void {
+    this.selectedItems = this.getOrderedSelectedItems(this.getSelectedItems());
+  }
+
   private calciteComboboxItemChangeHandler(
     event: CustomEvent<HTMLCalciteComboboxItemElement["el"]>,
   ): void {
@@ -832,6 +894,8 @@ export class Combobox extends LitElement implements LabelableComponent, Floating
     );
     this.updateActiveItemIndex(newIndex);
     this.toggleSelection(target, target.selected);
+
+    this.updateSelectedItems();
   }
 
   private calciteInternalComboboxItemChangeHandler(
@@ -850,7 +914,7 @@ export class Combobox extends LitElement implements LabelableComponent, Floating
       this.ignoreSelectedEventsFlag = true;
       enabledSelectedItems.forEach((el) => (el.selected = false));
       this.ignoreSelectedEventsFlag = false;
-      this.selectedItems = this.getSelectedItems();
+      this.updateSelectedItems();
       this.emitComboboxChange();
     }
 
@@ -877,8 +941,26 @@ export class Combobox extends LitElement implements LabelableComponent, Floating
   }
 
   private getValue(): string | string[] {
-    const items = this.selectedItems.map((item) => item.value?.toString());
+    const items = this.getOrderedSelectedValues(
+      this.selectedItems.map((item) => item.value?.toString()),
+    );
+
     return items.length ? (items.length > 1 ? items : items[0]) : "";
+  }
+
+  private getOrderedSelectedValues(selectedValues: string[]): string[] {
+    if (!this.isMulti()) {
+      return selectedValues;
+    }
+
+    const previousValues = Array.isArray(this.value) ? this.value : this.value ? [this.value] : [];
+    return orderValuesByPrevious(selectedValues, previousValues);
+  }
+
+  private getOrderedSelectedItems(
+    selectedItems: HTMLCalciteComboboxItemElement["el"][],
+  ): HTMLCalciteComboboxItemElement["el"][] {
+    return this.isMulti() ? orderByPrevious(selectedItems, this.selectedItems) : selectedItems;
   }
 
   private comboboxInViewport(): boolean {
@@ -899,7 +981,7 @@ export class Combobox extends LitElement implements LabelableComponent, Floating
       }
       item.selected = toggledValue;
     });
-    this.selectedItems = this.getSelectedItems();
+    this.updateSelectedItems();
     this.emitComboboxChange();
   }
 
@@ -1553,7 +1635,7 @@ export class Combobox extends LitElement implements LabelableComponent, Floating
   private handleMultiSelection(item: HTMLCalciteComboboxItemElement["el"], value: boolean): void {
     item.selected = value;
     this.updateAncestors(item);
-    this.selectedItems = this.getSelectedItems();
+    this.updateSelectedItems();
     this.emitComboboxChange();
     this.resetText();
     this.filterItems("");
@@ -1563,7 +1645,7 @@ export class Combobox extends LitElement implements LabelableComponent, Floating
     this.ignoreSelectedEventsFlag = true;
     this.items.forEach((el) => (el.selected = el === item ? value : false));
     this.ignoreSelectedEventsFlag = false;
-    this.selectedItems = this.getSelectedItems();
+    this.updateSelectedItems();
     this.emitComboboxChange();
 
     if (this.textInputRef.value) {
@@ -1613,7 +1695,7 @@ export class Combobox extends LitElement implements LabelableComponent, Floating
 
     this.updateItemProps();
 
-    this.selectedItems = this.getSelectedItems();
+    this.updateSelectedItems();
     this.previousAllSelected = this.allSelected;
   }
 
@@ -1948,41 +2030,40 @@ export class Combobox extends LitElement implements LabelableComponent, Floating
     let disabledIndex = 0;
 
     if (preserveOrder) {
-      this.allItems.forEach((item) => {
+      const selectedChipItems = this.allItems.filter(
+        (item) => item.selected && (!isAncestors || !hasActiveChildren(item)),
+      );
+      const orderedSelectedChipItems = orderByPrevious(selectedChipItems, this.selectedItems);
+
+      orderedSelectedChipItems.forEach((item) => {
         if (item.disabled) {
-          if (item.selected && (!isAncestors || !hasActiveChildren(item))) {
-            chips.push(
-              this.renderChip({
-                activeChipIndex,
-                disabled: true,
-                index: disabledIndex++,
-                item,
-                messages,
-                readOnly,
-                scale,
-                isAncestors,
-              }),
-            );
-          }
+          chips.push(
+            this.renderChip({
+              activeChipIndex,
+              disabled: true,
+              index: disabledIndex++,
+              item,
+              messages,
+              readOnly,
+              scale,
+              isAncestors,
+            }),
+          );
           return;
         }
 
-        if (!hideSelectedChipsForSelectAll) {
-          if (item.selected && (!isAncestors || !hasActiveChildren(item))) {
-            chips.push(
-              this.renderChip({
-                activeChipIndex,
-                disabled: false,
-                index: selectedIndex++,
-                item,
-                messages,
-                readOnly,
-                scale,
-                isAncestors,
-              }),
-            );
-          }
-        }
+        chips.push(
+          this.renderChip({
+            activeChipIndex,
+            disabled: false,
+            index: selectedIndex++,
+            item,
+            messages,
+            readOnly,
+            scale,
+            isAncestors,
+          }),
+        );
       });
     } else if (!hideSelectedChipsForSelectAll) {
       this.selectedItems.forEach((item) => {

--- a/packages/components/src/components/combobox/combobox.tsx
+++ b/packages/components/src/components/combobox/combobox.tsx
@@ -894,8 +894,6 @@ export class Combobox extends LitElement implements LabelableComponent, Floating
     );
     this.updateActiveItemIndex(newIndex);
     this.toggleSelection(target, target.selected);
-
-    this.updateSelectedItems();
   }
 
   private calciteInternalComboboxItemChangeHandler(

--- a/packages/components/src/components/combobox/combobox.tsx
+++ b/packages/components/src/components/combobox/combobox.tsx
@@ -62,6 +62,8 @@ import {
   getLabel,
   hasActiveChildren,
   isSingleLike,
+  orderByPrevious,
+  orderValuesByPrevious,
 } from "./utils";
 import { styles } from "./combobox.scss";
 
@@ -69,77 +71,6 @@ declare global {
   interface DeclareElements {
     "calcite-combobox": Combobox;
   }
-}
-
-function orderByPrevious<T>(items: T[], previousItems: T[]): T[] {
-  if (items.length < 2 || previousItems.length === 0) {
-    return items;
-  }
-
-  const previousItemOrder = new Map(previousItems.map((item, index) => [item, index]));
-
-  return [...items].sort((a, b) => {
-    const aOrder = previousItemOrder.get(a);
-    const bOrder = previousItemOrder.get(b);
-
-    if (aOrder !== undefined && bOrder !== undefined) {
-      return aOrder - bOrder;
-    }
-
-    if (aOrder !== undefined) {
-      return -1;
-    }
-
-    if (bOrder !== undefined) {
-      return 1;
-    }
-
-    return 0;
-  });
-}
-
-function consumeValue(counts: Map<string, number>, value: string): boolean {
-  const count = counts.get(value) ?? 0;
-
-  if (count === 0) {
-    return false;
-  }
-
-  if (count === 1) {
-    counts.delete(value);
-  } else {
-    counts.set(value, count - 1);
-  }
-
-  return true;
-}
-
-function orderValuesByPrevious(selectedValues: string[], previousValues: string[]): string[] {
-  if (selectedValues.length < 2 || previousValues.length === 0) {
-    return selectedValues;
-  }
-
-  const selectedValueCounts = new Map<string, number>();
-
-  selectedValues.forEach((value) => {
-    selectedValueCounts.set(value, (selectedValueCounts.get(value) ?? 0) + 1);
-  });
-
-  const orderedSelectedValues = previousValues.filter((value) =>
-    consumeValue(selectedValueCounts, value),
-  );
-
-  if (orderedSelectedValues.length === 0) {
-    return selectedValues;
-  }
-
-  selectedValues.forEach((value) => {
-    if (consumeValue(selectedValueCounts, value)) {
-      orderedSelectedValues.push(value);
-    }
-  });
-
-  return orderedSelectedValues;
 }
 
 /**

--- a/packages/components/src/components/combobox/utils.ts
+++ b/packages/components/src/components/combobox/utils.ts
@@ -60,3 +60,72 @@ export function isSingleLike(selectionMode: Combobox["selectionMode"]): boolean 
 export function getLabel(item: ComboboxItem["el"]): string {
   return item.shortHeading || item.heading;
 }
+
+export function orderByPrevious<T>(items: T[], previousItems: T[]): T[] {
+  if (items.length < 2 || previousItems.length === 0) {
+    return items;
+  }
+
+  const previousItemOrder = new Map(previousItems.map((item, index) => [item, index]));
+
+  return [...items].sort((a, b) => {
+    const aOrder = previousItemOrder.get(a);
+    const bOrder = previousItemOrder.get(b);
+
+    if (aOrder !== undefined && bOrder !== undefined) {
+      return aOrder - bOrder;
+    }
+
+    if (aOrder !== undefined) {
+      return -1;
+    }
+
+    if (bOrder !== undefined) {
+      return 1;
+    }
+
+    return 0;
+  });
+}
+
+function consumeValue(counts: Map<string, number>, value: string): boolean {
+  const count = counts.get(value) ?? 0;
+
+  if (count === 0) {
+    return false;
+  }
+
+  if (count === 1) {
+    counts.delete(value);
+  } else {
+    counts.set(value, count - 1);
+  }
+
+  return true;
+}
+
+export function orderValuesByPrevious(selectedValues: string[], previousValues: string[]): string[] {
+  if (selectedValues.length < 2 || previousValues.length === 0) {
+    return selectedValues;
+  }
+
+  const selectedValueCounts = new Map<string, number>();
+
+  selectedValues.forEach((value) => {
+    selectedValueCounts.set(value, (selectedValueCounts.get(value) ?? 0) + 1);
+  });
+
+  const orderedSelectedValues = previousValues.filter((value) => consumeValue(selectedValueCounts, value));
+
+  if (orderedSelectedValues.length === 0) {
+    return selectedValues;
+  }
+
+  selectedValues.forEach((value) => {
+    if (consumeValue(selectedValueCounts, value)) {
+      orderedSelectedValues.push(value);
+    }
+  });
+
+  return orderedSelectedValues;
+}


### PR DESCRIPTION
**Related Issue:** #14290

## Summary

This updates `combobox` to separate DOM from value ordering.
