### PR TITLE
fix(input): fix file selection validation for `input[type=file]`

### DIFF
--- a/packages/components/src/components/input/input.tsx
+++ b/packages/components/src/components/input/input.tsx
@@ -3,6 +3,7 @@ import { PropertyValues } from "lit";
 import { createRef } from "lit/directives/ref.js";
 import {
   createEvent,
+  h,
   JsxNode,
   LitElement,
   LuminaJsx,

--- a/packages/components/src/components/input/input.tsx
+++ b/packages/components/src/components/input/input.tsx
@@ -94,7 +94,7 @@ export class Input
 
   formSupport = useForm<this>({
     inputType: "text",
-    getValue: () => (this.type === "file" ? this.childRef.value?.files ?? this.files ?? null : this.value),
+    getValue: () => (this.type === "file" ? (this.childRef.value?.files ?? null) : this.value),
   })(this);
 
   private inlineEditableEl: InlineEditable["el"];

--- a/packages/components/src/components/input/input.tsx
+++ b/packages/components/src/components/input/input.tsx
@@ -93,7 +93,7 @@ export class Input
 
   formSupport = useForm<this>({
     inputType: "text",
-    getValue: () => (this.type === "file" ? this.files || this.value : this.value),
+    getValue: () => (this.type === "file" ? this.childRef.value?.files ?? this.files ?? null : this.value),
   })(this);
 
   private inlineEditableEl: InlineEditable["el"];

--- a/packages/components/src/components/input/input.tsx
+++ b/packages/components/src/components/input/input.tsx
@@ -2,14 +2,13 @@
 import { PropertyValues } from "lit";
 import { createRef } from "lit/directives/ref.js";
 import {
-  LitElement,
-  property,
   createEvent,
-  h,
-  method,
-  state,
   JsxNode,
+  LitElement,
   LuminaJsx,
+  method,
+  property,
+  state,
   stringOrBoolean,
 } from "@arcgis/lumina";
 import { useDirection, useWatchAttributes } from "@arcgis/lumina/controllers";
@@ -41,12 +40,12 @@ import T9nStrings from "./assets/t9n/messages.en.json";
 import { InputPlacement, NumberNudgeDirection, SetValueOrigin } from "./interfaces";
 import {
   CSS,
+  DIRECTION,
+  ICONS,
   IDS,
   INPUT_TYPE_ICONS,
-  SLOTS,
-  ICONS,
-  DIRECTION,
   NUDGE_DELAY_IN_MS,
+  SLOTS,
 } from "./resources";
 import { NumericInputComponent, TextualInputComponent } from "./common/input";
 import { styles } from "./input.scss";
@@ -94,6 +93,7 @@ export class Input
 
   formSupport = useForm<this>({
     inputType: "text",
+    getValue: () => (this.type === "file" ? this.files || this.value : this.value),
   })(this);
 
   private inlineEditableEl: InlineEditable["el"];

--- a/packages/components/src/controllers/useForm.browser.spec.tsx
+++ b/packages/components/src/controllers/useForm.browser.spec.tsx
@@ -1,9 +1,11 @@
 import { afterEach, beforeEach, describe, it, expect } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { LitElement, method, property } from "@arcgis/lumina";
+import { h, JsxNode, LitElement, method, property } from "@arcgis/lumina";
 import { useForm } from "./useForm";
 import { defaultValidity } from "../tests/commonTests/browser/defaults";
-import { html } from "lit";
+import { html, PropertyValues } from "lit";
+import { createRef } from "lit/directives/ref.js";
+import { page, userEvent } from "vitest/browser";
 
 describe("useForm", () => {
   class TestComponent extends LitElement {
@@ -70,6 +72,146 @@ describe("useForm", () => {
       });
 
       expect(el.validity).toMatchObject(defaultValidity);
+    });
+  });
+
+  it("allows mapping value when the component's value is different than the form submit value", async () => {
+    class MappedValueFormComponent extends LitElement {
+      static formAssociated = true;
+
+      @property({ type: Boolean })
+      disabled = false;
+
+      @property()
+      value = "";
+
+      @property()
+      name?: string;
+
+      @property()
+      form?: string;
+
+      @property({ type: Boolean })
+      required: boolean = false;
+
+      @property()
+      validity!: ValidityState;
+
+      defaultValue?: TestComponent["value"];
+
+      @method()
+      async setFocus(): Promise<void> {}
+
+      formSupport = useForm<this>({
+        inputType: "text",
+        getValue: () => `mapped-${this.value}`,
+      })(this);
+    }
+
+    await mount(
+      html`<mapped-value-form-component
+        name="mapped-value"
+        value="test"
+      ></mapped-value-form-component>`,
+      {
+        dynamicComponents: [MappedValueFormComponent],
+        parent: form,
+      },
+    );
+
+    const formData = new FormData(form);
+    expect(formData.get("mapped-value")).toBe("mapped-test");
+  });
+
+  describe("input types", () => {
+    class FileTypeFormComponent extends LitElement {
+      static formAssociated = true;
+
+      inputRef = createRef<HTMLInputElement>();
+
+      @property({ type: Boolean })
+      disabled = false;
+
+      @property()
+      value = "";
+
+      @property()
+      name?: string;
+
+      @property()
+      form?: string;
+
+      @property({ type: Boolean })
+      required: boolean = false;
+
+      @property()
+      type!: HTMLInputElement["type"];
+
+      @property()
+      validity!: ValidityState;
+
+      defaultValue?: TestComponent["value"];
+
+      formSupport = useForm<this>({
+        inputType: "text",
+        getValue: () =>
+          this.type === "file" ? this.inputRef.value?.files || this.value : this.value,
+      })(this);
+
+      @method()
+      async setFocus(): Promise<void> {}
+
+      private handleChange(event: Event): void {
+        this.value = (event.target as HTMLInputElement).value;
+      }
+
+      protected willUpdate(changes: PropertyValues) {
+        if (changes.has("type")) {
+          this.formSupport.overrideInputType(this.type);
+        }
+      }
+
+      protected render(): JsxNode {
+        return (
+          <input
+            data-testid="internal-input"
+            onChange={this.handleChange}
+            ref={this.inputRef}
+            type={this.type}
+          />
+        );
+      }
+    }
+
+    it("supports file type", async () => {
+      const { el, reRender } = await mount(
+        html`<file-type-form-component name="file-type" type="file"></file-type-form-component>`,
+        {
+          dynamicComponents: [FileTypeFormComponent],
+          parent: form,
+        },
+      );
+
+      expect(el.validity.valid).toBe(true);
+
+      el.required = true;
+      await reRender();
+
+      expect(el.validity.valid).toBe(false);
+
+      const input = page.getByTestId("internal-input");
+      const file = new File(["file"], "fake-file.png", { type: "image/png" });
+      await userEvent.upload(input, file);
+      await reRender();
+
+      expect(el.validity.valid).toBe(true);
+
+      const formData = new FormData(form);
+
+      const submittedFile = formData.get("file-type");
+
+      expect(submittedFile).toBeInstanceOf(File);
+      expect((submittedFile as File).name).toBe(file.name);
     });
   });
 });

--- a/packages/components/src/controllers/useForm.ts
+++ b/packages/components/src/controllers/useForm.ts
@@ -257,7 +257,7 @@ export interface UseFormOptions {
   /**
    * A function that returns the value to be submitted for this component. If not provided, the controller will attempt to determine the value based on the component's `value` property and, if applicable, `checked` property.
    *
-   * Note: this is mostly intended for components that need to map their value differently
+   * Note: this is mostly intended for components that need to map their value differently (e.g., file type input passing its `files` property instead of `value`)
    */
   getValue?: () => any;
 
@@ -437,9 +437,11 @@ export const useForm = <T extends FormComponent>(
     function getFormValue(): any {
       const value = getComponentValue();
 
-      if (Array.isArray(value)) {
+      if (Array.isArray(value) || value instanceof FileList) {
         const formData = new FormData();
-        value.forEach((value) => formData.append(component.name!, value));
+        for (const item of value) {
+          formData.append(component.name!, item);
+        }
         return formData;
       }
 

--- a/packages/components/src/controllers/useForm/validation.ts
+++ b/packages/components/src/controllers/useForm/validation.ts
@@ -98,9 +98,19 @@ export function validate({
 }
 
 function validateValue(inputDelegate: HTMLInputElement, valueToValidate: any): boolean {
-  inputDelegate.value =
+  if (inputDelegate.type === "file") {
     // file will throw if non-empty string is provided
-    inputDelegate.type === "file" || valueToValidate == null ? "" : String(valueToValidate);
+    inputDelegate.value = "";
+
+    if (inputDelegate.required && valueToValidate instanceof FileList && valueToValidate.length === 0) {
+      // we override the delegate's validation as its value and files prop cannot be directly set for validation
+      return false;
+    }
+
+    return true;
+  }
+
+  inputDelegate.value = valueToValidate == null ? "" : String(valueToValidate);
 
   return inputDelegate.validity.valid;
 }

--- a/packages/components/src/controllers/useForm/validation.ts
+++ b/packages/components/src/controllers/useForm/validation.ts
@@ -102,12 +102,9 @@ function validateValue(inputDelegate: HTMLInputElement, valueToValidate: any): b
     // file will throw if non-empty string is provided
     inputDelegate.value = "";
 
-    if (inputDelegate.required && valueToValidate instanceof FileList && valueToValidate.length === 0) {
-      // we override the delegate's validation as its value and files prop cannot be directly set for validation
-      return false;
-    }
-
-    return true;
+    const isMissingValue = !valueToValidate || (valueToValidate instanceof FileList && valueToValidate.length === 0);
+    // we override the delegate's validation as its value and files prop cannot be directly set for validation
+    return !inputDelegate.required || !isMissingValue;
   }
 
   inputDelegate.value = valueToValidate == null ? "" : String(valueToValidate);


### PR DESCRIPTION
**Related Issue:** #14560 

## Summary

This fixes a regression introduced in #8126 where `input` was not properly handling its `files` value, causing the element to always be considered invalid.