### PR TITLE
fix(checkbox): use danger token color when invalid and hovered

### DIFF
--- a/packages/components/src/components/checkbox/checkbox.scss
+++ b/packages/components/src/components/checkbox/checkbox.scss
@@ -62,7 +62,7 @@
   }
   .toggle:hover {
     .check-svg {
-      box-shadow: inset 0 0 0 2px var(--calcite-color-brand-hover);
+      box-shadow: inset 0 0 0 2px var(--calcite-color-status-danger);
     }
   }
   .toggle:active {


### PR DESCRIPTION
**Related Issue:** #14568 

## Summary
Changes checkboxes box shadow color to use `--calcite-color-status-danger` instead of `--calcite-color-brand-hover` when the status is invalid.