### PR TITLE
test(input): stabilize keyboard nudging test

### DIFF
--- a/packages/components/src/components/input/input.browser.e2e.tsx
+++ b/packages/components/src/components/input/input.browser.e2e.tsx
@@ -861,7 +861,7 @@ describe("input type number increment/decrement functionality", () => {
     // dispatching synthetic events best emulates the original use case from https://github.com/Esri/calcite-design-system/pull/3908
     // otherwise, `userEvent.keyboard` emits 2 additional events due to async nature
     function dispatchKeyboardEvent(type: "keydown" | "keyup", key: "ArrowUp" | "ArrowDown"): void {
-      input.dispatchEvent(new KeyboardEvent(type, { key }));
+      input.dispatchEvent(new KeyboardEvent(type, { key, bubbles: true, cancelable: true, composed: true }));
     }
 
     dispatchKeyboardEvent("keydown", "ArrowUp");

--- a/packages/components/src/components/input/input.browser.e2e.tsx
+++ b/packages/components/src/components/input/input.browser.e2e.tsx
@@ -861,9 +861,12 @@ describe("input type number increment/decrement functionality", () => {
     // dispatching synthetic events best emulates the original use case from https://github.com/Esri/calcite-design-system/pull/3908
     // otherwise, `userEvent.keyboard` emits 2 additional events due to async nature
     function dispatchKeyboardEvent(type: "keydown" | "keyup", key: "ArrowUp" | "ArrowDown"): void {
-      input.dispatchEvent(new KeyboardEvent(type, { key, bubbles: true, cancelable: true, composed: true }));
+      input.dispatchEvent(
+        new KeyboardEvent(type, { key, bubbles: true, cancelable: true, composed: true }),
+      );
     }
 
+    await userEvent.keyboard("{Tab}");
     dispatchKeyboardEvent("keydown", "ArrowUp");
     dispatchKeyboardEvent("keydown", "ArrowDown");
     dispatchKeyboardEvent("keyup", "ArrowUp");

--- a/packages/components/src/components/input/input.browser.e2e.tsx
+++ b/packages/components/src/components/input/input.browser.e2e.tsx
@@ -856,14 +856,19 @@ describe("input type number increment/decrement functionality", () => {
     const { el } = await mount<Input>(<calcite-input type="number" value="0" />);
     const inputEventHandler = vi.fn();
     el.addEventListener("calciteInputInput", inputEventHandler);
+    const input = page.getBySelector("calcite-input input").element();
 
-    await el.setFocus();
-    await Promise.all([
-      userEvent.keyboard("{ArrowUp}"),
-      userEvent.keyboard("{ArrowUp}"),
-      userEvent.keyboard("{ArrowDown}"),
-      userEvent.keyboard("{ArrowDown}"),
-    ]);
+    // dispatching synthetic events best emulates the original use case from https://github.com/Esri/calcite-design-system/pull/3908
+    // otherwise, `userEvent.keyboard` emits 2 additional events due to async nature
+    function dispatchKeyboardEvent(type: "keydown" | "keyup", key: "ArrowUp" | "ArrowDown"): void {
+      input.dispatchEvent(new KeyboardEvent(type, { key }));
+    }
+
+    dispatchKeyboardEvent("keydown", "ArrowUp");
+    dispatchKeyboardEvent("keydown", "ArrowDown");
+    dispatchKeyboardEvent("keyup", "ArrowUp");
+    dispatchKeyboardEvent("keyup", "ArrowDown");
+    vi.advanceTimersByTime(1000);
 
     expect(inputEventHandler).toHaveBeenCalledTimes(2);
   });

--- a/packages/components/src/components/input/input.browser.e2e.tsx
+++ b/packages/components/src/components/input/input.browser.e2e.tsx
@@ -868,7 +868,7 @@ describe("input type number increment/decrement functionality", () => {
     dispatchKeyboardEvent("keydown", "ArrowDown");
     dispatchKeyboardEvent("keyup", "ArrowUp");
     dispatchKeyboardEvent("keyup", "ArrowDown");
-    vi.advanceTimersByTime(1000);
+    vi.advanceTimersByTime(delayFor2UpdatesInMs + 1);
 
     expect(inputEventHandler).toHaveBeenCalledTimes(2);
   });


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Stabilizes the following test that was likely flaky due to parallel `userEvent.keyboard` calls:

```
src/components/input/input.browser.e2e.tsx > input type number increment/decrement functionality > on input type number, should emit event only twice when toggled fast between up/down arrows
```