### PR TITLE
refactor(focus-trap): add setFocus method

### DIFF
--- a/packages/components/src/components/focus-trap/focus-trap.browser.e2e.tsx
+++ b/packages/components/src/components/focus-trap/focus-trap.browser.e2e.tsx
@@ -187,6 +187,24 @@ describe("focus trap behavior", () => {
 });
 
 describe("public methods", () => {
+  it("supports setFocus", async () => {
+    const { el } = await mount<FocusTrap>(
+      <calcite-focus-trap>
+        <button id="inside-one" type="button">
+          inside one
+        </button>
+        <button id="inside-two" type="button">
+          inside two
+        </button>
+      </calcite-focus-trap>,
+    );
+
+    const insideOne = el.querySelector("#inside-one") as HTMLButtonElement | null;
+
+    await expect(el.setFocus()).resolves.toBeUndefined();
+    expect(document.activeElement).toBe(insideOne);
+  });
+
   it("supports focus-trap container updates", async () => {
     const { el } = await mount<FocusTrap>(
       <calcite-focus-trap>

--- a/packages/components/src/components/focus-trap/focus-trap.browser.e2e.tsx
+++ b/packages/components/src/components/focus-trap/focus-trap.browser.e2e.tsx
@@ -60,7 +60,7 @@ describe("renders", () => {
 
 describe("focus trap behavior", () => {
   it("cycles focus within slotted content when enabled", async () => {
-    const { el } = await mount<FocusTrap>(
+    const { el, container } = await mount<FocusTrap>(
       <>
         <calcite-focus-trap>
           <button id="inside-one" type="button">
@@ -80,20 +80,20 @@ describe("focus trap behavior", () => {
     expect(el.active).toBe(true);
     await afterNextTask();
 
-    const insideOne = el.querySelector("#inside-one") as HTMLButtonElement | null;
-    const insideTwo = el.querySelector("#inside-two") as HTMLButtonElement | null;
+    const insideOne = container.querySelector<HTMLButtonElement>("#inside-one")!;
+    const insideTwo = container.querySelector<HTMLButtonElement>("#inside-two")!;
 
-    expect(document.activeElement).toBe(insideOne);
-
-    await userEvent.tab();
-    expect(document.activeElement).toBe(insideTwo);
+    await expect.element(insideOne).toHaveFocus();
 
     await userEvent.tab();
-    expect(document.activeElement).toBe(insideOne);
+    await expect.element(insideTwo).toHaveFocus();
+
+    await userEvent.tab();
+    await expect.element(insideOne).toHaveFocus();
   });
 
   it("allows focus to leave when disabled", async () => {
-    const { el, component } = await mount<FocusTrap>(
+    const { el, component, container } = await mount<FocusTrap>(
       <>
         <calcite-focus-trap>
           <button id="inside-one" type="button">
@@ -114,19 +114,19 @@ describe("focus trap behavior", () => {
     await component.updateComplete;
     expect(el.active).toBe(false);
 
-    const insideOne = el.querySelector("#inside-one") as HTMLButtonElement;
-    const outside = el.parentElement?.querySelector("#outside") as HTMLButtonElement;
+    const insideOne = container.querySelector<HTMLButtonElement>("#inside-one")!;
+    const outside = container.querySelector<HTMLButtonElement>("#outside")!;
 
     insideOne.focus();
 
     await userEvent.tab();
     await userEvent.tab();
 
-    expect(document.activeElement).toBe(outside);
+    await expect.element(outside).toHaveFocus();
   });
 
   it("allows focus to leave when focusTrapDisabledOverride returns true", async () => {
-    const { el, component } = await mount<FocusTrap>(
+    const { el, component, container } = await mount<FocusTrap>(
       <>
         <calcite-focus-trap>
           <button id="inside-one" type="button">
@@ -147,19 +147,19 @@ describe("focus trap behavior", () => {
     await component.updateComplete;
     expect(el.active).toBe(false);
 
-    const insideOne = el.querySelector("#inside-one") as HTMLButtonElement;
-    const outside = el.parentElement?.querySelector("#outside") as HTMLButtonElement | null;
+    const insideOne = container.querySelector<HTMLButtonElement>("#inside-one")!;
+    const outside = container.querySelector<HTMLButtonElement>("#outside")!;
 
     insideOne.focus();
 
     await userEvent.tab();
     await userEvent.tab();
 
-    expect(document.activeElement).toBe(outside);
+    await expect.element(outside).toHaveFocus();
   });
 
   it("honors focusTrapOptions.initialFocus=false", async () => {
-    const { el } = await mount<FocusTrap>(
+    const { el, container } = await mount<FocusTrap>(
       <>
         <calcite-focus-trap>
           <button id="inside-one" type="button">
@@ -175,14 +175,14 @@ describe("focus trap behavior", () => {
       </>,
     );
 
-    const outside = el.parentElement?.querySelector("#outside") as HTMLButtonElement;
+    const outside = container.querySelector<HTMLButtonElement>("#outside")!;
 
     outside.focus();
     el.focusTrapOptions = { initialFocus: false };
     await el.activate();
     expect(el.active).toBe(true);
 
-    expect(document.activeElement).toBe(outside);
+    await expect.element(outside).toHaveFocus();
   });
 });
 
@@ -202,7 +202,7 @@ describe("public methods", () => {
     const insideOne = page.getByText("inside one", { exact: true });
 
     await expect(component.setFocus()).resolves.toBeUndefined();
-    expect(document.activeElement).toBe(insideOne.element());
+    await expect.element(insideOne).toHaveFocus();
   });
 
   it("supports focus-trap container updates", async () => {
@@ -227,7 +227,7 @@ describe("public methods", () => {
 
 describe("events", () => {
   it("emits deactivated state when deactivated by outside click", async () => {
-    const { el, component } = await mount<FocusTrap>(
+    const { el, component, container } = await mount<FocusTrap>(
       <>
         <calcite-focus-trap>
           <button id="inside-one" type="button">
@@ -243,7 +243,7 @@ describe("events", () => {
       </>,
     );
 
-    const outside = el.parentElement?.querySelector("#outside") as HTMLButtonElement;
+    const outside = container.querySelector<HTMLButtonElement>("#outside")!;
 
     const changeHandler = vi.fn();
     const activeStates: boolean[] = [];
@@ -287,7 +287,7 @@ describe("events", () => {
   });
 
   it("emits calciteFocusTrapActiveChange when internally deactivated", async () => {
-    const { el, component } = await mount<FocusTrap>(
+    const { el, component, container } = await mount<FocusTrap>(
       <>
         <calcite-focus-trap>
           <button id="inside-one" type="button">
@@ -304,7 +304,7 @@ describe("events", () => {
     );
     const changeHandler = vi.fn();
     const activeStates: boolean[] = [];
-    const outside = el.parentElement?.querySelector("#outside") as HTMLButtonElement;
+    const outside = container.querySelector<HTMLButtonElement>("#outside")!;
 
     el.addEventListener("calciteFocusTrapActiveChange", changeHandler);
     el.addEventListener("calciteFocusTrapActiveChange", () => {

--- a/packages/components/src/components/focus-trap/focus-trap.browser.e2e.tsx
+++ b/packages/components/src/components/focus-trap/focus-trap.browser.e2e.tsx
@@ -1,7 +1,7 @@
 import { h, Fragment } from "@arcgis/lumina";
 import { describe, expect, it, vi } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { userEvent } from "vitest/browser";
+import { page, userEvent } from "vitest/browser";
 import { defaults, hidden, reflects, renders } from "../../tests/commonTests/browser";
 import { afterNextTask } from "../../tests/utils/timing";
 import type { FocusTrap } from "./focus-trap";
@@ -114,8 +114,8 @@ describe("focus trap behavior", () => {
     await component.updateComplete;
     expect(el.active).toBe(false);
 
-    const insideOne = el.querySelector("#inside-one") as HTMLButtonElement | null;
-    const outside = el.parentElement?.querySelector("#outside") as HTMLButtonElement | null;
+    const insideOne = el.querySelector("#inside-one") as HTMLButtonElement;
+    const outside = el.parentElement?.querySelector("#outside") as HTMLButtonElement;
 
     insideOne.focus();
 
@@ -147,7 +147,7 @@ describe("focus trap behavior", () => {
     await component.updateComplete;
     expect(el.active).toBe(false);
 
-    const insideOne = el.querySelector("#inside-one") as HTMLButtonElement | null;
+    const insideOne = el.querySelector("#inside-one") as HTMLButtonElement;
     const outside = el.parentElement?.querySelector("#outside") as HTMLButtonElement | null;
 
     insideOne.focus();
@@ -175,7 +175,7 @@ describe("focus trap behavior", () => {
       </>,
     );
 
-    const outside = el.parentElement?.querySelector("#outside") as HTMLButtonElement | null;
+    const outside = el.parentElement?.querySelector("#outside") as HTMLButtonElement;
 
     outside.focus();
     el.focusTrapOptions = { initialFocus: false };
@@ -188,7 +188,7 @@ describe("focus trap behavior", () => {
 
 describe("public methods", () => {
   it("supports setFocus", async () => {
-    const { el } = await mount<FocusTrap>(
+    const { component } = await mount<FocusTrap>(
       <calcite-focus-trap>
         <button id="inside-one" type="button">
           inside one
@@ -199,10 +199,10 @@ describe("public methods", () => {
       </calcite-focus-trap>,
     );
 
-    const insideOne = el.querySelector("#inside-one") as HTMLButtonElement | null;
+    const insideOne = page.getByText("inside one", { exact: true });
 
-    await expect(el.setFocus()).resolves.toBeUndefined();
-    expect(document.activeElement).toBe(insideOne);
+    await expect(component.setFocus()).resolves.toBeUndefined();
+    expect(document.activeElement).toBe(insideOne.element());
   });
 
   it("supports focus-trap container updates", async () => {
@@ -243,7 +243,7 @@ describe("events", () => {
       </>,
     );
 
-    const outside = el.parentElement?.querySelector("#outside") as HTMLButtonElement | null;
+    const outside = el.parentElement?.querySelector("#outside") as HTMLButtonElement;
 
     const changeHandler = vi.fn();
     const activeStates: boolean[] = [];
@@ -304,7 +304,7 @@ describe("events", () => {
     );
     const changeHandler = vi.fn();
     const activeStates: boolean[] = [];
-    const outside = el.parentElement?.querySelector("#outside") as HTMLButtonElement | null;
+    const outside = el.parentElement?.querySelector("#outside") as HTMLButtonElement;
 
     el.addEventListener("calciteFocusTrapActiveChange", changeHandler);
     el.addEventListener("calciteFocusTrapActiveChange", () => {

--- a/packages/components/src/components/focus-trap/focus-trap.tsx
+++ b/packages/components/src/components/focus-trap/focus-trap.tsx
@@ -78,11 +78,11 @@ export class FocusTrap extends LitElement {
   }
 
   /**
-   Sets focus on the component's first focusable element.
+   * Sets focus on the component's first focusable element.
    *
    * @param options - When specified an optional object customizes the component's focusing process. When `preventScroll` is `true`, scrolling will not occur on the component.
-   
-   *@see [MDN - focus(options)](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus#options)
+   *
+   * @see [MDN - focus(options)](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus#options)
    */
   @method()
   async setFocus(options?: FocusOptions): Promise<void> {

--- a/packages/components/src/components/focus-trap/focus-trap.tsx
+++ b/packages/components/src/components/focus-trap/focus-trap.tsx
@@ -1,5 +1,6 @@
 import { createEvent, h, JsxNode, LitElement, method, property } from "@arcgis/lumina";
 import { FocusTrapOptions, useFocusTrap } from "../../controllers/useFocusTrap";
+import { useSetFocus } from "../../controllers/useSetFocus";
 import { styles } from "./focus-trap.scss";
 
 declare global {
@@ -19,6 +20,8 @@ export class FocusTrap extends LitElement {
   //#region Private Properties
 
   private _active = false;
+
+  private focusSetter = useSetFocus<this>()(this);
 
   private focusTrapController = useFocusTrap<this>({
     focusTrapOptions: {
@@ -72,6 +75,18 @@ export class FocusTrap extends LitElement {
   @method()
   async deactivate(): Promise<void> {
     this.focusTrapController.deactivate();
+  }
+
+  /**
+   Sets focus on the component's first focusable element.
+   *
+   * @param options - When specified an optional object customizes the component's focusing process. When `preventScroll` is `true`, scrolling will not occur on the component.
+   
+   *@see [MDN - focus(options)](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus#options)
+   */
+  @method()
+  async setFocus(options?: FocusOptions): Promise<void> {
+    return this.focusSetter(() => this.el, options);
   }
 
   /**


### PR DESCRIPTION
**monday.com sync:** #12164179825

**Related Issue:** https://github.com/Esri/calcite-design-system/issues/14545

## Summary

This PR adds a public `setFocus()` method to `calcite-focus-trap`. The method uses the shared focus utility to move focus to the first focusable element inside the trap and accepts standard `FocusOptions`.