### PR TITLE
test(focus-trap): migrate test helper to browser mode

### DIFF
--- a/packages/components/src/components/dialog/dialog.browser.e2e.tsx
+++ b/packages/components/src/components/dialog/dialog.browser.e2e.tsx
@@ -6,6 +6,7 @@ import { page, userEvent } from "vitest/browser";
 import {
   defaults,
   focusable,
+  focusTrap,
   reflects,
   hidden,
   renders,
@@ -139,6 +140,28 @@ describe("is focusable", () => {
     focusable(() => mount(renderDialog(true)), {
       focusTargetSelector,
     });
+  });
+});
+
+describe("focus-trap", () => {
+  describe("default", () => {
+    focusTrap(() => mount(<calcite-dialog heading="Title">Content</calcite-dialog>), {
+      toggleProp: "open",
+    });
+  });
+
+  describe("modal", () => {
+    focusTrap(
+      () =>
+        mount(
+          <calcite-dialog heading="Title" modal>
+            Content
+          </calcite-dialog>,
+        ),
+      {
+        toggleProp: "open",
+      },
+    );
   });
 });
 

--- a/packages/components/src/components/dialog/dialog.e2e.ts
+++ b/packages/components/src/components/dialog/dialog.e2e.ts
@@ -6,7 +6,6 @@ import { html } from "../../../support/formatting";
 import { isElementFocused, newProgrammaticE2EPage, skipAnimations } from "../../tests/utils/puppeteer";
 import { IDS as PanelIDS } from "../panel/resources";
 import { resizeShiftStep } from "../../utils/resources";
-import { focusTrap } from "../../tests/commonTests/focusTrap";
 import { mockConsole } from "../../tests/utils/logging";
 import { GlobalTestProps } from "../../tests/utils/interfaces";
 import { CSS } from "./resources";
@@ -54,20 +53,6 @@ describe("accessible", () => {
     await openEventSpy.next();
 
     return { page, tag: "calcite-dialog" };
-  });
-});
-
-describe("focus-trap", () => {
-  describe("default", () => {
-    focusTrap("calcite-dialog", {
-      toggleProp: "open",
-    });
-  });
-
-  describe("modal", () => {
-    focusTrap(html`<calcite-dialog modal></calcite-dialog>`, {
-      toggleProp: "open",
-    });
   });
 });
 

--- a/packages/components/src/components/sheet/sheet.browser.e2e.tsx
+++ b/packages/components/src/components/sheet/sheet.browser.e2e.tsx
@@ -1,11 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { h } from "@arcgis/lumina";
-import { userEvent } from "vitest/browser";
+import { page, userEvent } from "vitest/browser";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import { commands } from "../../tests/browser/commands";
 import {
   defaults,
   focusable,
+  focusTrap,
   hidden,
   openClose,
   reflects,
@@ -87,6 +88,21 @@ describe("is focusable", () => {
       },
     );
   });
+});
+
+describe("focus-trap", () => {
+  focusTrap(
+    () =>
+      mount(
+        <calcite-sheet>
+          <input id="focusable-content" />
+        </calcite-sheet>,
+      ),
+    {
+      toggleProp: "open",
+      focusTarget: () => page.getBySelector("#focusable-content"),
+    },
+  );
 });
 
 describe("reflects", () => {

--- a/packages/components/src/components/sheet/sheet.e2e.ts
+++ b/packages/components/src/components/sheet/sheet.e2e.ts
@@ -5,7 +5,6 @@ import { html } from "../../../support/formatting";
 import { accessible, themed } from "../../tests/commonTests";
 import { skipAnimations } from "../../tests/utils/puppeteer";
 import { resizeStep, resizeShiftStep } from "../../utils/resources";
-import { focusTrap } from "../../tests/commonTests/focusTrap";
 import { mockConsole } from "../../tests/utils/logging";
 import { GlobalTestProps } from "../../tests/utils/interfaces";
 import { CSS, IDS } from "./resources";
@@ -51,18 +50,7 @@ describe("accessible", () => {
   });
 });
 
-describe("focus-trap", () => {
-  focusTrap(
-    html` <calcite-sheet>
-      <!-- sheet has no default focusable parts -->
-      <input id="focusable-content" />
-    </calcite-sheet>`,
-    {
-      toggleProp: "open",
-      focusTargetSelector: "#focusable-content",
-    },
-  );
-});
+// focus-trap coverage is in sheet.browser.e2e.tsx.
 
 it("sets custom width correctly", async () => {
   const page = await newE2EPage();

--- a/packages/components/src/controllers/useFocusTrap.ts
+++ b/packages/components/src/controllers/useFocusTrap.ts
@@ -59,7 +59,7 @@ interface UseFocusTrapOptions<T extends LitElement = LitElement> {
   focusTrapOptions?: Options;
 }
 
-interface FocusTrapComponent extends LitElement {
+export interface FocusTrapComponent extends LitElement {
   /*
    * When `true` prevents focus trapping.
    */

--- a/packages/components/src/tests/commonTests/browser/focus-trap.ts
+++ b/packages/components/src/tests/commonTests/browser/focus-trap.ts
@@ -3,6 +3,7 @@ import { mount } from "@arcgis/lumina-compiler/testing";
 import { Locator, page } from "vitest/browser";
 import { getEventPrefix, waitForEvent } from "./utils";
 import { FocusTrapComponent } from "../../../controllers/useFocusTrap";
+import { afterFocusShiftDelay } from "../../utils/focus-trap";
 
 interface FocusTrapOptions {
   /**
@@ -24,6 +25,7 @@ async function toggleComponent(el: FocusTrapTestElement, toggleProp: string): Pr
 
   el[toggleProp] = true;
   await openEvent;
+  await afterFocusShiftDelay();
 }
 
 /**
@@ -64,7 +66,7 @@ export function focusTrap(setup: () => ReturnType<typeof mount>, options: FocusT
       await expect.element(target).toHaveFocus();
     });
 
-    it("focuses when true", async () => {
+    it("focuses when set to undefined (default behavior)", async () => {
       const { el, target } = await setUpTest();
 
       await expect.element(target).not.toHaveFocus();
@@ -78,9 +80,9 @@ export function focusTrap(setup: () => ReturnType<typeof mount>, options: FocusT
     describe("when focusTrapDisabled = true", () => {
       it("focuses when false", async () => {
         const { el, target } = await setUpTest();
-
         el.focusTrapDisabled = true;
         el.focusTrapOptions = { initialFocus: false };
+
         await expect.element(target).not.toHaveFocus();
 
         await toggleComponent(el, toggleProp);
@@ -90,9 +92,8 @@ export function focusTrap(setup: () => ReturnType<typeof mount>, options: FocusT
 
       it("focuses by default", async () => {
         const { el, target } = await setUpTest();
-
         el.focusTrapDisabled = true;
-        el.focusTrapOptions = { initialFocus: undefined };
+
         await expect.element(target).not.toHaveFocus();
 
         await toggleComponent(el, toggleProp);
@@ -100,7 +101,7 @@ export function focusTrap(setup: () => ReturnType<typeof mount>, options: FocusT
         await expect.element(target).toHaveFocus();
       });
 
-      it("focuses when true", async () => {
+      it("focuses when set to undefined (default behavior)", async () => {
         const { el, target } = await setUpTest();
 
         el.focusTrapDisabled = true;

--- a/packages/components/src/tests/commonTests/browser/focus-trap.ts
+++ b/packages/components/src/tests/commonTests/browser/focus-trap.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import { mount } from "@arcgis/lumina-compiler/testing";
+import { Locator, page } from "vitest/browser";
+import { getEventPrefix, waitForEvent } from "./utils";
+import { FocusTrapComponent } from "../../../controllers/useFocusTrap";
+
+interface FocusTrapOptions {
+  /**
+   * The locator for the element expected to receive focus when the component is opened.
+   * If not provided, the component itself will be used as the target.
+   */
+  focusTarget?: () => Locator;
+
+  /**
+   * The property that toggles the opening of the component.
+   */
+  toggleProp: string;
+}
+
+type FocusTrapTestElement = FocusTrapComponent;
+
+async function toggleComponent(el: FocusTrapTestElement, toggleProp: string): Promise<void> {
+  const openEvent = waitForEvent(el, `${getEventPrefix(el)}Open`);
+
+  el[toggleProp] = true;
+  await openEvent;
+}
+
+/**
+ * Helper for testing focus-trapping behavior in components.
+ *
+ * Note: this assumes the component under test is closed and will be opened before running assertions.
+ */
+export function focusTrap(setup: () => ReturnType<typeof mount>, options: FocusTrapOptions): void {
+  const { focusTarget, toggleProp } = options;
+
+  describe("initialFocus", () => {
+    async function setUpTest(): Promise<{ el: FocusTrapTestElement; target: Locator }> {
+      const { el } = await setup();
+      const component = el as FocusTrapTestElement;
+      const target = focusTarget?.() ?? page.elementLocator(el);
+
+      return { el: component, target };
+    }
+
+    it("does not focus when false", async () => {
+      const { el, target } = await setUpTest();
+
+      await expect.element(target).not.toHaveFocus();
+
+      el.focusTrapOptions = { initialFocus: false };
+      await toggleComponent(el, toggleProp);
+
+      await expect.element(target).not.toHaveFocus();
+    });
+
+    it("focuses by default", async () => {
+      const { el, target } = await setUpTest();
+
+      await expect.element(target).not.toHaveFocus();
+
+      await toggleComponent(el, toggleProp);
+
+      await expect.element(target).toHaveFocus();
+    });
+
+    it("focuses when true", async () => {
+      const { el, target } = await setUpTest();
+
+      await expect.element(target).not.toHaveFocus();
+
+      el.focusTrapOptions = { initialFocus: undefined };
+      await toggleComponent(el, toggleProp);
+
+      await expect.element(target).toHaveFocus();
+    });
+
+    describe("when focusTrapDisabled = true", () => {
+      it("focuses when false", async () => {
+        const { el, target } = await setUpTest();
+
+        el.focusTrapDisabled = true;
+        el.focusTrapOptions = { initialFocus: false };
+        await expect.element(target).not.toHaveFocus();
+
+        await toggleComponent(el, toggleProp);
+
+        await expect.element(target).toHaveFocus();
+      });
+
+      it("focuses by default", async () => {
+        const { el, target } = await setUpTest();
+
+        el.focusTrapDisabled = true;
+        el.focusTrapOptions = { initialFocus: undefined };
+        await expect.element(target).not.toHaveFocus();
+
+        await toggleComponent(el, toggleProp);
+
+        await expect.element(target).toHaveFocus();
+      });
+
+      it("focuses when true", async () => {
+        const { el, target } = await setUpTest();
+
+        el.focusTrapDisabled = true;
+        await expect.element(target).not.toHaveFocus();
+
+        el.focusTrapOptions = { initialFocus: undefined };
+        await toggleComponent(el, toggleProp);
+
+        await expect.element(target).toHaveFocus();
+      });
+    });
+  });
+}

--- a/packages/components/src/tests/commonTests/browser/index.ts
+++ b/packages/components/src/tests/commonTests/browser/index.ts
@@ -2,6 +2,7 @@ export { cancelable } from "./cancelable";
 export { defaults } from "./defaults";
 export { disabled } from "./disabled";
 export { focusable } from "./focusable";
+export { focusTrap } from "./focus-trap";
 export { formAssociated } from "./form-associated";
 export { hidden } from "./hidden";
 export { floatingUIOwner, delegatesToFloatingUiOwningComponent, handlesActionMenuPlacements } from "./floating-ui";


### PR DESCRIPTION
**Related Issue:** #11268 

## Summary

Continues the migration of Puppeteer based common test helpers to Vitest browser mode.