### PR TITLE
fix(list): preserve filter input value during rapid item loading

### DIFF
--- a/packages/components/src/components/list/list.browser.e2e.tsx
+++ b/packages/components/src/components/list/list.browser.e2e.tsx
@@ -486,6 +486,41 @@ describe("group filtering", () => {
     expect(rerenderedFilterEl.value).toBe(typedValue);
     expect(el.filterText).toBe("");
   });
+
+  it("preserves filter input text while items are loading before debounced filterText updates", async () => {
+    const typedValue = "Bui";
+    const { el } = await mount<List>(
+      <calcite-list filter-enabled>
+        <calcite-list-item label="Buildings" value="buildings" />
+      </calcite-list>,
+    );
+
+    await el.setFocus();
+    await userEvent.keyboard(typedValue);
+
+    expect(el.filterText).toBe("");
+
+    for (let i = 0; i < 20; i++) {
+      const item = document.createElement("calcite-list-item");
+      item.label = `Loading item ${i}`;
+      item.value = `loading-item-${i}`;
+      el.append(item);
+
+      vi.advanceTimersByTime(DEBOUNCE.nextTick + 1);
+
+      const filterEl = page
+        .getBySelector("calcite-list calcite-filter")
+        .element() as HTMLElement & {
+        value: string;
+      };
+
+      expect(filterEl.value).toBe(typedValue);
+      expect(el.filterText).toBe("");
+    }
+
+    vi.advanceTimersByTime(DEBOUNCE.filter + 1);
+    expect(el.filterText).toBe(typedValue);
+  });
 });
 
 describe("filter item data updates", () => {

--- a/packages/components/src/components/list/list.tsx
+++ b/packages/components/src/components/list/list.tsx
@@ -902,7 +902,9 @@ export class List extends LitElement {
   }
 
   private async filterAndUpdateData(): Promise<void> {
-    await this.filterEl?.filter(this.filterText);
+    // Keep in-progress user input as source-of-truth during rapid item updates.
+    const filterValue = this.filterEl?.value ?? this.filterText;
+    await this.filterEl?.filter(filterValue);
     this.updateFilteredData();
   }
 


### PR DESCRIPTION
**Related Issue:** #14454

## Summary
This PR fixes a race condition where the list filter input could lose in-progress user text while list items were rapidly loading and rerendering.

## Changes
- Use the live filter component value during list filter refreshes to avoid overwriting active typing with stale debounced state.
- Keep existing filter behavior intact once debounce completes.

## Why this matters
Users can continue typing in the filter field without seeing their input reset during heavy or incremental list loading.