### PR TITLE
ci(release): add missing `package-lock.json` to cherry-pick ignore list

### DIFF
--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -66,7 +66,7 @@ jobs:
             conflicts="$(git diff --name-only --diff-filter=U)"
 
             if [ -n "$conflicts" ] && echo "$conflicts" |
-              grep -qvE 'packages/.*/(CHANGELOG\.md|package\.json)'; then
+              grep -qvE '^(package-lock\.json|packages/.*/(CHANGELOG\.md|package\.json))$'; then
               echo "Aborting cherry-pick due to unexpected conflicts:"
               echo "$conflicts"
               git cherry-pick --abort

--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -74,6 +74,7 @@ jobs:
             fi
           fi
 
+          git checkout "$release_commit" -- package-lock.json
           git checkout "$release_commit" -- packages/*/CHANGELOG.md
           git checkout "$kept_commit" -- packages/*/package.json
           git add packages/*/CHANGELOG.md packages/*/package.json

--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -74,10 +74,10 @@ jobs:
             fi
           fi
 
-          git checkout "$release_commit" -- package-lock.json
           git checkout "$release_commit" -- packages/*/CHANGELOG.md
+          git checkout "$kept_commit" -- package-lock.json
           git checkout "$kept_commit" -- packages/*/package.json
-          git add packages/*/CHANGELOG.md packages/*/package.json
+          git add package-lock.json packages/*/CHANGELOG.md packages/*/package.json
 
           if git diff --name-only --diff-filter=U | grep -q .; then
             echo "Aborting cherry-pick, as there are still conflicts after auto-resolution."


### PR DESCRIPTION
**Related Issue:** n/a

## Summary

Adds the root `package-lock.json` file to the cherry-pick auto-merge ignore list.

The absence of this file likely caused the [cherry-pick auto-merge to fail](https://github.com/Esri/calcite-design-system/actions/runs/27309387694/job/80675483379) during the `5.1.1` patch release, as it errored with the following message:

```
Aborting cherry-pick due to unexpected conflicts:
package-lock.json
packages/components-react/CHANGELOG.md
packages/components-react/package.json
packages/components/CHANGELOG.md
packages/components/package.json
```

All the files in that list should have been ignored by the grep regex, besides the `package-lock.json` file.

With it added, hopefully the cherry-pick will ignore the expected conflicts and move forward with handling merge conflicts correctly.

Related: #14654