### PR TITLE
ci(actions): replace `Stalled` milestone with `paused` label

### DIFF
--- a/.github/scripts/support/monday.js
+++ b/.github/scripts/support/monday.js
@@ -136,7 +136,7 @@ module.exports = function Monday(issue, core, updateIssueBody) {
     designEstimate: { id: "numeric_mkw8yzkt", title: "Design Estimate" },
     devEstimate: { id: "numeric_mkswahrw", title: "Dev Estimate" },
     designIssue: { id: "color_mkswbke0", title: "Design Issue" },
-    stalled: { id: "color_mkv79bbx", title: "Stalled" },
+    paused: { id: "color_mkv79bbx", title: "Paused" },
     blocked: { id: "color_mkv7x1gw", title: "Blocked" },
     breaking: { id: "color_mm48xr8j", title: "Breaking" },
     spike: { id: "color_mkrt20dy", title: "Spike" },
@@ -488,10 +488,10 @@ module.exports = function Monday(issue, core, updateIssueBody) {
       },
     ],
     [
-      milestones.stalled.name,
+      planning.paused,
       {
-        column: mondayColumns.stalled,
-        value: "Stalled",
+        column: mondayColumns.paused,
+        value: "Paused",
         clearable: true,
       },
     ],
@@ -994,7 +994,6 @@ module.exports = function Monday(issue, core, updateIssueBody) {
     const logParams = { title: "Handle Milestone" };
     if (!issueMilestone) {
       setColumnValue(mondayColumns.date, "", logParams);
-      clearLabel(milestones.stalled.name);
       return;
     }
     const milestoneTitle = issueMilestone.title;
@@ -1003,7 +1002,6 @@ module.exports = function Monday(issue, core, updateIssueBody) {
 
     if (milestoneDate) {
       setColumnValue(mondayColumns.date, milestoneDate, logParams);
-      clearLabel(milestones.stalled.name);
       const { needsTriage, installed, readyForDev } = issueWorkflow;
       setAssignedStatus({
         assignedCondition: notInLifecycle({
@@ -1015,11 +1013,8 @@ module.exports = function Monday(issue, core, updateIssueBody) {
     } else {
       setColumnValue(mondayColumns.date, "", logParams);
 
-      if (milestoneTitle === milestones.stalled.name) {
-        addLabel(milestones.stalled.name);
-      } else if (inMilestoneStatus()) {
+      if (inMilestoneStatus()) {
         setColumnValue(mondayColumns.status, milestoneTitle, logParams);
-        clearLabel(milestones.stalled.name);
       }
     }
   }

--- a/.github/scripts/support/resources.js
+++ b/.github/scripts/support/resources.js
@@ -42,6 +42,7 @@ const resources = {
       breakingChange: "breaking change",
       futureBreakingChange: "future breaking change",
       monday: "monday.com sync",
+      paused: "paused",
     },
     priority: {
       low: "p - low",
@@ -76,7 +77,6 @@ const resources = {
   },
   milestones: {
     backlog: { name: "Backlog", number: 154 },
-    stalled: { name: "Stalled", number: 75 },
     freezer: { name: "Freezer", number: 28 },
   },
   teams: {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,14 @@ Lifecycle labels are used to communicate the state of an issue. Each issue can o
 - `4 - installed`: Issues that have been merged to the `dev` branch and/or are ready for QA/QC.
 - `5 - verified`: Issues that have been tested, confirmed as mitigated, and are ready to close.
 
+### Paused issue process
+
+When work has begun on an issue, but has paused for varying reasons (e.g., priorities shifting, waiting on a meeting or individual), the `paused` label should be added. This helps ensure the issue's status is clearly communicated, aiding in the prioritization and planning process.
+
+When adding the `paused` label, add a comment to the issue stating **why** it has been paused and if predictable, when work is expected to resume. No other lifecycle label change is needed.
+
+Paused issues may be moved into future milestones or the `Backlog` by PEs, depending on when work is expected to resume and the priority of the issue.
+
 ### Issues that cannot be worked on
 
 Certain labels indicate that an issue is not ready for development:
@@ -120,7 +128,6 @@ When the `needs refinement` label is added to an issue, additional information o
 
 Milestones are used to organize issues targeted for a sprint in a planned release, and are not closed until all of the issues are verified. We have multiple milestones open at a time to help with future sprint planning. Calcite Core team members should grab issues from the current milestone when you are looking for something to work on. External contributors should ask before working on issues in upcoming milestones, since some of them need to be completed in a timely manner. There are also two constant milestones:
 
-- **Stalled:** Issues we want to work on now, but are blocked, missing information, or require discussion to define action items. Try not to work on these issues unless an issue has a `spike` label and the research can be added to the issue for consideration in a future sprint.
 - **Freezer:** Items that we want to look into, but do not have an immediate timeline associated. Try not to work on these issues unless they have a `help wanted` label.
 
 ### Estimates

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,13 +82,13 @@ Lifecycle labels are used to communicate the state of an issue. Each issue can o
 - `4 - installed`: Issues that have been merged to the `dev` branch and/or are ready for QA/QC.
 - `5 - verified`: Issues that have been tested, confirmed as mitigated, and are ready to close.
 
-### Paused issue process
+### Paused issues
 
-When work has begun on an issue, but has paused for varying reasons (e.g., priorities shifting, waiting on a meeting or individual), the `paused` label should be added. This helps ensure the issue's status is clearly communicated, aiding in the prioritization and planning process.
+When work has begun on an issue, but has paused for varying reasons (e.g., priorities shifting, waiting on a meeting or individual), the `paused` label is added. The label ensures the issue's status is clearly communicated, aiding in the prioritization and planning process.
 
 When adding the `paused` label, add a comment to the issue stating **why** it has been paused and if predictable, when work is expected to resume. No other lifecycle label change is needed.
 
-Paused issues may be moved into future milestones or the `Backlog` by PEs, depending on when work is expected to resume and the priority of the issue.
+Paused issues may be moved into future milestones or the `Backlog` milestone by Calcite contributing members, depending on when work is expected to resume and the priority of the issue.
 
 ### Issues that cannot be worked on
 


### PR DESCRIPTION
**Related Issue:** #14666

## Summary

Replaces the `Stalled` milestone in workflows and docs with the new `paused` label. As part of the new usage of `paused`, there is no need to clear the `Paused` (formerly `Stalled`) column when the milestone changes.

Test runs done from this branch for the associated issue, and all worked as expected. View the action summaries below to see the behavior:
- [Add `paused` label](https://github.com/Esri/calcite-design-system/actions/runs/27842683648)
- [Remove `paused` label](https://github.com/Esri/calcite-design-system/actions/runs/27842733373)
- [Change milestone - should no longer clear `Paused` column](https://github.com/Esri/calcite-design-system/actions/runs/27842766159)
