### PR TITLE
test(input-time-zone): skip unstable tests

### DIFF
--- a/packages/components/src/components/input-time-zone/input-time-zone.time-zone.browser.e2e.tsx
+++ b/packages/components/src/components/input-time-zone/input-time-zone.time-zone.browser.e2e.tsx
@@ -190,7 +190,9 @@ describe("mode", () => {
       ).toBeGreaterThan(1);
     });
 
-    it("recreates time zone items when item-dependent props change", async () => {
+    it("recreates time zone items when item-dependent props change", async (context) => {
+      context.skip("waitForTimeZoneItemRefresh() is unstable");
+
       const itemSelector = `calcite-combobox-item[value='${alternateTimeZoneItem.offset}']`;
       const { el, component } = await mountInputTimeZone({ referenceDate: "2020-01-01" });
 
@@ -259,7 +261,9 @@ describe("mode", () => {
       expect(getSelectedTimeZoneItem().heading).toMatch(configuredTimeZoneItem.name);
     });
 
-    it("recreates time zone items when item-dependent props change", async () => {
+    it("recreates time zone items when item-dependent props change", async (context) => {
+      context.skip("waitForTimeZoneItemRefresh() is unstable");
+
       const itemSelector = `calcite-combobox-item[value='${alternateTimeZoneItem.name}']`;
       const { el, component } = await mountInputTimeZone({
         mode: "name",
@@ -381,7 +385,9 @@ describe("mode", () => {
       expect(el.value).toBe(aliasTimeZone2);
     });
 
-    it("recreates time zone items when item-dependent props change", async () => {
+    it("recreates time zone items when item-dependent props change", async (context) => {
+      context.skip("waitForTimeZoneItemRefresh() is unstable");
+
       const itemSelector = `calcite-combobox-item[value='${alternateTimeZoneItem.name}']`;
       const { el, component } = await mountInputTimeZone({
         mode: "region",


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Skips the following unstable test (and related ones):

```
FAIL   chromium  src/components/input-time-zone/input-time-zone.time-zone.browser.e2e.tsx > mode > region > recreates time zone items when item-dependent props change
Error: Expected time zone item to be recreated.
 ❯ src/components/input-time-zone/input-time-zone.time-zone.browser.e2e.tsx:80:12
    78|
    79|     if (itemWasRecreated !== expectedItemRecreation) {
    80|       throw new Error(`Expected time zone item to be ${expectedUpdate}…
      |            ^
    81|     }
    82|
```