### PR TITLE
fix(list-item): only emit internal change event when metadata values differ

### DIFF
--- a/packages/components/src/components/list-item/list-item.browser.e2e.tsx
+++ b/packages/components/src/components/list-item/list-item.browser.e2e.tsx
@@ -1,5 +1,5 @@
 import { h } from "@arcgis/lumina";
-import { describe } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import {
   defaults,
@@ -11,6 +11,7 @@ import {
   slots,
 } from "../../tests/commonTests/browser";
 import { CSS, SLOTS } from "./resources";
+import type { ListItem } from "./list-item";
 
 describe("defaults", () => {
   defaults(
@@ -144,4 +145,49 @@ describe("is focusable", () => {
 
 describe("disabled", () => {
   disabled(() => mount(<calcite-list-item active label="test" />));
+});
+
+it("emits calciteInternalListItemChange only when metadata values change", async () => {
+  const { el, component } = await mount<ListItem>(<calcite-list-item />);
+  const eventSpy = vi.fn();
+
+  el.addEventListener("calciteInternalListItemChange", eventSpy);
+
+  el.metadata = { first: "same", second: "value" };
+  await component.updateComplete;
+
+  el.metadata = { second: "value", first: "same" };
+  await component.updateComplete;
+
+  el.metadata = { first: "different", second: "value" };
+  await component.updateComplete;
+
+  el.metadata = { keyword: "different", nested: { key: "same" } };
+  await component.updateComplete;
+
+  el.metadata = { keyword: "different", nested: { key: "same" } };
+  await component.updateComplete;
+
+  el.metadata = { keyword: "different", nested: { key: "changed" } };
+  await component.updateComplete;
+
+  el.metadata = {
+    tags: ["a", "b"],
+    when: "2024-01-01T00:00:00.000Z",
+  };
+  await component.updateComplete;
+
+  el.metadata = {
+    tags: ["a", "b"],
+    when: "2024-01-01T00:00:00.000Z",
+  };
+  await component.updateComplete;
+
+  el.metadata = {
+    tags: ["a", "b", "c"],
+    when: "2024-01-01T00:00:00.000Z",
+  };
+  await component.updateComplete;
+
+  expect(eventSpy).toHaveBeenCalledTimes(6);
 });

--- a/packages/components/src/components/list-item/list-item.e2e.ts
+++ b/packages/components/src/components/list-item/list-item.e2e.ts
@@ -252,59 +252,6 @@ it("emits calciteInternalListItemActive on click", async () => {
   expect(eventSpy).toHaveReceivedEventTimes(1);
 });
 
-it("emits calciteInternalListItemChange only when metadata values change", async () => {
-  const page = await newE2EPage({ html: `<calcite-list-item></calcite-list-item>` });
-
-  await page.waitForChanges();
-
-  const eventSpy = await page.spyOnEvent("calciteInternalListItemChange");
-  const item = await page.find("calcite-list-item");
-
-  item.setProperty("metadata", { first: "same", second: "value" });
-  await page.waitForChanges();
-
-  item.setProperty("metadata", { second: "value", first: "same" });
-  await page.waitForChanges();
-
-  item.setProperty("metadata", { first: "different", second: "value" });
-  await page.waitForChanges();
-
-  item.setProperty("metadata", { keyword: "different", nested: { key: "same" } });
-  await page.waitForChanges();
-
-  item.setProperty("metadata", { keyword: "different", nested: { key: "same" } });
-  await page.waitForChanges();
-
-  item.setProperty("metadata", { keyword: "different", nested: { key: "changed" } });
-  await page.waitForChanges();
-
-  await page.$eval("calcite-list-item", (el: HTMLElement) => {
-    (el as HTMLElement & { metadata: Record<string, unknown> }).metadata = {
-      tags: ["a", "b"],
-      when: "2024-01-01T00:00:00.000Z",
-    };
-  });
-  await page.waitForChanges();
-
-  await page.$eval("calcite-list-item", (el: HTMLElement) => {
-    (el as HTMLElement & { metadata: Record<string, unknown> }).metadata = {
-      tags: ["a", "b"],
-      when: "2024-01-01T00:00:00.000Z",
-    };
-  });
-  await page.waitForChanges();
-
-  await page.$eval("calcite-list-item", (el: HTMLElement) => {
-    (el as HTMLElement & { metadata: Record<string, unknown> }).metadata = {
-      tags: ["a", "b", "c"],
-      when: "2024-01-01T00:00:00.000Z",
-    };
-  });
-  await page.waitForChanges();
-
-  expect(eventSpy).toHaveReceivedEventTimes(6);
-});
-
 it("honors closed prop", async () => {
   const page = await newE2EPage();
 

--- a/packages/components/src/components/list-item/list-item.e2e.ts
+++ b/packages/components/src/components/list-item/list-item.e2e.ts
@@ -252,6 +252,59 @@ it("emits calciteInternalListItemActive on click", async () => {
   expect(eventSpy).toHaveReceivedEventTimes(1);
 });
 
+it("emits calciteInternalListItemChange only when metadata values change", async () => {
+  const page = await newE2EPage({ html: `<calcite-list-item></calcite-list-item>` });
+
+  await page.waitForChanges();
+
+  const eventSpy = await page.spyOnEvent("calciteInternalListItemChange");
+  const item = await page.find("calcite-list-item");
+
+  item.setProperty("metadata", { first: "same", second: "value" });
+  await page.waitForChanges();
+
+  item.setProperty("metadata", { second: "value", first: "same" });
+  await page.waitForChanges();
+
+  item.setProperty("metadata", { first: "different", second: "value" });
+  await page.waitForChanges();
+
+  item.setProperty("metadata", { keyword: "different", nested: { key: "same" } });
+  await page.waitForChanges();
+
+  item.setProperty("metadata", { keyword: "different", nested: { key: "same" } });
+  await page.waitForChanges();
+
+  item.setProperty("metadata", { keyword: "different", nested: { key: "changed" } });
+  await page.waitForChanges();
+
+  await page.$eval("calcite-list-item", (el: HTMLElement) => {
+    (el as HTMLElement & { metadata: Record<string, unknown> }).metadata = {
+      tags: ["a", "b"],
+      when: "2024-01-01T00:00:00.000Z",
+    };
+  });
+  await page.waitForChanges();
+
+  await page.$eval("calcite-list-item", (el: HTMLElement) => {
+    (el as HTMLElement & { metadata: Record<string, unknown> }).metadata = {
+      tags: ["a", "b"],
+      when: "2024-01-01T00:00:00.000Z",
+    };
+  });
+  await page.waitForChanges();
+
+  await page.$eval("calcite-list-item", (el: HTMLElement) => {
+    (el as HTMLElement & { metadata: Record<string, unknown> }).metadata = {
+      tags: ["a", "b", "c"],
+      when: "2024-01-01T00:00:00.000Z",
+    };
+  });
+  await page.waitForChanges();
+
+  expect(eventSpy).toHaveReceivedEventTimes(6);
+});
+
 it("honors closed prop", async () => {
   const page = await newE2EPage();
 

--- a/packages/components/src/components/list-item/list-item.tsx
+++ b/packages/components/src/components/list-item/list-item.tsx
@@ -45,14 +45,6 @@ function metadataValuesAreEqual(
   currentMetadata?: Record<string, unknown>,
   previousMetadata?: Record<string, unknown>,
 ): boolean {
-  if (currentMetadata === previousMetadata) {
-    return true;
-  }
-
-  if (!currentMetadata || !previousMetadata) {
-    return false;
-  }
-
   return isEqual(currentMetadata, previousMetadata);
 }
 

--- a/packages/components/src/components/list-item/list-item.tsx
+++ b/packages/components/src/components/list-item/list-item.tsx
@@ -41,13 +41,6 @@ declare global {
 
 const focusMap = new Map<List["el"], number | undefined>();
 
-function metadataValuesAreEqual(
-  currentMetadata?: Record<string, unknown>,
-  previousMetadata?: Record<string, unknown>,
-): boolean {
-  return isEqual(currentMetadata, previousMetadata);
-}
-
 /**
  * @slot - A slot for adding `calcite-list`, `calcite-list-item` and `calcite-list-item-group` elements.
  * @slot actions-start - A slot for adding actionable `calcite-action` elements before the content of the component.
@@ -456,8 +449,7 @@ export class ListItem extends LitElement implements SortableComponentItem {
 
     const metadataChanged = changes.has("metadata");
     const previousMetadata = changes.get("metadata");
-    const shouldEmitMetadataChange =
-      metadataChanged && !metadataValuesAreEqual(this.metadata, previousMetadata);
+    const shouldEmitMetadataChange = metadataChanged && !isEqual(this.metadata, previousMetadata);
 
     if (
       (changes.has("label") || changes.has("description") || shouldEmitMetadataChange) &&

--- a/packages/components/src/components/list-item/list-item.tsx
+++ b/packages/components/src/components/list-item/list-item.tsx
@@ -1,3 +1,4 @@
+import { isEqual } from "es-toolkit";
 import { PropertyValues } from "lit";
 import { createRef } from "lit/directives/ref.js";
 import {
@@ -39,6 +40,22 @@ declare global {
 }
 
 const focusMap = new Map<List["el"], number | undefined>();
+
+function metadataValuesAreEqual(
+  currentMetadata?: Record<string, unknown>,
+  previousMetadata?: Record<string, unknown>,
+): boolean {
+  if (currentMetadata === previousMetadata) {
+    return true;
+  }
+
+  if (!currentMetadata || !previousMetadata) {
+    return false;
+  }
+
+  return isEqual(currentMetadata, previousMetadata);
+}
+
 /**
  * @slot - A slot for adding `calcite-list`, `calcite-list-item` and `calcite-list-item-group` elements.
  * @slot actions-start - A slot for adding actionable `calcite-action` elements before the content of the component.
@@ -445,7 +462,15 @@ export class ListItem extends LitElement implements SortableComponentItem {
       this.handleExpandableChange(this.defaultSlotRef.value);
     }
 
-    if (changes.has("label") || changes.has("description") || changes.has("metadata")) {
+    const metadataChanged = changes.has("metadata");
+    const previousMetadata = changes.get("metadata");
+    const shouldEmitMetadataChange =
+      metadataChanged && !metadataValuesAreEqual(this.metadata, previousMetadata);
+
+    if (
+      (changes.has("label") || changes.has("description") || shouldEmitMetadataChange) &&
+      this.hasUpdated
+    ) {
       this.emitCalciteInternalListItemChange();
     }
 


### PR DESCRIPTION
**Related Issue:** #14587

## Summary

This PR updates `calcite-list-item` so `calciteInternalListItemChange` is emitted for metadata updates only when the metadata values actually change.

This was causing issues with drag and drop as it would continuously set up sorting again and again which prevented drag and drop. It was likely causing a memory leak as well.