### PR TITLE
ci(actions): move refactor sync location to main Monday board

### DIFF
--- a/.github/actions/monday/action.yml
+++ b/.github/actions/monday/action.yml
@@ -132,9 +132,6 @@ runs:
       with:
         script: |
           core.startGroup("Sync Action Changes");
-          let action = require('${{ github.action_path }}/../../scripts/monday/syncActionChanges.js')
-          if (github.event.inputs.refactor_pr == 'true') {
-            action = require('${{ github.action_path }}/../../scripts/monday/createRefactorTask.js')
-          }
+          const action = require('${{ github.action_path }}/../../scripts/monday/syncActionChanges.js')
           await action({github, context, core})
           core.endGroup();

--- a/.github/actions/monday/action.yml
+++ b/.github/actions/monday/action.yml
@@ -132,6 +132,9 @@ runs:
       with:
         script: |
           core.startGroup("Sync Action Changes");
-          const action = require('${{ github.action_path }}/../../scripts/monday/syncActionChanges.js')
+          let action = require('${{ github.action_path }}/../../scripts/monday/syncActionChanges.js')
+          if (github.event.inputs.refactor_pr == 'true') {
+            action = require('${{ github.action_path }}/../../scripts/monday/createRefactorTask.js')
+          }
           await action({github, context, core})
           core.endGroup();

--- a/.github/scripts/monday/syncActionChanges.js
+++ b/.github/scripts/monday/syncActionChanges.js
@@ -45,8 +45,7 @@ module.exports = async ({ github, context, core }) => {
   const monday = Monday(issue, core, createBodyUpdater({ github, context, core }));
 
   if (refactor_pr === "true" && issue.pull_request?.merged_at) {
-    monday.createTask();
-    await monday.commit();
+    await monday.createTask();
     return;
   }
 

--- a/.github/scripts/monday/syncActionChanges.js
+++ b/.github/scripts/monday/syncActionChanges.js
@@ -12,6 +12,7 @@ const { assertRequired, createBodyUpdater } = require("../support/utils");
  * @property {string} [label_name] - The label name added or removed from the issue.
  * @property {string} [label_color] - The hex code color (without '#' prefix) associated with the label.
  * @property {"added" | "removed"} [label_action] - The action taken on the label.
+ * @property {"true" | "false"} [refactor_pr] - Indicates if the item to sync is a refactor PR instead of an issue.
  */
 
 /**
@@ -32,6 +33,7 @@ module.exports = async ({ github, context, core }) => {
     label_name,
     label_color,
     label_action,
+    refactor_pr,
   } = context.payload.inputs;
 
   const [issue_number] = assertRequired([issue_number_input], core, "Required issue number not provided.");
@@ -41,6 +43,12 @@ module.exports = async ({ github, context, core }) => {
   });
 
   const monday = Monday(issue, core, createBodyUpdater({ github, context, core }));
+
+  if (refactor_pr === "true" && issue.pull_request?.merged_at) {
+    monday.createTask();
+    await monday.commit();
+    return;
+  }
 
   if (milestone_updated === "true") {
     monday.handleMilestone();

--- a/.github/scripts/monday/syncActionChanges.js
+++ b/.github/scripts/monday/syncActionChanges.js
@@ -37,32 +37,18 @@ module.exports = async ({ github, context, core }) => {
   } = context.payload.inputs;
 
   const [issue_number] = assertRequired([issue_number_input], core, "Required issue number not provided.");
-
-  core.warning(`refactor_pr arg: ${refactor_pr}`);
-
-  if (refactor_pr === "true") {
-    const { data: pr } = await github.rest.pulls.get({
-      ...context.repo,
-      pull_number: issue_number,
-    });
-
-    if (!pr.merged) {
-      core.info(`PR #${issue_number} is not merged. Skipping Monday.com sync.`);
-      return;
-    }
-
-    const monday = Monday(pr, core, createBodyUpdater({ github, context, core }));
-    monday.createTask();
-    await monday.commit();
-    return;
-  }
-
   const { data: issue } = await github.rest.issues.get({
     ...context.repo,
     issue_number,
   });
 
   const monday = Monday(issue, core, createBodyUpdater({ github, context, core }));
+
+  if (refactor_pr === "true" && issue.pull_request?.merged_at) {
+    monday.createTask();
+    await monday.commit();
+    return;
+  }
 
   if (milestone_updated === "true") {
     monday.handleMilestone();

--- a/.github/scripts/monday/syncActionChanges.js
+++ b/.github/scripts/monday/syncActionChanges.js
@@ -38,6 +38,8 @@ module.exports = async ({ github, context, core }) => {
 
   const [issue_number] = assertRequired([issue_number_input], core, "Required issue number not provided.");
 
+  core.warning(`refactor_pr arg: ${refactor_pr}`);
+
   if (refactor_pr === "true") {
     const { data: pr } = await github.rest.pulls.get({
       ...context.repo,

--- a/.github/scripts/monday/syncActionChanges.js
+++ b/.github/scripts/monday/syncActionChanges.js
@@ -37,18 +37,30 @@ module.exports = async ({ github, context, core }) => {
   } = context.payload.inputs;
 
   const [issue_number] = assertRequired([issue_number_input], core, "Required issue number not provided.");
+
+  if (refactor_pr === "true") {
+    const { data: pr } = await github.rest.pulls.get({
+      ...context.repo,
+      pull_number: issue_number,
+    });
+
+    if (!pr.merged) {
+      core.info(`PR #${issue_number} is not merged. Skipping Monday.com sync.`);
+      return;
+    }
+
+    const monday = Monday(pr, core, createBodyUpdater({ github, context, core }));
+    monday.createTask();
+    await monday.commit();
+    return;
+  }
+
   const { data: issue } = await github.rest.issues.get({
     ...context.repo,
     issue_number,
   });
 
   const monday = Monday(issue, core, createBodyUpdater({ github, context, core }));
-
-  if (refactor_pr === "true" && issue.pull_request?.merged_at) {
-    monday.createTask();
-    await monday.commit();
-    return;
-  }
 
   if (milestone_updated === "true") {
     monday.handleMilestone();

--- a/.github/scripts/support/monday.js
+++ b/.github/scripts/support/monday.js
@@ -473,6 +473,13 @@ module.exports = function Monday(issue, core, updateIssueBody) {
         clearable: true,
       },
     ],
+    [
+      issueType.pull_request,
+      {
+        column: mondayColumns.typeDropdown,
+        value: "PR",
+      },
+    ],
   ]);
 
   /**
@@ -872,8 +879,9 @@ module.exports = function Monday(issue, core, updateIssueBody) {
       handleMilestone();
     }
 
-    if ("merged" in issue) {
+    if ("merged" in issue || issue.pull_request?.merged_at) {
       handleState("closed");
+      addLabel(issueType.pull_request);
     }
 
     const { id: syncId, source } = await getId();

--- a/.github/scripts/support/resources.js
+++ b/.github/scripts/support/resources.js
@@ -17,6 +17,7 @@ const resources = {
       i18nL10n: "i18n-l10n",
       newComponent: "new component",
       perf: "perf",
+      pull_request: "pr",
       refactor: "refactor",
       research: "research",
       test: "testing",

--- a/.github/scripts/support/resources.js
+++ b/.github/scripts/support/resources.js
@@ -17,6 +17,7 @@ const resources = {
       i18nL10n: "i18n-l10n",
       newComponent: "new component",
       perf: "perf",
+      // "pr" is not a GitHub label, rather a keyword to sync the `PR` issue type to Monday.com
       pull_request: "pr",
       refactor: "refactor",
       research: "research",

--- a/.github/scripts/support/resources.js
+++ b/.github/scripts/support/resources.js
@@ -17,7 +17,7 @@ const resources = {
       i18nL10n: "i18n-l10n",
       newComponent: "new component",
       perf: "perf",
-      // "pr" is not a GitHub label, rather a keyword to sync the `PR` issue type to Monday.com
+      // "pr" is not a GitHub label, rather a keyword used to sync the `PR` issue type to Monday.com
       pull_request: "pr",
       refactor: "refactor",
       research: "research",

--- a/.github/workflows/issue-monday-sync.yml
+++ b/.github/workflows/issue-monday-sync.yml
@@ -51,6 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
+      pull-requests: write
       contents: read
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/issue-monday-sync.yml
+++ b/.github/workflows/issue-monday-sync.yml
@@ -42,6 +42,10 @@ on:
         options:
           - added
           - removed
+      refactor_pr:
+        type: boolean
+        description: "Indicates if the item to sync is a refactor PR instead of an issue."
+        required: false
 jobs:
   sync-issue:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-merged.yml
+++ b/.github/workflows/pr-merged.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/github-script@v9
         env:
           MONDAY_KEY: ${{ secrets.MONDAY_KEY }}
-          MONDAY_BOARD: ${{ secrets.MONDAY_BOARD_REFACTOR }}
+          MONDAY_BOARD: ${{ secrets.MONDAY_BOARD }}
           GITHUB_REPO: ${{ github.event.repository.name }}
         with:
           script: |


### PR DESCRIPTION
**Related Issue:** #14159

## Summary

Moves the sync location for unrelated `refactor` PRs to the normal Monday.com board instead of its own one. To support filtering by the PRs, adds a special `pr` label (that does not exist as a GH label) that syncs to the `Issue Type` column in Monday.

Additionally, sets up the SyncActionChanges script to handle dispatching syncs for Refactor PRs. This will allow me to sync past refator PRs programmatically.
