### PR TITLE
ci(actions): sync milestone title and date to Monday

### DIFF
--- a/.github/scripts/support/monday.js
+++ b/.github/scripts/support/monday.js
@@ -99,9 +99,7 @@ module.exports = function Monday(issue, core, updateIssueBody) {
 
   /**
    * Return the appropriate Monday.com column ID based on repository context.
-   * @param {object} columnIds - An object containing the column IDs for each repository
-   * @param {string} columnIds.calcite - The column ID for the Calcite repository
-   * @param {string} columnIds.docs - The column ID for the Docs repository
+   * @param {{ calcite: string; docs: string }} columnIds - An object containing the column IDs for each repository
    * @return {string} - The appropriate column ID for the current repository
    */
   function getColumnId(columnIds) {

--- a/.github/scripts/support/monday.js
+++ b/.github/scripts/support/monday.js
@@ -97,6 +97,21 @@ module.exports = function Monday(issue, core, updateIssueBody) {
     return usernameMap[publicUsername] || publicUsername;
   }
 
+  /**
+   * Return the appropriate Monday.com column ID based on repository context.
+   * @param {object} columnIds - An object containing the column IDs for each repository
+   * @param {string} columnIds.calcite - The column ID for the Calcite repository
+   * @param {string} columnIds.docs - The column ID for the Docs repository
+   * @return {string} - The appropriate column ID for the current repository
+   */
+  function getColumnId(columnIds) {
+    if (GITHUB_REPO === REPO_DOCS) {
+      return columnIds.docs;
+    }
+
+    return columnIds.calcite;
+  }
+
   /** @typedef {object} MondayColumn
    * @property {string} id - The Monday.com column ID
    * @property {string} title - The Monday.com column title. Used for logging, not critical to functionality
@@ -125,7 +140,14 @@ module.exports = function Monday(issue, core, updateIssueBody) {
       type: "multiAppendable",
     },
     status: { id: "dup__of_overall_status__1", title: "Status" },
-    date: { id: "date6", title: "Milestone" },
+    milestoneTitle: {
+      id: getColumnId({
+        calcite: "text_mm4fjj0n",
+        docs: "text_mm4fbb1a",
+      }),
+      title: "Milestone",
+    },
+    milestoneDate: { id: "date6", title: "Milestone Date" },
     priority: { id: "priority", title: "Priority" },
     typeDropdown: {
       id: "dropdown_mkwhjde2",
@@ -988,35 +1010,31 @@ module.exports = function Monday(issue, core, updateIssueBody) {
   }
 
   /**
-   * Update columnUpdates based on milestone title
+   * Update columnUpdates based on milestone values.
+   * If no milestone is present, the milestone columns are cleared.
    */
   function handleMilestone() {
     const logParams = { title: "Handle Milestone" };
     if (!issueMilestone) {
-      setColumnValue(mondayColumns.date, "", logParams);
+      setColumnValue(mondayColumns.milestoneTitle, "", logParams);
+      setColumnValue(mondayColumns.milestoneDate, "", logParams);
       return;
     }
-    const milestoneTitle = issueMilestone.title;
-    const milestoneDateRegex = /\d{4}-\d{2}-\d{2}/;
-    const milestoneDate = milestoneTitle.match(milestoneDateRegex)?.[0];
 
-    if (milestoneDate) {
-      setColumnValue(mondayColumns.date, milestoneDate, logParams);
-      const { needsTriage, installed, readyForDev } = issueWorkflow;
-      setAssignedStatus({
-        assignedCondition: notInLifecycle({
-          labels,
-          skip: [needsTriage],
-        }),
-        unassignedCondition: !includesLabel(labels, installed) && !includesLabel(labels, readyForDev),
-      });
-    } else {
-      setColumnValue(mondayColumns.date, "", logParams);
+    // The milestone date is returned in ISO format (e.g., "2026-06-30T00:00:00Z"),
+    // but Monday requires just the date portion.
+    const milestoneDate = issueMilestone.due_on ? issueMilestone.due_on.slice(0, 10) : "";
+    setColumnValue(mondayColumns.milestoneTitle, issueMilestone.title, logParams);
+    setColumnValue(mondayColumns.milestoneDate, milestoneDate, logParams);
 
-      if (inMilestoneStatus()) {
-        setColumnValue(mondayColumns.status, milestoneTitle, logParams);
-      }
-    }
+    const { needsTriage, installed, readyForDev } = issueWorkflow;
+    setAssignedStatus({
+      assignedCondition: notInLifecycle({
+        labels,
+        skip: [needsTriage],
+      }),
+      unassignedCondition: !includesLabel(labels, installed) && !includesLabel(labels, readyForDev),
+    });
   }
 
   /**


### PR DESCRIPTION
**Related Issue:** #14462

## Summary

Syncs the Milestone `title` and `due_on` fields to separate columns in Monday.com, replacing the previous process of syncing the parsed date from the `title` field to a single column. This allows for more accurate portrayal of information ("status" milestones listed in the same place as date milestones), as well as cleans up the Milestone logic.

The `getColumnId` helper is introduced to get the appropriate column ID for either public/enterprise boards. This is not ideal for the long run, but with only one column needed this behavior it makes sense for now.

The columns have already been created/renamed in Monday.com (all boards), but the old Statuses for milestones will have to be removed after this PR is merged.

Tested by running workflows from this branch on the #12909 testing issue and all looks good to me. You can view the action results below:

- [Date Milestone added, Unassigned](https://github.com/Esri/calcite-design-system/actions/runs/27852282535)
- [Milestone removed](https://github.com/Esri/calcite-design-system/actions/runs/27852322751)
- [`Backlog` Milestone added, Assigned](https://github.com/Esri/calcite-design-system/actions/runs/27852347755)
- [`Backlog` Milestone added, Unassigned](https://github.com/Esri/calcite-design-system/actions/runs/27852571904)
- [`Freezer` Milestone added](https://github.com/Esri/calcite-design-system/actions/runs/27852541028)
- [Date Milestone added, Unassigned with `2 - ready for dev`](https://github.com/Esri/calcite-design-system/actions/runs/27852596907)
- [Date Milestone added, Unassigned with `4 - installed`](https://github.com/Esri/calcite-design-system/actions/runs/27852541028)
