### PR TITLE
docs: add copydoc guidance

### DIFF
--- a/packages/components/conventions/Documentation.md
+++ b/packages/components/conventions/Documentation.md
@@ -20,7 +20,17 @@ Follow these conventions when adding or editing API reference:
 
 ### Shared definitions using `@copyDoc`
 
-When a description is shared across multiple components, the `@copyDoc` tag should be used. This improves consistency and reduces repetition. To add shared component documentation definitions, perform the following:
+When a description is shared across multiple components, the `@copyDoc` tag should be used. This improves consistency and reduces repetition.
+
+#### Support
+
+- Supported sections: `properties`, `methods`, and `events`
+- Unsupported sections: `slots`
+- Supported fields: `deprecated`, `description`, `docsTags`, `readonly`, and `return`
+
+#### Usage
+
+To add shared component documentation definitions, perform the following:
 
 - Add a shared definition in the [api-extractor.config.ts file](../api-extractor.config.ts) within the `copyDocDefinitions` object. The `copyDocDefinitions` object stores shared documentation definitions by section, such as `properties`, `methods`, and `events`. The example below adds a shared definition for the `checked` property.
   ```ts
@@ -46,12 +56,6 @@ When a description is shared across multiple components, the `@copyDoc` tag shou
      * @deprecated in v5.1.0, removal target v6.0.0 - This property has no effect on the component.
      */
     ```
-
-`@copyDoc` support:
-
-- Supported sections: `properties`, `methods`, and `events`
-- Unsupported sections: `slots`
-- Supported fields: `deprecated`, `description`, `docsTags`, `readonly`, and `return`
 
 In some cases a component may need different verbiage than the default description in `@copyDoc`. For example, most `heading` properties use the verbiage "Specifies the component's heading text." List Item Group uses the more specific description "Specifies the heading text for the nested `calcite-list-item` rows."
 To facilitate using a component-specific description either:

--- a/packages/components/conventions/Documentation.md
+++ b/packages/components/conventions/Documentation.md
@@ -18,6 +18,31 @@ Follow these conventions when adding or editing API reference:
 - Verify slots and properties/attributes don't use the text "optional" in their descriptions.
 - For CSS token properties, avoid the use of forward slashes (`/`) in descriptions as it causes the generated API documentation to be cut off.
 
+### Shared definitions using `@copyDoc`
+
+Usage: Use `@copyDoc` when the same description is shared across multiple components.
+
+- Add shared definitions in [api-extractor.config.ts](../api-extractor.config.ts) within `copyDocDefinitions`.
+- Use the `@copyDoc` tag in the component file in place of the description. Other tags, such as `@deprecated` or `@required`, can still be used in conjunction with `@copyDoc`. Example:
+
+```js
+/**
+@copyDoc
+@deprecated in v5.1.0, removal target v6.0.0 - This property has no effect on the component.
+*/
+```
+
+Supported sections: `properties`, `methods`, and `events`
+
+Unsupported sections: `slots`
+
+If a component needs different verbiage than an `@copyDoc` description, either:
+
+- Use override functions as seen for the [`heading` property in api-extractor.config.ts](../api-extractor.config.ts).
+- Add a description in the component file and don't use `@copyDoc`.
+
+For additional guidance, review the WebGIS reference `@copyDoc` documentation.
+
 ### Deprecation notices
 
 There are two ways to document deprecations, depending on the API reference. In both cases a deprecated chip will be displayed in the SDK site within the component's API reference section.

--- a/packages/components/conventions/Documentation.md
+++ b/packages/components/conventions/Documentation.md
@@ -20,17 +20,32 @@ Follow these conventions when adding or editing API reference:
 
 ### Shared definitions using `@copyDoc`
 
-When a description is shared across multiple components, the `@copyDoc` tag should be used. This improves consistency and reduces repetition.
+When a description is shared across multiple components, the `@copyDoc` tag should be used. This improves consistency and reduces repetition. To add shared component documentation definitions, perform the following:
 
-- Add shared definitions in [api-extractor.config.ts](../api-extractor.config.ts) within `copyDocDefinitions`.
-- Use the `@copyDoc` tag in the component file in place of the description. Other tags, such as `@deprecated` or `@required`, can still be used in conjunction with `@copyDoc`:
+- Add a shared definition in the [api-extractor.config.ts file](../api-extractor.config.ts) within the `copyDocDefinitions` object. The `copyDocDefinitions` object stores shared documentation definitions by section, such as `properties`, `methods`, and `events`. The example below adds a shared definition for the `checked` property.
+  ```js
+  copyDocDefinitions: {
+    properties: {
+      checked: {
+        description: "When `true`, the component is checked.",
+      },
+    ...
+  ```
+- Use the `@copyDoc` tag in the component file in place of the description. If a matching category and name exists in `copyDocDefinitions`, in this case `properties` and `checked`, then the documentation will use the associated description. In the example below, the description would read "When `true`, the component is checked."
 
   ```js
-  /**
-   * @copyDoc
-   * @deprecated in v5.1.0, removal target v6.0.0 - This property has no effect on the component.
-   */
+    /** @copyDoc */
+    @property({ reflect: true }) checked = false;
   ```
+
+  - Other tags, such as `@deprecated` or `@required`, can be used in conjunction with `@copyDoc`, such as with the example below.
+
+    ```js
+    /**
+     * @copyDoc
+     * @deprecated in v5.1.0, removal target v6.0.0 - This property has no effect on the component.
+     */
+    ```
 
 `@copyDoc` support:
 

--- a/packages/components/conventions/Documentation.md
+++ b/packages/components/conventions/Documentation.md
@@ -41,7 +41,7 @@ To add shared component documentation definitions, perform the following:
       },
     ...
   ```
-- Use the `@copyDoc` tag in the component file in place of the description. If a matching category and name exists in `copyDocDefinitions`, in this case `properties` and `checked`, then the documentation will use the associated description. In the example below, the description would read "When `true`, the component is checked."
+- Use the `@copyDoc` tag in the component file in place of the description. If a matching section and name exists in `copyDocDefinitions`, in this case `properties` and `checked`, then the documentation will use the associated description. In the example below, the description would read "When `true`, the component is checked."
 
   ```tsx
   /** @copyDoc */

--- a/packages/components/conventions/Documentation.md
+++ b/packages/components/conventions/Documentation.md
@@ -43,7 +43,7 @@ If a component needs different verbiage than an `@copyDoc` description, either:
 - Use override functions as seen for the [`heading` property in api-extractor.config.ts](../api-extractor.config.ts).
 - Add a description in the component file and don't use `@copyDoc`.
 
-For additional guidance, review the WebGIS reference `@copyDoc` documentation.
+For additional guidance, review the Web GIS reference `@copyDoc` documentation.
 
 ### Deprecation notices
 

--- a/packages/components/conventions/Documentation.md
+++ b/packages/components/conventions/Documentation.md
@@ -23,7 +23,7 @@ Follow these conventions when adding or editing API reference:
 When a description is shared across multiple components, the `@copyDoc` tag should be used. This improves consistency and reduces repetition. To add shared component documentation definitions, perform the following:
 
 - Add a shared definition in the [api-extractor.config.ts file](../api-extractor.config.ts) within the `copyDocDefinitions` object. The `copyDocDefinitions` object stores shared documentation definitions by section, such as `properties`, `methods`, and `events`. The example below adds a shared definition for the `checked` property.
-  ```js
+  ```ts
   copyDocDefinitions: {
     properties: {
       checked: {
@@ -33,14 +33,14 @@ When a description is shared across multiple components, the `@copyDoc` tag shou
   ```
 - Use the `@copyDoc` tag in the component file in place of the description. If a matching category and name exists in `copyDocDefinitions`, in this case `properties` and `checked`, then the documentation will use the associated description. In the example below, the description would read "When `true`, the component is checked."
 
-  ```js
+  ```tsx
     /** @copyDoc */
     @property({ reflect: true }) checked = false;
   ```
 
   - Other tags, such as `@deprecated` or `@required`, can be used in conjunction with `@copyDoc`, such as with the example below.
 
-    ```js
+    ```tsx
     /**
      * @copyDoc
      * @deprecated in v5.1.0, removal target v6.0.0 - This property has no effect on the component.

--- a/packages/components/conventions/Documentation.md
+++ b/packages/components/conventions/Documentation.md
@@ -24,11 +24,11 @@ Descriptions that are shared across components should use the `@copyDoc` tag to 
 
 #### Support
 
-- @copyDoc support includes:
-  - Sections: properties, methods, and events
-  - Fields: deprecated, description, docTags, readonly, and return
-- Unsupported in @copyDoc:
-  - Sections: slots
+- `@copyDoc` support includes:
+  - Sections: `properties`, `methods`, and `events`
+  - Fields: `deprecated`, `description`, `docTags`, `readonly`, and `return`
+- Unsupported in `@copyDoc`:
+  - Sections: `slots`
 
 #### Usage
 

--- a/packages/components/conventions/Documentation.md
+++ b/packages/components/conventions/Documentation.md
@@ -63,7 +63,6 @@ In some cases a component may need different verbiage than the default descripti
 To facilitate using a component-specific description either:
 
 - Use override functions, such as the [`heading` property in api-extractor.config.ts](../api-extractor.config.ts). Name each override function after the target `property`, `method`, or `event` section. Override functions give access to API metadata which can be used to customize `@copyDoc` definitions.
-
   - In the override function example below, the `heading` property uses `apiClass.name` to return a specific value for List Item Group.
 
   ```ts
@@ -94,7 +93,7 @@ To facilitate using a component-specific description either:
   @property({ reflect: true }) heading?: string;
   ```
 
-For additional guidance, review the Web GIS Resources `@copyDoc` documentation within the API Extractor's "Tag reference" section.
+For additional guidance, review the [Web GIS Resources `@copyDoc` documentation](https://webgis.esri.com/references/api-extractor/tags-reference#copydoc).
 
 ### Deprecation notices
 

--- a/packages/components/conventions/Documentation.md
+++ b/packages/components/conventions/Documentation.md
@@ -20,7 +20,7 @@ Follow these conventions when adding or editing API reference:
 
 ### Shared definitions using `@copyDoc`
 
-When a description is shared across multiple components, the `@copyDoc` tag should be used. This improves consistency and reduces repetition.
+Descriptions that are shared across components should use the @copyDoc tag to improve consistency and reduce repetition in the repository.
 
 #### Support
 

--- a/packages/components/conventions/Documentation.md
+++ b/packages/components/conventions/Documentation.md
@@ -34,8 +34,8 @@ When a description is shared across multiple components, the `@copyDoc` tag shou
 - Use the `@copyDoc` tag in the component file in place of the description. If a matching category and name exists in `copyDocDefinitions`, in this case `properties` and `checked`, then the documentation will use the associated description. In the example below, the description would read "When `true`, the component is checked."
 
   ```tsx
-    /** @copyDoc */
-    @property({ reflect: true }) checked = false;
+  /** @copyDoc */
+  @property({ reflect: true }) checked = false;
   ```
 
   - Other tags, such as `@deprecated` or `@required`, can be used in conjunction with `@copyDoc`, such as with the example below.
@@ -53,10 +53,40 @@ When a description is shared across multiple components, the `@copyDoc` tag shou
 - Unsupported sections: `slots`
 - Supported fields: `deprecated`, `description`, `docsTags`, `readonly`, and `return`
 
-If a component needs different verbiage than an `@copyDoc` description, either:
+In some cases a component may need different verbiage than the default description in `@copyDoc`. For example, most `heading` properties use the verbiage "Specifies the component's heading text." List Item Group uses the more specific description "Specifies the heading text for the nested `calcite-list-item` rows."
+To facilitate using a component-specific description either:
 
-- Use override functions, such as the [`heading` property in api-extractor.config.ts](../api-extractor.config.ts).
-- Add a description in the component file and don't use `@copyDoc`.
+- Use override functions, such as the [`heading` property in api-extractor.config.ts](../api-extractor.config.ts). Name each override function after the target property, method, or event. Override functions give access to API metadata which can be used to customize `@copyDoc` definitions.
+
+  In the override function example below, the `heading` property uses `apiClass.name` to return a specific value for List Item Group.
+
+  ```ts
+  copyDocDefinitions: {
+    properties: {
+      heading(_apiProperty, apiClass) {
+        const descriptionOverrides: Record<string, string> = {
+          ListItemGroup: "Specifies the heading text for the nested `calcite-list-item` rows.",
+        };
+
+        return {
+          description: descriptionOverrides[apiClass.name] ?? "Specifies the component's heading text.",
+        };
+      },
+  ...
+  ```
+
+  Add the typical `@copyDoc` tag in the component `.tsx` file.
+
+  ```tsx
+  /** @copyDoc */
+  @property({ reflect: true }) heading?: string;
+  ```
+
+- Add a description directly in the component file instead of using `@copyDoc`. Even when a matching `@copyDoc` definition exists, you can choose not to use it and provide a separate description in the component’s .tsx file instead. Below is an example for List Item Group's `heading` property:
+  ```tsx
+  /** Specifies the heading text for the nested `calcite-list-item` rows. */
+  @property({ reflect: true }) heading?: string;
+  ```
 
 For additional guidance, review the Web GIS reference `@copyDoc` documentation.
 

--- a/packages/components/conventions/Documentation.md
+++ b/packages/components/conventions/Documentation.md
@@ -27,9 +27,9 @@ Usage: Use `@copyDoc` when the same description is shared across multiple compon
 
 ```js
 /**
-@copyDoc
-@deprecated in v5.1.0, removal target v6.0.0 - This property has no effect on the component.
-*/
+ * @copyDoc
+ * @deprecated in v5.1.0, removal target v6.0.0 - This property has no effect on the component.
+ */
 ```
 
 Supported sections: `properties`, `methods`, and `events`

--- a/packages/components/conventions/Documentation.md
+++ b/packages/components/conventions/Documentation.md
@@ -25,12 +25,12 @@ Usage: Use `@copyDoc` when the same description is shared across multiple compon
 - Add shared definitions in [api-extractor.config.ts](../api-extractor.config.ts) within `copyDocDefinitions`.
 - Use the `@copyDoc` tag in the component file in place of the description. Other tags, such as `@deprecated` or `@required`, can still be used in conjunction with `@copyDoc`. Example:
 
-```js
-/**
- * @copyDoc
- * @deprecated in v5.1.0, removal target v6.0.0 - This property has no effect on the component.
- */
-```
+  ```js
+  /**
+   * @copyDoc
+   * @deprecated in v5.1.0, removal target v6.0.0 - This property has no effect on the component.
+   */
+  ```
 
 `@copyDoc` support
 

--- a/packages/components/conventions/Documentation.md
+++ b/packages/components/conventions/Documentation.md
@@ -20,10 +20,10 @@ Follow these conventions when adding or editing API reference:
 
 ### Shared definitions using `@copyDoc`
 
-Usage: Use `@copyDoc` when the same description is shared across multiple components.
+When a description is shared across multiple components, the `@copyDoc` tag should be used. This improves consistency and reduces repetition.
 
 - Add shared definitions in [api-extractor.config.ts](../api-extractor.config.ts) within `copyDocDefinitions`.
-- Use the `@copyDoc` tag in the component file in place of the description. Other tags, such as `@deprecated` or `@required`, can still be used in conjunction with `@copyDoc`. Example:
+- Use the `@copyDoc` tag in the component file in place of the description. Other tags, such as `@deprecated` or `@required`, can still be used in conjunction with `@copyDoc`:
 
   ```js
   /**
@@ -32,7 +32,7 @@ Usage: Use `@copyDoc` when the same description is shared across multiple compon
    */
   ```
 
-`@copyDoc` support
+`@copyDoc` support:
 
 - Supported sections: `properties`, `methods`, and `events`
 - Unsupported sections: `slots`
@@ -40,7 +40,7 @@ Usage: Use `@copyDoc` when the same description is shared across multiple compon
 
 If a component needs different verbiage than an `@copyDoc` description, either:
 
-- Use override functions as seen for the [`heading` property in api-extractor.config.ts](../api-extractor.config.ts).
+- Use override functions, such as the [`heading` property in api-extractor.config.ts](../api-extractor.config.ts).
 - Add a description in the component file and don't use `@copyDoc`.
 
 For additional guidance, review the Web GIS reference `@copyDoc` documentation.

--- a/packages/components/conventions/Documentation.md
+++ b/packages/components/conventions/Documentation.md
@@ -34,7 +34,7 @@ Descriptions that are shared across components should use the `@copyDoc` tag to 
 
 To add shared component documentation definitions, perform the following:
 
-- Add a shared definition in the [api-extractor.config.ts file](../api-extractor.config.ts) within the `copyDocDefinitions` object. The `copyDocDefinitions` object stores shared documentation definitions by section, such as `properties`, `methods`, and `events`. The example below adds a shared definition for the `checked` property.
+- Add a shared definition in the [api-extractor.config.ts file](../api-extractor.config.ts) within the `copyDocDefinitions` object. The `copyDocDefinitions` object stores shared documentation definitions by section, such as `properties`, `methods`, and `events`. For example with the `properties` section:
   ```ts
   copyDocDefinitions: {
     properties: {
@@ -62,9 +62,9 @@ To add shared component documentation definitions, perform the following:
 In some cases a component may need different verbiage than the default description in `@copyDoc`. For example, most `heading` properties use the verbiage "Specifies the component's heading text." List Item Group uses the more specific description "Specifies the heading text for the nested `calcite-list-item` rows."
 To facilitate using a component-specific description either:
 
-- Use override functions, such as the [`heading` property in api-extractor.config.ts](../api-extractor.config.ts). Name each override function after the target property, method, or event. Override functions give access to API metadata which can be used to customize `@copyDoc` definitions.
+- Use override functions, such as the [`heading` property in api-extractor.config.ts](../api-extractor.config.ts). Name each override function after the target `property`, `method`, or `event` section. Override functions give access to API metadata which can be used to customize `@copyDoc` definitions.
 
-  In the override function example below, the `heading` property uses `apiClass.name` to return a specific value for List Item Group.
+  - In the override function example below, the `heading` property uses `apiClass.name` to return a specific value for List Item Group.
 
   ```ts
   copyDocDefinitions: {
@@ -81,20 +81,20 @@ To facilitate using a component-specific description either:
   ...
   ```
 
-  Add the typical `@copyDoc` tag in the component `.tsx` file.
+  - Add the `@copyDoc` tag in the component `.tsx` file.
 
   ```tsx
   /** @copyDoc */
   @property({ reflect: true }) heading?: string;
   ```
 
-- Add a description directly in the component file instead of using `@copyDoc`. Even when a matching `@copyDoc` definition exists, you can choose not to use it and provide a separate description in the component’s .tsx file instead. Below is an example for List Item Group's `heading` property:
+- Add a description directly in the component file instead of using `@copyDoc`. When a matching `@copyDoc` definition exists, you can choose not to use it and provide a separate description in the component’s .tsx file instead. For instance:
   ```tsx
   /** Specifies the heading text for the nested `calcite-list-item` rows. */
   @property({ reflect: true }) heading?: string;
   ```
 
-For additional guidance, review the Web GIS reference `@copyDoc` documentation.
+For additional guidance, review the Web GIS Resources `@copyDoc` documentation within the API Extractor's "Tag reference" section.
 
 ### Deprecation notices
 

--- a/packages/components/conventions/Documentation.md
+++ b/packages/components/conventions/Documentation.md
@@ -32,9 +32,11 @@ Usage: Use `@copyDoc` when the same description is shared across multiple compon
  */
 ```
 
-Supported sections: `properties`, `methods`, and `events`
+`@copyDoc` support
 
-Unsupported sections: `slots`
+- Supported sections: `properties`, `methods`, and `events`
+- Unsupported sections: `slots`
+- Supported fields: `deprecated`, `description`, `docsTags`, `readonly`, and `return`
 
 If a component needs different verbiage than an `@copyDoc` description, either:
 

--- a/packages/components/conventions/Documentation.md
+++ b/packages/components/conventions/Documentation.md
@@ -20,13 +20,15 @@ Follow these conventions when adding or editing API reference:
 
 ### Shared definitions using `@copyDoc`
 
-Descriptions that are shared across components should use the @copyDoc tag to improve consistency and reduce repetition in the repository.
+Descriptions that are shared across components should use the `@copyDoc` tag to improve consistency and reduce repetition in the repository.
 
 #### Support
 
-- Supported sections: `properties`, `methods`, and `events`
-- Unsupported sections: `slots`
-- Supported fields: `deprecated`, `description`, `docsTags`, `readonly`, and `return`
+- @copyDoc support includes:
+  - Sections: properties, methods, and events
+  - Fields: deprecated, description, docTags, readonly, and return
+- Unsupported in @copyDoc:
+  - Sections: slots
 
 #### Usage
 


### PR DESCRIPTION
**Related Issue:** #14293 

## Summary
Add supporting documentation for `@copydoc` usage. 

`@copydoc` functionality was added in PR #14628