### PR TITLE
ci(actions): sync breaking change labels to Monday.com

### DIFF
--- a/.github/scripts/support/monday.js
+++ b/.github/scripts/support/monday.js
@@ -138,6 +138,7 @@ module.exports = function Monday(issue, core, updateIssueBody) {
     designIssue: { id: "color_mkswbke0", title: "Design Issue" },
     stalled: { id: "color_mkv79bbx", title: "Stalled" },
     blocked: { id: "color_mkv7x1gw", title: "Blocked" },
+    breaking: { id: "color_mm48xr8j", title: "Breaking" },
     spike: { id: "color_mkrt20dy", title: "Spike" },
     figmaChanges: { id: "color_mkrvmhg7", title: "Figma Changes" },
     open: { id: "color_mknkrb2n", title: "Open/Closed" },
@@ -186,6 +187,22 @@ module.exports = function Monday(issue, core, updateIssueBody) {
       {
         column: mondayColumns.blocked,
         value: "Blocked",
+        clearable: true,
+      },
+    ],
+    [
+      planning.breakingChange,
+      {
+        column: mondayColumns.breaking,
+        value: "Breaking Change",
+        clearable: true,
+      },
+    ],
+    [
+      planning.futureBreakingChange,
+      {
+        column: mondayColumns.breaking,
+        value: "Future Breaking Change",
         clearable: true,
       },
     ],

--- a/.github/scripts/support/resources.js
+++ b/.github/scripts/support/resources.js
@@ -40,6 +40,8 @@ const resources = {
       spikeComplete: "spike complete",
       noChangelogEntry: "no changelog entry",
       blocked: "blocked",
+      breakingChange: "breaking change",
+      futureBreakingChange: "future breaking change",
       monday: "monday.com sync",
     },
     priority: {


### PR DESCRIPTION
**Related Issue:** #14612

## Summary

Adds the breaking change labels (`breaking change`, `future breaking change`) to the `resources.js` file and maps them to a new Monday.com column for syncing.
