### PR TITLE
refactor(tokens): update token deprecation strategy (option 2.1)

### DIFF
--- a/packages/design-tokens/src/build/filter/core.ts
+++ b/packages/design-tokens/src/build/filter/core.ts
@@ -4,7 +4,10 @@ import type { RegisterFn } from "../../types/interfaces.d.ts";
 import { isLightOrDarkColorToken } from "./light-or-dark.ts";
 
 export const filterCoreTokens: Filter["filter"] = (token, config) =>
-  !token.isSource && token.$type !== "typography" && !isLightOrDarkColorToken(token, config);
+  !token.isSource &&
+  token.path[0] !== "internal" &&
+  token.$type !== "typography" &&
+  !isLightOrDarkColorToken(token, config);
 
 export const registerFilterCoreTokens: RegisterFn = () =>
   StyleDictionary.registerFilter({

--- a/packages/design-tokens/src/build/filter/index.ts
+++ b/packages/design-tokens/src/build/filter/index.ts
@@ -10,6 +10,7 @@ import { registerFilterGlobalTokens } from "./global.ts";
 import { registerFilterLightOrDarkColorTokens } from "./light-or-dark.ts";
 import { registerFilterGlobalTokensJs } from "./global-js.ts";
 import { registerFilterEs6BreakpointTokens } from "./es6-breakpoints.ts";
+import { registerFilterInternalTokens } from "./internal.ts";
 
 export function registerFilters(): void {
   registerFilterBreakpointTokens();
@@ -21,6 +22,7 @@ export function registerFilters(): void {
   registerFilterLightColorTokens();
   registerFilterLightOrDarkColorTokens();
   registerFilterTypographyTokens();
+  registerFilterInternalTokens();
   registerFilterCoreTokens();
   registerFilterSourceTokens();
   registerFilterIncludeTokens();
@@ -32,6 +34,7 @@ export { FilterSemanticTokens } from "./semantic.ts";
 export { FilterBreakpointTokens } from "./breakpoints.ts";
 export { FilterEs6BreakpointTokens } from "./es6-breakpoints.ts";
 export { FilterCoreTokens } from "./core.ts";
+export { FilterInternalTokens } from "./internal.ts";
 export { FilterLightColorTokens } from "./light.ts";
 export { FilterDarkColorTokens } from "./dark.ts";
 export { FilterLightOrDarkColorTokens } from "./light-or-dark.ts";

--- a/packages/design-tokens/src/build/filter/internal.ts
+++ b/packages/design-tokens/src/build/filter/internal.ts
@@ -1,0 +1,13 @@
+import type { Filter } from "style-dictionary/types";
+import StyleDictionary from "style-dictionary";
+import type { RegisterFn } from "../../types/interfaces.d.ts";
+
+export const filterInternalTokens: Filter["filter"] = (token) => !token.isSource && token.path[0] === "internal";
+
+export const registerFilterInternalTokens: RegisterFn = () =>
+  StyleDictionary.registerFilter({
+    name: FilterInternalTokens,
+    filter: filterInternalTokens,
+  });
+
+export const FilterInternalTokens = "calcite/filter/tokens/internal";

--- a/packages/design-tokens/src/config/index.ts
+++ b/packages/design-tokens/src/config/index.ts
@@ -28,7 +28,7 @@ const stylesheetOutputReferences: OutputReferences = (token, options) => {
 
 const config: Config = {
   source: ["src/tokens/semantic/[!$]*.json"],
-  include: ["src/tokens/core/[!$]*.json", "src/tokens/semantic/color/[!$]*.json"],
+  include: ["src/tokens/core/[!$]*.json", "src/tokens/internal/[!$]*.json", "src/tokens/semantic/color/[!$]*.json"],
   preprocessors: [
     "tokens-studio",
     preprocessors.PreprocessorStorePostMergeDictionary,
@@ -54,6 +54,11 @@ const config: Config = {
           filter: filters.FilterSemanticTokens,
         },
         {
+          destination: "internal.scss",
+          format: sdFormats.scssVariables,
+          filter: filters.FilterInternalTokens,
+        },
+        {
           destination: "core.scss",
           format: sdFormats.scssVariables,
           filter: filters.FilterCoreTokens,
@@ -73,7 +78,7 @@ const config: Config = {
           format: formats.FormatIndex,
           filter: filters.FilterLightOrDarkColorTokens,
           options: {
-            imports: ["semantic", "breakpoints", "mixins"],
+            imports: ["internal", "semantic", "breakpoints", "mixins"],
           },
         },
       ],
@@ -109,6 +114,11 @@ const config: Config = {
           filter: filters.FilterSemanticTokens,
         },
         {
+          destination: "internal.css",
+          format: sdFormats.cssVariables,
+          filter: filters.FilterInternalTokens,
+        },
+        {
           destination: "core.css",
           format: sdFormats.cssVariables,
           filter: filters.FilterCoreTokens,
@@ -128,7 +138,7 @@ const config: Config = {
           format: formats.FormatIndex,
           filter: filters.FilterLightOrDarkColorTokens,
           options: {
-            imports: ["semantic", "classes"],
+            imports: ["internal", "semantic", "classes"],
           },
         },
       ],
@@ -194,6 +204,16 @@ const config: Config = {
           filter: filters.FilterSemanticTokens,
         },
         {
+          destination: "internal.js",
+          format: sdFormats.javascriptEs6,
+          filter: filters.FilterInternalTokens,
+        },
+        {
+          destination: "internal.d.ts",
+          format: sdFormats.typescriptEs6Declarations,
+          filter: filters.FilterInternalTokens,
+        },
+        {
           destination: "core.js",
           format: sdFormats.javascriptEs6,
           filter: filters.FilterCoreTokens,
@@ -246,6 +266,11 @@ const config: Config = {
           destination: "semantic.json",
           format: formats.FormatCalciteDocs,
           filter: filters.FilterSemanticTokens,
+        },
+        {
+          destination: "internal.json",
+          format: formats.FormatCalciteDocs,
+          filter: filters.FilterInternalTokens,
         },
         {
           destination: "core.json",

--- a/packages/design-tokens/src/tokens/internal/font.json
+++ b/packages/design-tokens/src/tokens/internal/font.json
@@ -1,0 +1,32 @@
+{
+  "internal": {
+    "font": {
+      "weight": {
+        "light": {
+          "$value": "{core.font.weight.light}",
+          "$type": "fontWeights"
+        },
+        "normal": {
+          "$value": "{core.font.weight.regular}",
+          "$type": "fontWeights"
+        },
+        "regular": {
+          "$value": "{core.font.weight.regular}",
+          "$type": "fontWeights"
+        },
+        "medium": {
+          "$value": "{core.font.weight.medium}",
+          "$type": "fontWeights"
+        },
+        "semibold": {
+          "$value": "{core.font.weight.demi}",
+          "$type": "fontWeights"
+        },
+        "bold": {
+          "$value": "{core.font.weight.demi}",
+          "$type": "fontWeights"
+        }
+      }
+    }
+  }
+}

--- a/packages/design-tokens/src/tokens/semantic/font.json
+++ b/packages/design-tokens/src/tokens/semantic/font.json
@@ -22,7 +22,7 @@
     },
     "weight": {
       "light": {
-        "$value": "{core.font.weight.light}",
+        "$value": "{internal.font.weight.light}",
         "$description": "For Avenir Next World (secondary font family)",
         "$type": "fontWeights",
         "attributes": {
@@ -31,7 +31,7 @@
         }
       },
       "normal": {
-        "$value": "{core.font.weight.regular}",
+        "$value": "{internal.font.weight.normal}",
         "$description": "Deprecated in v3.0.0, removal target v5.0.0 - Use `--calcite-font-weight-regular` instead.",
         "$type": "fontWeights",
         "attributes": {
@@ -56,7 +56,7 @@
         }
       },
       "medium": {
-        "$value": "{core.font.weight.medium}",
+        "$value": "{internal.font.weight.medium}",
         "$type": "fontWeights",
         "attributes": {
           "category": "font",
@@ -64,7 +64,7 @@
         }
       },
       "semibold": {
-        "$value": "{core.font.weight.demi}",
+        "$value": "{internal.font.weight.semibold}",
         "$type": "fontWeights",
         "attributes": {
           "category": "font",
@@ -72,7 +72,7 @@
         }
       },
       "bold": {
-        "$value": "{core.font.weight.demi}",
+        "$value": "{internal.font.weight.bold}",
         "$type": "fontWeights",
         "attributes": {
           "category": "font",

--- a/packages/design-tokens/tests/spec/__snapshots__/index.spec.ts.snap
+++ b/packages/design-tokens/tests/spec/__snapshots__/index.spec.ts.snap
@@ -1004,11 +1004,6 @@ exports[`CSS > global should match 1`] = `
   --calcite-corner-radius-pill: 9999px;
   --calcite-font-family: 'Avenir Next', Avenir, 'Helvetica Neue', sans-serif; /** Primary font with fallbacks */
   --calcite-font-family-code: Monaco, Consolas, 'Andale Mono', 'Lucida Console', monospace; /** Font family for code with fallbacks */
-  --calcite-font-weight-light: 300; /** For Avenir Next World (secondary font family) */
-  --calcite-font-weight-normal: 400; /** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-font-weight-regular\` instead. */
-  --calcite-font-weight-medium: 500;
-  --calcite-font-weight-semibold: 600;
-  --calcite-font-weight-bold: 600;
   --calcite-font-size-xs: 10px;
   --calcite-font-size-sm: 12px;
   --calcite-font-size: 14px;
@@ -1148,6 +1143,11 @@ exports[`CSS > global should match 1`] = `
   --calcite-z-index-popup: 900;
   --calcite-z-index-tooltip: 901;
   --calcite-corner-radius: var(--calcite-corner-radius-none);
+  --calcite-font-weight-light: 300; /** For Avenir Next World (secondary font family) */
+  --calcite-font-weight-normal: 400; /** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-font-weight-regular\` instead. */
+  --calcite-font-weight-medium: 500;
+  --calcite-font-weight-semibold: 600;
+  --calcite-font-weight-bold: 600;
   --calcite-font-weight-regular: var(--calcite-font-weight-normal); /** Replaces \`--calcite-font-weight-normal\` */
 }
 "
@@ -1159,6 +1159,7 @@ exports[`CSS > index should match 1`] = `
  * Do not edit directly, this file was auto-generated.
  */
 
+@import url("./internal.css");
 @import url("./semantic.css");
 @import url("./classes.css");
 :root {
@@ -1478,6 +1479,23 @@ exports[`CSS > index should match 1`] = `
 "
 `;
 
+exports[`CSS > internal should match 1`] = `
+"/**
+ * Calcite Design System
+ * Do not edit directly, this file was auto-generated.
+ */
+
+:root {
+  --calcite-internal-font-weight-light: 300;
+  --calcite-internal-font-weight-normal: 400;
+  --calcite-internal-font-weight-regular: 400;
+  --calcite-internal-font-weight-medium: 500;
+  --calcite-internal-font-weight-semibold: 600;
+  --calcite-internal-font-weight-bold: 600;
+}
+"
+`;
+
 exports[`CSS > light should match 1`] = `
 "/**
  * Calcite Design System
@@ -1562,11 +1580,6 @@ exports[`CSS > semantic should match 1`] = `
   --calcite-corner-radius-pill: 9999px;
   --calcite-font-family: 'Avenir Next', Avenir, 'Helvetica Neue', sans-serif; /** Primary font with fallbacks */
   --calcite-font-family-code: Monaco, Consolas, 'Andale Mono', 'Lucida Console', monospace; /** Font family for code with fallbacks */
-  --calcite-font-weight-light: 300; /** For Avenir Next World (secondary font family) */
-  --calcite-font-weight-normal: 400; /** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-font-weight-regular\` instead. */
-  --calcite-font-weight-medium: 500;
-  --calcite-font-weight-semibold: 600;
-  --calcite-font-weight-bold: 600;
   --calcite-font-size-xs: 10px;
   --calcite-font-size-sm: 12px;
   --calcite-font-size: 14px;
@@ -1706,6 +1719,11 @@ exports[`CSS > semantic should match 1`] = `
   --calcite-z-index-popup: 900;
   --calcite-z-index-tooltip: 901;
   --calcite-corner-radius: var(--calcite-corner-radius-none);
+  --calcite-font-weight-light: 300; /** For Avenir Next World (secondary font family) */
+  --calcite-font-weight-normal: 400; /** Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-font-weight-regular\` instead. */
+  --calcite-font-weight-medium: 500;
+  --calcite-font-weight-semibold: 600;
+  --calcite-font-weight-bold: 600;
   --calcite-font-weight-regular: var(--calcite-font-weight-normal); /** Replaces \`--calcite-font-weight-normal\` */
 }
 "
@@ -17515,6 +17533,156 @@ exports[`DOCS (internal) > core should match 1`] = `
       "isSource": false,
       "name": "Z Index 9",
       "path": ["core", "z-index", "9"]
+    },
+    {
+      "key": "{internal.font.weight.light}",
+      "$value": "300",
+      "$type": "fontWeight",
+      "filePath": "src/tokens/internal/font.json",
+      "isSource": false,
+      "name": "Internal Font Weight Light",
+      "attributes": {
+        "category": "internal",
+        "type": "font",
+        "item": "weight",
+        "subitem": "light",
+        "names": {
+          "scss": "$calcite-internal-font-weight-light",
+          "css": "var(--calcite-internal-font-weight-light)",
+          "docs": "internal.font.weight.light",
+          "es6": "calciteInternalFontWeightLight"
+        },
+        "calcite-schema": {
+          "system": "calcite",
+          "tier": "internal"
+        }
+      },
+      "path": ["internal", "font", "weight", "light"]
+    },
+    {
+      "key": "{internal.font.weight.normal}",
+      "$value": "400",
+      "$type": "fontWeight",
+      "filePath": "src/tokens/internal/font.json",
+      "isSource": false,
+      "name": "Internal Font Weight Normal",
+      "attributes": {
+        "category": "internal",
+        "type": "font",
+        "item": "weight",
+        "subitem": "normal",
+        "names": {
+          "scss": "$calcite-internal-font-weight-normal",
+          "css": "var(--calcite-internal-font-weight-normal)",
+          "docs": "internal.font.weight.normal",
+          "es6": "calciteInternalFontWeightNormal"
+        },
+        "calcite-schema": {
+          "system": "calcite",
+          "tier": "internal"
+        }
+      },
+      "path": ["internal", "font", "weight", "normal"]
+    },
+    {
+      "key": "{internal.font.weight.regular}",
+      "$value": "400",
+      "$type": "fontWeight",
+      "filePath": "src/tokens/internal/font.json",
+      "isSource": false,
+      "name": "Internal Font Weight Regular",
+      "attributes": {
+        "category": "internal",
+        "type": "font",
+        "item": "weight",
+        "subitem": "regular",
+        "names": {
+          "scss": "$calcite-internal-font-weight-regular",
+          "css": "var(--calcite-internal-font-weight-regular)",
+          "docs": "internal.font.weight.regular",
+          "es6": "calciteInternalFontWeightRegular"
+        },
+        "calcite-schema": {
+          "system": "calcite",
+          "tier": "internal"
+        }
+      },
+      "path": ["internal", "font", "weight", "regular"]
+    },
+    {
+      "key": "{internal.font.weight.medium}",
+      "$value": "500",
+      "$type": "fontWeight",
+      "filePath": "src/tokens/internal/font.json",
+      "isSource": false,
+      "name": "Internal Font Weight Medium",
+      "attributes": {
+        "category": "internal",
+        "type": "font",
+        "item": "weight",
+        "subitem": "medium",
+        "names": {
+          "scss": "$calcite-internal-font-weight-medium",
+          "css": "var(--calcite-internal-font-weight-medium)",
+          "docs": "internal.font.weight.medium",
+          "es6": "calciteInternalFontWeightMedium"
+        },
+        "calcite-schema": {
+          "system": "calcite",
+          "tier": "internal"
+        }
+      },
+      "path": ["internal", "font", "weight", "medium"]
+    },
+    {
+      "key": "{internal.font.weight.semibold}",
+      "$value": "600",
+      "$type": "fontWeight",
+      "filePath": "src/tokens/internal/font.json",
+      "isSource": false,
+      "name": "Internal Font Weight Semibold",
+      "attributes": {
+        "category": "internal",
+        "type": "font",
+        "item": "weight",
+        "subitem": "semibold",
+        "names": {
+          "scss": "$calcite-internal-font-weight-semibold",
+          "css": "var(--calcite-internal-font-weight-semibold)",
+          "docs": "internal.font.weight.semibold",
+          "es6": "calciteInternalFontWeightSemibold"
+        },
+        "calcite-schema": {
+          "system": "calcite",
+          "tier": "internal"
+        }
+      },
+      "path": ["internal", "font", "weight", "semibold"]
+    },
+    {
+      "key": "{internal.font.weight.bold}",
+      "$value": "600",
+      "$type": "fontWeight",
+      "filePath": "src/tokens/internal/font.json",
+      "isSource": false,
+      "name": "Internal Font Weight Bold",
+      "attributes": {
+        "category": "internal",
+        "type": "font",
+        "item": "weight",
+        "subitem": "bold",
+        "names": {
+          "scss": "$calcite-internal-font-weight-bold",
+          "css": "var(--calcite-internal-font-weight-bold)",
+          "docs": "internal.font.weight.bold",
+          "es6": "calciteInternalFontWeightBold"
+        },
+        "calcite-schema": {
+          "system": "calcite",
+          "tier": "internal"
+        }
+      },
+      "path": ["internal", "font", "weight", "bold"]
     }
   ]
 }
@@ -25369,6 +25537,165 @@ exports[`DOCS (internal) > global should match 1`] = `
 "
 `;
 
+exports[`DOCS (internal) > internal should match 1`] = `
+"{
+  "timestamp": "TEST_TIMESTAMP",
+  "tokens": [
+    {
+      "key": "{internal.font.weight.light}",
+      "$value": "300",
+      "$type": "fontWeight",
+      "filePath": "src/tokens/internal/font.json",
+      "isSource": false,
+      "name": "Internal Font Weight Light",
+      "attributes": {
+        "category": "internal",
+        "type": "font",
+        "item": "weight",
+        "subitem": "light",
+        "names": {
+          "scss": "$calcite-internal-font-weight-light",
+          "css": "var(--calcite-internal-font-weight-light)",
+          "docs": "internal.font.weight.light",
+          "es6": "calciteInternalFontWeightLight"
+        },
+        "calcite-schema": {
+          "system": "calcite",
+          "tier": "internal"
+        }
+      },
+      "path": ["internal", "font", "weight", "light"]
+    },
+    {
+      "key": "{internal.font.weight.normal}",
+      "$value": "400",
+      "$type": "fontWeight",
+      "filePath": "src/tokens/internal/font.json",
+      "isSource": false,
+      "name": "Internal Font Weight Normal",
+      "attributes": {
+        "category": "internal",
+        "type": "font",
+        "item": "weight",
+        "subitem": "normal",
+        "names": {
+          "scss": "$calcite-internal-font-weight-normal",
+          "css": "var(--calcite-internal-font-weight-normal)",
+          "docs": "internal.font.weight.normal",
+          "es6": "calciteInternalFontWeightNormal"
+        },
+        "calcite-schema": {
+          "system": "calcite",
+          "tier": "internal"
+        }
+      },
+      "path": ["internal", "font", "weight", "normal"]
+    },
+    {
+      "key": "{internal.font.weight.regular}",
+      "$value": "400",
+      "$type": "fontWeight",
+      "filePath": "src/tokens/internal/font.json",
+      "isSource": false,
+      "name": "Internal Font Weight Regular",
+      "attributes": {
+        "category": "internal",
+        "type": "font",
+        "item": "weight",
+        "subitem": "regular",
+        "names": {
+          "scss": "$calcite-internal-font-weight-regular",
+          "css": "var(--calcite-internal-font-weight-regular)",
+          "docs": "internal.font.weight.regular",
+          "es6": "calciteInternalFontWeightRegular"
+        },
+        "calcite-schema": {
+          "system": "calcite",
+          "tier": "internal"
+        }
+      },
+      "path": ["internal", "font", "weight", "regular"]
+    },
+    {
+      "key": "{internal.font.weight.medium}",
+      "$value": "500",
+      "$type": "fontWeight",
+      "filePath": "src/tokens/internal/font.json",
+      "isSource": false,
+      "name": "Internal Font Weight Medium",
+      "attributes": {
+        "category": "internal",
+        "type": "font",
+        "item": "weight",
+        "subitem": "medium",
+        "names": {
+          "scss": "$calcite-internal-font-weight-medium",
+          "css": "var(--calcite-internal-font-weight-medium)",
+          "docs": "internal.font.weight.medium",
+          "es6": "calciteInternalFontWeightMedium"
+        },
+        "calcite-schema": {
+          "system": "calcite",
+          "tier": "internal"
+        }
+      },
+      "path": ["internal", "font", "weight", "medium"]
+    },
+    {
+      "key": "{internal.font.weight.semibold}",
+      "$value": "600",
+      "$type": "fontWeight",
+      "filePath": "src/tokens/internal/font.json",
+      "isSource": false,
+      "name": "Internal Font Weight Semibold",
+      "attributes": {
+        "category": "internal",
+        "type": "font",
+        "item": "weight",
+        "subitem": "semibold",
+        "names": {
+          "scss": "$calcite-internal-font-weight-semibold",
+          "css": "var(--calcite-internal-font-weight-semibold)",
+          "docs": "internal.font.weight.semibold",
+          "es6": "calciteInternalFontWeightSemibold"
+        },
+        "calcite-schema": {
+          "system": "calcite",
+          "tier": "internal"
+        }
+      },
+      "path": ["internal", "font", "weight", "semibold"]
+    },
+    {
+      "key": "{internal.font.weight.bold}",
+      "$value": "600",
+      "$type": "fontWeight",
+      "filePath": "src/tokens/internal/font.json",
+      "isSource": false,
+      "name": "Internal Font Weight Bold",
+      "attributes": {
+        "category": "internal",
+        "type": "font",
+        "item": "weight",
+        "subitem": "bold",
+        "names": {
+          "scss": "$calcite-internal-font-weight-bold",
+          "css": "var(--calcite-internal-font-weight-bold)",
+          "docs": "internal.font.weight.bold",
+          "es6": "calciteInternalFontWeightBold"
+        },
+        "calcite-schema": {
+          "system": "calcite",
+          "tier": "internal"
+        }
+      },
+      "path": ["internal", "font", "weight", "bold"]
+    }
+  ]
+}
+"
+`;
+
 exports[`DOCS (internal) > semantic should match 1`] = `
 "{
   "timestamp": "TEST_TIMESTAMP",
@@ -31987,6 +32314,36 @@ export const calciteZIndexTooltip: string;
 "
 `;
 
+exports[`ES6 > internal should match 1`] = `
+"/**
+ * Calcite Design System
+ * Do not edit directly, this file was auto-generated.
+ */
+
+export const calciteInternalFontWeightLight = "300";
+export const calciteInternalFontWeightNormal = "400";
+export const calciteInternalFontWeightRegular = "400";
+export const calciteInternalFontWeightMedium = "500";
+export const calciteInternalFontWeightSemibold = "600";
+export const calciteInternalFontWeightBold = "600";
+"
+`;
+
+exports[`ES6 > internal types should match 1`] = `
+"/**
+ * Calcite Design System
+ * Do not edit directly, this file was auto-generated.
+ */
+
+export const calciteInternalFontWeightLight: string;
+export const calciteInternalFontWeightNormal: string;
+export const calciteInternalFontWeightRegular: string;
+export const calciteInternalFontWeightMedium: string;
+export const calciteInternalFontWeightSemibold: string;
+export const calciteInternalFontWeightBold: string;
+"
+`;
+
 exports[`ES6 > semantic should match 1`] = `
 "/**
  * Calcite Design System
@@ -33191,11 +33548,6 @@ $calcite-corner-radius-round: 4px; // Deprecated in v3.1.0, removal target v5.0.
 $calcite-corner-radius-pill: 9999px;
 $calcite-font-family: 'Avenir Next', Avenir, 'Helvetica Neue', sans-serif; // Primary font with fallbacks
 $calcite-font-family-code: Monaco, Consolas, 'Andale Mono', 'Lucida Console', monospace; // Font family for code with fallbacks
-$calcite-font-weight-light: 300; // For Avenir Next World (secondary font family)
-$calcite-font-weight-normal: 400; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-font-weight-regular\` instead.
-$calcite-font-weight-medium: 500;
-$calcite-font-weight-semibold: 600;
-$calcite-font-weight-bold: 600;
 $calcite-font-size-xs: 10px;
 $calcite-font-size-sm: 12px;
 $calcite-font-size: 14px;
@@ -33335,6 +33687,11 @@ $calcite-z-index-modal: 800;
 $calcite-z-index-popup: 900;
 $calcite-z-index-tooltip: 901;
 $calcite-corner-radius: $calcite-corner-radius-none;
+$calcite-font-weight-light: 300; // For Avenir Next World (secondary font family)
+$calcite-font-weight-normal: 400; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-font-weight-regular\` instead.
+$calcite-font-weight-medium: 500;
+$calcite-font-weight-semibold: 600;
+$calcite-font-weight-bold: 600;
 $calcite-font-weight-regular: $calcite-font-weight-normal; // Replaces \`--calcite-font-weight-normal\`
 "
 `;
@@ -33345,6 +33702,7 @@ exports[`SCSS > index should match 1`] = `
  * Do not edit directly, this file was auto-generated.
  */
 
+@use "./internal.scss";
 @use "./semantic.scss";
 @use "./breakpoints.scss";
 @use "./mixins.scss";
@@ -33472,6 +33830,20 @@ exports[`SCSS > index should match 1`] = `
   --calcite-color-surface-1: #212121;
   --calcite-color-focus: var(--calcite-color-brand);
 }
+"
+`;
+
+exports[`SCSS > internal should match 1`] = `
+"
+// Calcite Design System
+// Do not edit directly, this file was auto-generated.
+
+$calcite-internal-font-weight-light: 300;
+$calcite-internal-font-weight-normal: 400;
+$calcite-internal-font-weight-regular: 400;
+$calcite-internal-font-weight-medium: 500;
+$calcite-internal-font-weight-semibold: 600;
+$calcite-internal-font-weight-bold: 600;
 "
 `;
 
@@ -33884,11 +34256,6 @@ $calcite-corner-radius-round: 4px; // Deprecated in v3.1.0, removal target v5.0.
 $calcite-corner-radius-pill: 9999px;
 $calcite-font-family: 'Avenir Next', Avenir, 'Helvetica Neue', sans-serif; // Primary font with fallbacks
 $calcite-font-family-code: Monaco, Consolas, 'Andale Mono', 'Lucida Console', monospace; // Font family for code with fallbacks
-$calcite-font-weight-light: 300; // For Avenir Next World (secondary font family)
-$calcite-font-weight-normal: 400; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-font-weight-regular\` instead.
-$calcite-font-weight-medium: 500;
-$calcite-font-weight-semibold: 600;
-$calcite-font-weight-bold: 600;
 $calcite-font-size-xs: 10px;
 $calcite-font-size-sm: 12px;
 $calcite-font-size: 14px;
@@ -34028,6 +34395,11 @@ $calcite-z-index-modal: 800;
 $calcite-z-index-popup: 900;
 $calcite-z-index-tooltip: 901;
 $calcite-corner-radius: $calcite-corner-radius-none;
+$calcite-font-weight-light: 300; // For Avenir Next World (secondary font family)
+$calcite-font-weight-normal: 400; // Deprecated in v3.0.0, removal target v5.0.0 - Use \`--calcite-font-weight-regular\` instead.
+$calcite-font-weight-medium: 500;
+$calcite-font-weight-semibold: 600;
+$calcite-font-weight-bold: 600;
 $calcite-font-weight-regular: $calcite-font-weight-normal; // Replaces \`--calcite-font-weight-normal\`
 "
 `;

--- a/packages/design-tokens/tests/spec/index.spec.ts
+++ b/packages/design-tokens/tests/spec/index.spec.ts
@@ -10,11 +10,14 @@ const platforms: {
 }[] = [
   {
     name: "css",
-    files: ["breakpoints", "classes", "core", "dark", "global", "index", "light", "semantic"],
+    files: ["breakpoints", "classes", "core", "dark", "global", "index", "internal", "light", "semantic"],
   },
-  { name: "scss", files: ["breakpoints", "core", "dark", "global", "index", "light", "mixins", "semantic"] },
-  { name: "es6", files: ["breakpoints", "core", "global", "semantic"] },
-  { name: "docs", files: ["core", "global", "semantic"], internal: true },
+  {
+    name: "scss",
+    files: ["breakpoints", "core", "dark", "global", "index", "internal", "light", "mixins", "semantic"],
+  },
+  { name: "es6", files: ["breakpoints", "core", "global", "internal", "semantic"] },
+  { name: "docs", files: ["core", "global", "internal", "semantic"], internal: true },
 ];
 
 platforms.forEach(({ name, files, internal }) => generateTests(name, files, internal));


### PR DESCRIPTION
**Related Issue:** #14190

### Option 2.1: The same as option 2 (PR #14655), but with an added internal token layer to obscure token mapping

## Summary

Note: This PR is using [`matgalla/14190-update-token-deprecation-strategy-2`](https://github.com/Esri/calcite-design-system/pull/14655/changes) as the head to clarify the differences between them

### Unique changes in this PR vs option 2.0:
- adds internal token layer for semantic tokens to reference
- updates src tokens to account for Tokens Studio's inability to handle fallbacks

### Updates to make once proof-of-concept is reviewed
- If this is the preferred method, then these changes can be merged into the option 2.0 branch