### PR TITLE
feat(flow-item): add collapseDirection property

### DIFF
--- a/packages/components/src/components/flow-item/flow-item.tsx
+++ b/packages/components/src/components/flow-item/flow-item.tsx
@@ -81,11 +81,7 @@ export class FlowItem extends LitElement {
   /** When `true`, hides the component. */
   @property({ reflect: true }) closed = false;
 
-  /**
-   * Specifies the direction of the collapse.
-   *
-   * @private
-   */
+  /** When `collapsible` is `true`, specifies the direction of the collapse icon. */
   @property() collapseDirection: CollapseDirection = "down";
 
   /** When `true`, hides the component's content area. */


### PR DESCRIPTION
**Related Issue:** #14585

## Summary
This PR adds a new `collapseDirection` property to `flow-item` so consumers can control the direction used for collapse behavior/icon presentation.