### PR TITLE
fix(pagination): ignore truncation indicators in screen readers

### DIFF
--- a/packages/components/src/components/pagination/pagination.tsx
+++ b/packages/components/src/components/pagination/pagination.tsx
@@ -319,9 +319,11 @@ export class Pagination extends LitElement {
 
   private renderEllipsis(type: "start" | "end"): JsxNode {
     return (
-      <span ariaHidden="true" class={CSS.ellipsis} data-test-ellipsis={type} key={type}>
-        &hellip;
-      </span>
+      <li ariaHidden="true" role="presentation">
+        <span class={CSS.ellipsis} data-test-ellipsis={type} key={type}>
+          &hellip;
+        </span>
+      </li>
     );
   }
 

--- a/packages/components/src/components/pagination/pagination.tsx
+++ b/packages/components/src/components/pagination/pagination.tsx
@@ -319,7 +319,7 @@ export class Pagination extends LitElement {
 
   private renderEllipsis(type: "start" | "end"): JsxNode {
     return (
-      <span class={CSS.ellipsis} data-test-ellipsis={type} key={type}>
+      <span ariaHidden="true" class={CSS.ellipsis} data-test-ellipsis={type} key={type}>
         &hellip;
       </span>
     );


### PR DESCRIPTION
**Related Issue:** #14594 

## Summary

Fixes the following issue reported by axe:

```ts
<ul> and <ol> must only directly contain <li>, <script> or <template> elements
```

Coverage for this change will be provided by https://github.com/Esri/calcite-design-system/pull/13361, so no test was added.