### PR TITLE
ci(actions): fix backlog milestone being removed in some cases

### DIFF
--- a/.github/scripts/notifyWhenReadyForDev.js
+++ b/.github/scripts/notifyWhenReadyForDev.js
@@ -48,18 +48,11 @@ module.exports = async ({ github, context }) => {
     label: issueWorkflow.inDesign,
   });
 
-  await github.rest.issues.update({
-    ...issueProps,
-    milestone: milestones.backlog.number,
-  });
-
-  /* Update issue */
-
-  // Clear assignees and milestone
+  // Clear assignees and set milestone to backlog
   await github.rest.issues.update({
     ...issueProps,
     assignees: [],
-    milestone: null,
+    milestone: milestones.backlog.number,
   });
 
   // Add a comment to notify the planner(s)

--- a/.github/scripts/notifyWhenSpikeComplete.js
+++ b/.github/scripts/notifyWhenSpikeComplete.js
@@ -48,18 +48,11 @@ module.exports = async ({ github, context }) => {
     label: issueWorkflow.inDevelopment,
   });
 
-  await github.rest.issues.update({
-    ...issueProps,
-    milestone: milestones.backlog.number,
-  });
-
-  /* Update issue */
-
-  // Clear assignees and milestone
+  // Clear assignees and set milestone to backlog
   await github.rest.issues.update({
     ...issueProps,
     assignees: [],
-    milestone: null,
+    milestone: milestones.backlog.number,
   });
 
   // Add a comment to notify the planner(s)


### PR DESCRIPTION
**Related Issue:** N/A

## Summary
[Aaron noticed](https://github.com/Esri/calcite-design-system/issues/12129#issuecomment-4801267067) that the backlog milestone was not assigned after setting an issue to "ready for dev" although the event stated that it was. 

This update resolves that issue for the "ready for dev" and "spike complete" scripts.

