### PR TITLE
refactor: add parseInt radix to restore eslint radix rule

### DIFF
--- a/.github/scripts/trackMilestoneEstimates.js
+++ b/.github/scripts/trackMilestoneEstimates.js
@@ -52,7 +52,7 @@ module.exports = async ({ github, context, core }) => {
 
           if (estimateLabelMatch?.length > 1) {
             outputJson[milestone.number][issue.state === "open" ? "remaining_estimate" : "completed_estimate"] +=
-              Number.parseInt(estimateLabelMatch[1]);
+              Number.parseInt(estimateLabelMatch[1], 10);
 
             break; // assumes an issue will only have one estimate label
           }

--- a/packages/components-snippets/cli.ts
+++ b/packages/components-snippets/cli.ts
@@ -84,7 +84,7 @@ async function promptForChoice(promptLabel: string, options: string[]): Promise<
     pageSize: 10,
   });
 
-  const index = Number.parseInt(value);
+  const index = Number.parseInt(value, 10);
   if (Number.isNaN(index) || index < 0 || index >= options.length) {
     console.error("Unexpected selection result");
     process.exit(1);
@@ -110,7 +110,7 @@ async function promptForMultipleChoices(promptLabel: string, options: string[]):
   });
 
   const indices = values
-    .map((value) => Number.parseInt(value))
+    .map((value) => Number.parseInt(value, 10))
     .filter((index) => !Number.isNaN(index) && index >= 0 && index < options.length);
 
   if (indices.length === 0) {

--- a/packages/components/src/components/carousel/carousel.e2e.ts
+++ b/packages/components/src/components/carousel/carousel.e2e.ts
@@ -538,7 +538,7 @@ describe("autoplay", () => {
     const carousel = await page.find("calcite-carousel");
     const playSpy = await page.spyOnEvent("calciteCarouselPlay");
     const stopSpy = await page.spyOnEvent("calciteCarouselStop");
-    const defaultSlideDurationWaitTimer = parseInt(await carousel.getProperty("autoplayDuration")) + 250;
+    const defaultSlideDurationWaitTimer = parseInt(await carousel.getProperty("autoplayDuration"), 10) + 250;
 
     let selectedItem = await carousel.find(`calcite-carousel-item[selected]`);
     expect(selectedItem.id).toEqual("two");

--- a/packages/components/src/components/carousel/carousel.tsx
+++ b/packages/components/src/components/carousel/carousel.tsx
@@ -437,7 +437,7 @@ export class Carousel extends LitElement {
 
   private handleItemSelection(event: MouseEvent): void {
     const item = event.currentTarget as HTMLElement;
-    const requestedPosition = parseInt(item.dataset.index!);
+    const requestedPosition = parseInt(item.dataset.index!, 10);
 
     if (requestedPosition === this.selectedIndex) {
       return;

--- a/packages/components/src/components/color-picker/resources.ts
+++ b/packages/components/src/components/color-picker/resources.ts
@@ -64,7 +64,7 @@ export const OPACITY_LIMITS = {
 
 export const STATIC_DIMENSIONS = {
   s: {
-    gap: parseInt(calciteSpacingFixedSm),
+    gap: parseInt(calciteSpacingFixedSm, 10),
     slider: {
       height: 12,
     },
@@ -77,7 +77,7 @@ export const STATIC_DIMENSIONS = {
     minWidth: 200,
   },
   m: {
-    gap: parseInt(calciteSpacingFixedMd),
+    gap: parseInt(calciteSpacingFixedMd, 10),
     slider: {
       height: 12,
     },
@@ -90,7 +90,7 @@ export const STATIC_DIMENSIONS = {
     minWidth: 240,
   },
   l: {
-    gap: parseInt(calciteSpacingFixedXl),
+    gap: parseInt(calciteSpacingFixedXl, 10),
     slider: {
       height: 12,
     },

--- a/packages/components/src/components/combobox/combobox.tsx
+++ b/packages/components/src/components/combobox/combobox.tsx
@@ -1252,12 +1252,12 @@ export class Combobox extends LitElement implements LabelableComponent, Floating
       return;
     }
 
-    const chipContainerElGap = parseInt(getComputedStyle(chipContainerEl).gap);
+    const chipContainerElGap = parseInt(getComputedStyle(chipContainerEl).gap, 10);
     const chipContainerElWidth = getElementWidth(chipContainerEl);
     const { fontSize, fontFamily, minInlineSize } = getComputedStyle(textInputRef.value);
     // Heuristic placeholder width multiplier for stable hidden chip calculations.
     const placeholderWidthMultiplier = 0.55;
-    const inputMinWidth = parseFloat(minInlineSize) || parseInt(calciteSize48);
+    const inputMinWidth = parseFloat(minInlineSize) || parseInt(calciteSize48, 10);
     const measuredPlaceholderWidth = getTextWidth(placeholder, `${fontSize} ${fontFamily}`);
     const placeholderWidth =
       measuredPlaceholderWidth > 0
@@ -1266,7 +1266,7 @@ export class Combobox extends LitElement implements LabelableComponent, Floating
             inputMinWidth,
             Math.round(
               (placeholder?.length || 0) *
-                (parseFloat(fontSize) || parseInt(calciteSize48)) *
+                (parseFloat(fontSize) || parseInt(calciteSize48, 10)) *
                 placeholderWidthMultiplier,
             ),
           );
@@ -2034,12 +2034,12 @@ export class Combobox extends LitElement implements LabelableComponent, Floating
     let useFitCompactLabel = false;
 
     if (this.selectionDisplay === "fit" && this.textInputRef.value && this.chipContainerEl) {
-      const chipContainerElGap = parseInt(getComputedStyle(this.chipContainerEl).gap);
+      const chipContainerElGap = parseInt(getComputedStyle(this.chipContainerEl).gap, 10);
       const chipContainerElWidth = getElementWidth(this.chipContainerEl);
       const { fontSize, fontFamily, minInlineSize } = getComputedStyle(this.textInputRef.value);
       // Heuristic placeholder width multiplier for stable hidden chip calculations.
       const placeholderWidthMultiplier = 0.55;
-      const inputMinWidth = parseFloat(minInlineSize) || parseInt(calciteSize48);
+      const inputMinWidth = parseFloat(minInlineSize) || parseInt(calciteSize48, 10);
       const measuredPlaceholderWidth = getTextWidth(this.placeholder, `${fontSize} ${fontFamily}`);
       const placeholderWidth =
         measuredPlaceholderWidth > 0
@@ -2048,7 +2048,7 @@ export class Combobox extends LitElement implements LabelableComponent, Floating
               inputMinWidth,
               Math.round(
                 (this.placeholder?.length || 0) *
-                  (parseFloat(fontSize) || parseInt(calciteSize48)) *
+                  (parseFloat(fontSize) || parseInt(calciteSize48, 10)) *
                   placeholderWidthMultiplier,
               ),
             );

--- a/packages/components/src/components/date-picker-month-header/date-picker-month-header.tsx
+++ b/packages/components/src/components/date-picker-month-header/date-picker-month-header.tsx
@@ -299,7 +299,7 @@ export class DatePickerMonthHeader extends LitElement {
   }
 
   private setYearSelectWidthOffset(): void {
-    this.yearSelectWidthOffset = ICON_WIDTH_M + 3 * parseInt(this.getYearSelectPadding());
+    this.yearSelectWidthOffset = ICON_WIDTH_M + 3 * parseInt(this.getYearSelectPadding(), 10);
     this.setYearSelectMenuWidth();
   }
 

--- a/packages/components/src/components/dialog/dialog.browser.e2e.tsx
+++ b/packages/components/src/components/dialog/dialog.browser.e2e.tsx
@@ -307,8 +307,8 @@ describe("fullscreen disabled", () => {
 
       const computedStyle = window.getComputedStyle(dialog);
 
-      expect(parseInt(computedStyle.width)).toBeLessThan(width);
-      expect(parseInt(computedStyle.height)).toBeLessThan(height);
+      expect(parseInt(computedStyle.width, 10)).toBeLessThan(width);
+      expect(parseInt(computedStyle.height, 10)).toBeLessThan(height);
     },
   );
 
@@ -332,8 +332,10 @@ describe("fullscreen disabled", () => {
     await component.updateComplete;
 
     const resizedStyle = window.getComputedStyle(dialog);
-    expect(parseInt(resizedStyle.width)).toBeGreaterThanOrEqual(minimumDialogWidthForMediumScale);
-    expect(parseInt(resizedStyle.width)).toBeLessThan(viewportWidth);
+    expect(parseInt(resizedStyle.width, 10)).toBeGreaterThanOrEqual(
+      minimumDialogWidthForMediumScale,
+    );
+    expect(parseInt(resizedStyle.width, 10)).toBeLessThan(viewportWidth);
   });
 });
 

--- a/packages/components/src/components/dialog/dialog.e2e.ts
+++ b/packages/components/src/components/dialog/dialog.e2e.ts
@@ -192,8 +192,8 @@ it("does not overflow page bounds when requested css variable sizes are larger t
 
   const internalDialog = await page.find(`calcite-dialog >>> .${CSS.dialog}`);
   const style = await internalDialog.getComputedStyle();
-  expect(parseInt(style.width)).toBeLessThanOrEqual(800);
-  expect(parseInt(style.height)).toBeLessThanOrEqual(800);
+  expect(parseInt(style.width, 10)).toBeLessThanOrEqual(800);
+  expect(parseInt(style.height, 10)).toBeLessThanOrEqual(800);
 });
 
 it("escapeDisabled", async () => {
@@ -883,8 +883,8 @@ describe("keyboard resize", () => {
     let computedStyle = await container.getComputedStyle();
     const initialBlockSize = computedStyle.blockSize;
     const initialInlineSize = computedStyle.inlineSize;
-    const initialHeight = parseInt(initialBlockSize);
-    const initialWidth = parseInt(initialInlineSize);
+    const initialHeight = parseInt(initialBlockSize, 10);
+    const initialWidth = parseInt(initialInlineSize, 10);
 
     await dispatchDialogKeydown({ page, key: "ArrowUp", shiftKey: true });
 
@@ -940,9 +940,9 @@ describe("keyboard resize", () => {
 
     let computedStyle = await container.getComputedStyle();
     const initialBlockSize = computedStyle.blockSize;
-    const initialHeight = parseInt(initialBlockSize);
+    const initialHeight = parseInt(initialBlockSize, 10);
     const initialInlineSize = computedStyle.inlineSize;
-    const initialWidth = parseInt(initialInlineSize);
+    const initialWidth = parseInt(initialInlineSize, 10);
 
     await dispatchDialogKeydown({ page, key: "ArrowUp", shiftKey: true });
 

--- a/packages/components/src/components/input-time-picker/input-time-picker.tsx
+++ b/packages/components/src/components/input-time-picker/input-time-picker.tsx
@@ -603,7 +603,7 @@ export class InputTimePicker extends LitElement implements LabelableComponent, T
                 aria-label={this.messages.hour}
                 aria-valuemax="23"
                 aria-valuemin="1"
-                aria-valuenow={(hourIsNumber && parseInt(hour!)) || "0"}
+                aria-valuenow={(hourIsNumber && parseInt(hour!, 10)) || "0"}
                 aria-valuetext={hour}
                 class={{
                   [CSS.empty]: !localizedHour,
@@ -624,7 +624,7 @@ export class InputTimePicker extends LitElement implements LabelableComponent, T
                 aria-label={this.messages.minute}
                 aria-valuemax="12"
                 aria-valuemin="1"
-                aria-valuenow={(minuteIsNumber && parseInt(minute!)) || "0"}
+                aria-valuenow={(minuteIsNumber && parseInt(minute!, 10)) || "0"}
                 aria-valuetext={minute}
                 class={{
                   [CSS.empty]: !localizedMinute,
@@ -646,7 +646,7 @@ export class InputTimePicker extends LitElement implements LabelableComponent, T
                   aria-label={this.messages.second}
                   aria-valuemax="59"
                   aria-valuemin="0"
-                  aria-valuenow={(secondIsNumber && parseInt(second!)) || "0"}
+                  aria-valuenow={(secondIsNumber && parseInt(second!, 10)) || "0"}
                   aria-valuetext={second}
                   class={{
                     [CSS.empty]: !localizedSecond,
@@ -671,7 +671,9 @@ export class InputTimePicker extends LitElement implements LabelableComponent, T
                   aria-label={this.messages.fractionalSecond}
                   aria-valuemax="999"
                   aria-valuemin="1"
-                  aria-valuenow={(fractionalSecondIsNumber && parseInt(fractionalSecond!)) || "0"}
+                  aria-valuenow={
+                    (fractionalSecondIsNumber && parseInt(fractionalSecond!, 10)) || "0"
+                  }
                   aria-valuetext={localizedFractionalSecond}
                   class={{
                     [CSS.empty]: !localizedFractionalSecond,

--- a/packages/components/src/components/input-time-zone/utils.ts
+++ b/packages/components/src/components/input-time-zone/utils.ts
@@ -106,8 +106,8 @@ export async function createTimeZoneItems(
             const offsetStringA = timeZoneA.substring(gmtTimeZoneString.length);
             const offsetStringB = timeZoneB.substring(gmtTimeZoneString.length);
 
-            const offsetA = offsetStringA === "" ? 0 : parseInt(offsetStringA);
-            const offsetB = offsetStringB === "" ? 0 : parseInt(offsetStringB);
+            const offsetA = offsetStringA === "" ? 0 : parseInt(offsetStringA, 10);
+            const offsetB = offsetStringB === "" ? 0 : parseInt(offsetStringB, 10);
 
             return offsetB - offsetA;
           }

--- a/packages/components/src/components/pagination/pagination.tsx
+++ b/packages/components/src/components/pagination/pagination.tsx
@@ -309,7 +309,7 @@ export class Pagination extends LitElement {
 
   private handlePageClick(event: Event) {
     const target = event.target as HTMLButtonElement;
-    this.startItem = parseInt(target.value);
+    this.startItem = parseInt(target.value, 10);
     this.emitUpdate();
   }
 

--- a/packages/components/src/components/sheet/sheet.e2e.ts
+++ b/packages/components/src/components/sheet/sheet.e2e.ts
@@ -378,7 +378,7 @@ describe("keyboard resize", () => {
 
     let computedStyle = await container.getComputedStyle();
     const initialInlineSize = computedStyle.inlineSize;
-    const initialWidth = parseInt(initialInlineSize);
+    const initialWidth = parseInt(initialInlineSize, 10);
 
     const resizeHandle = await page.find(`calcite-sheet >>> .${CSS.resizeHandle}`);
     await resizeHandle.focus();
@@ -434,7 +434,7 @@ describe("keyboard resize", () => {
     await page.waitForChanges();
     computedStyle = await container.getComputedStyle();
     const initialBlockSize = computedStyle.blockSize;
-    const initialHeight = parseInt(initialBlockSize);
+    const initialHeight = parseInt(initialBlockSize, 10);
 
     await page.keyboard.down("ArrowDown");
     await page.keyboard.up("ArrowDown");

--- a/packages/components/src/components/shell-panel/shell-panel.e2e.ts
+++ b/packages/components/src/components/shell-panel/shell-panel.e2e.ts
@@ -413,7 +413,7 @@ describe("resizing", () => {
 
     const resizeHandle: E2EElement = await page.find(`calcite-shell-panel >>> .${CSS.resizeHandle}`);
     const content = await page.find(`calcite-shell-panel >>> .${CSS.content}`);
-    const initialHeight = parseInt((await content.getComputedStyle()).blockSize);
+    const initialHeight = parseInt((await content.getComputedStyle()).blockSize, 10);
 
     expect(resizeHandle).toBeDefined();
     expect(content).toBeDefined();
@@ -516,7 +516,7 @@ describe("resizing", () => {
 
     const resizeHandle: E2EElement = await page.find(`calcite-shell-panel >>> .${CSS.resizeHandle}`);
     const content = await page.find(`calcite-shell-panel >>> .${CSS.content}`);
-    const initialHeight = parseInt((await content.getComputedStyle()).blockSize.replace("px", ""));
+    const initialHeight = parseInt((await content.getComputedStyle()).blockSize.replace("px", ""), 10);
 
     expect(resizeHandle).toBeDefined();
     expect(content).toBeDefined();

--- a/packages/components/src/components/tab-nav/tab-nav.tsx
+++ b/packages/components/src/components/tab-nav/tab-nav.tsx
@@ -231,7 +231,10 @@ export class TabNav extends LitElement {
 
   private get scrollerButtonWidth(): number {
     const { scale } = this;
-    return parseInt(scale === "s" ? calciteSize24 : scale === "m" ? calciteSize32 : calciteSize44);
+    return parseInt(
+      scale === "s" ? calciteSize24 : scale === "m" ? calciteSize32 : calciteSize44,
+      10,
+    );
   }
 
   get tabTitles(): TabTitle["el"][] {

--- a/packages/components/src/components/time-picker/time-picker.tsx
+++ b/packages/components/src/components/time-picker/time-picker.tsx
@@ -435,7 +435,7 @@ export class TimePicker extends LitElement implements TimeComponent {
             ariaLabel={messages.hour}
             ariaValueMax="23"
             ariaValueMin="1"
-            ariaValueNow={(hourIsNumber && parseInt(hour!)) || "0"}
+            ariaValueNow={(hourIsNumber && parseInt(hour!, 10)) || "0"}
             ariaValueText={hour ?? undefined}
             class={{
               [CSS.input]: true,
@@ -481,7 +481,7 @@ export class TimePicker extends LitElement implements TimeComponent {
             ariaLabel={messages.minute}
             ariaValueMax="12"
             ariaValueMin="1"
-            ariaValueNow={(minuteIsNumber && parseInt(minute!)) || "0"}
+            ariaValueNow={(minuteIsNumber && parseInt(minute!, 10)) || "0"}
             ariaValueText={minute ?? undefined}
             class={{
               [CSS.input]: true,
@@ -531,7 +531,7 @@ export class TimePicker extends LitElement implements TimeComponent {
               ariaLabel={messages.second}
               ariaValueMax="59"
               ariaValueMin="0"
-              ariaValueNow={(secondIsNumber && parseInt(second!)) || "0"}
+              ariaValueNow={(secondIsNumber && parseInt(second!, 10)) || "0"}
               ariaValueText={second ?? undefined}
               class={{
                 [CSS.input]: true,
@@ -582,7 +582,7 @@ export class TimePicker extends LitElement implements TimeComponent {
               ariaLabel={messages.fractionalSecond}
               ariaValueMax="999"
               ariaValueMin="1"
-              ariaValueNow={(fractionalSecondIsNumber && parseInt(fractionalSecond!)) || "0"}
+              ariaValueNow={(fractionalSecondIsNumber && parseInt(fractionalSecond!, 10)) || "0"}
               ariaValueText={localizedFractionalSecond ?? undefined}
               class={{
                 [CSS.input]: true,

--- a/packages/components/src/controllers/useTime.ts
+++ b/packages/components/src/controllers/useTime.ts
@@ -188,7 +188,7 @@ class TimeController extends GenericController<TimeProperties, TimeComponent> {
   handleHourKeyDownEvent = (event: KeyboardEvent): void => {
     const key = event.key;
     if (numberKeys.includes(key)) {
-      const keyAsNumber = parseInt(key);
+      const keyAsNumber = parseInt(key, 10);
       let newHour;
       if (isValidNumber(this.hour)) {
         switch (this.hourFormat) {
@@ -235,10 +235,10 @@ class TimeController extends GenericController<TimeProperties, TimeComponent> {
   handleMinuteKeyDownEvent = (event: KeyboardEvent): void => {
     const key = event.key;
     if (numberKeys.includes(key)) {
-      const keyAsNumber = parseInt(key);
+      const keyAsNumber = parseInt(key, 10);
       let newMinute;
       if (typeof this.minute === "string" && isValidNumber(this.minute) && this.minute.startsWith("0")) {
-        const minuteAsNumber = parseInt(this.minute);
+        const minuteAsNumber = parseInt(this.minute, 10);
         newMinute = minuteAsNumber > maxTenthForMinuteAndSecond ? keyAsNumber : `${minuteAsNumber}${keyAsNumber}`;
       } else {
         newMinute = keyAsNumber;
@@ -270,10 +270,10 @@ class TimeController extends GenericController<TimeProperties, TimeComponent> {
   handleSecondKeyDownEvent = (event: KeyboardEvent): void => {
     const key = event.key;
     if (numberKeys.includes(key)) {
-      const keyAsNumber = parseInt(key);
+      const keyAsNumber = parseInt(key, 10);
       let newSecond;
       if (typeof this.second === "string" && isValidNumber(this.second) && this.second.startsWith("0")) {
-        const secondAsNumber = parseInt(this.second);
+        const secondAsNumber = parseInt(this.second, 10);
         newSecond = secondAsNumber > maxTenthForMinuteAndSecond ? keyAsNumber : `${secondAsNumber}${keyAsNumber}`;
       } else {
         newSecond = keyAsNumber;
@@ -306,7 +306,7 @@ class TimeController extends GenericController<TimeProperties, TimeComponent> {
     const { key } = event;
     if (numberKeys.includes(key)) {
       const stepPrecision = decimalPlaces(this.component.step);
-      const fractionalSecondAsInteger = parseInt(this.fractionalSecond!);
+      const fractionalSecondAsInteger = parseInt(this.fractionalSecond!, 10);
       const fractionalSecondAsIntegerLength = fractionalSecondAsInteger.toString().length;
 
       let newFractionalSecondAsIntegerString;
@@ -379,7 +379,7 @@ class TimeController extends GenericController<TimeProperties, TimeComponent> {
   //#region Public Methods
 
   decrementHour(): void {
-    const newHour = !this.hour ? 0 : this.hour === "00" ? 23 : parseInt(this.hour) - 1;
+    const newHour = !this.hour ? 0 : this.hour === "00" ? 23 : parseInt(this.hour, 10) - 1;
     this.setValuePart("hour", newHour);
   }
 
@@ -396,7 +396,7 @@ class TimeController extends GenericController<TimeProperties, TimeComponent> {
       typeof this.hour === "string" && isValidNumber(this.hour)
         ? this.hour === "23"
           ? 0
-          : parseInt(this.hour) + 1
+          : parseInt(this.hour, 10) + 1
         : 1;
     this.setValuePart("hour", newHour);
   }
@@ -412,7 +412,7 @@ class TimeController extends GenericController<TimeProperties, TimeComponent> {
   nudgeFractionalSecond(direction: "up" | "down"): void {
     const stepDecimal = getDecimals(this.component.step);
     const stepPrecision = decimalPlaces(this.component.step);
-    const fractionalSecondAsInteger = parseInt(this.fractionalSecond!);
+    const fractionalSecondAsInteger = parseInt(this.fractionalSecond!, 10);
     const fractionalSecondAsFloat = parseFloat(`0.${this.fractionalSecond}`);
     let nudgedValue;
     let nudgedValueRounded;
@@ -504,7 +504,7 @@ class TimeController extends GenericController<TimeProperties, TimeComponent> {
   private decrementMinuteOrSecond(key: MinuteOrSecond): void {
     let newValue;
     if (isValidNumber(this[key])) {
-      const valueAsNumber = parseInt(this[key]!);
+      const valueAsNumber = parseInt(this[key]!, 10);
       newValue = valueAsNumber === 0 ? 59 : valueAsNumber - 1;
     } else {
       newValue = 59;
@@ -513,7 +513,7 @@ class TimeController extends GenericController<TimeProperties, TimeComponent> {
   }
 
   private incrementMinuteOrSecond(key: MinuteOrSecond): void {
-    const newValue = isValidNumber(this[key]) ? (this[key] === "59" ? 0 : parseInt(this[key]!) + 1) : 0;
+    const newValue = isValidNumber(this[key]) ? (this[key] === "59" ? 0 : parseInt(this[key]!, 10) + 1) : 0;
     this.setValuePart(key, newValue);
   }
 
@@ -618,7 +618,7 @@ class TimeController extends GenericController<TimeProperties, TimeComponent> {
         value: this.meridiem,
       });
       if (isValidNumber(this.hour)) {
-        const hourAsNumber = parseInt(this.hour!);
+        const hourAsNumber = parseInt(this.hour!, 10);
         switch (value) {
           case "AM":
             if (hourAsNumber >= 12) {

--- a/packages/components/src/utils/date.ts
+++ b/packages/components/src/utils/date.ts
@@ -253,9 +253,9 @@ export function parseDateString(
 ): { day: number; month: number; year: number } {
   const { day, month, year } = datePartsFromLocalizedString(string, localeData);
   return {
-    day: parseInt(day),
-    month: parseInt(month) - 1, // this subtracts by 1 because the month in the Date constructor is zero-based https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getMonth
-    year: parseInt(year),
+    day: parseInt(day, 10),
+    month: parseInt(month, 10) - 1, // this subtracts by 1 because the month in the Date constructor is zero-based https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getMonth
+    year: parseInt(year, 10),
   };
 }
 

--- a/packages/components/src/utils/math.ts
+++ b/packages/components/src/utils/math.ts
@@ -13,7 +13,7 @@ const decimalNumberRegex = new RegExp(/(?:\.(\d+))?(?:[eE]([+-]?\d+))?$/);
  */
 export const decimalPlaces = (value: number | string): number => {
   const match = ("" + value).match(decimalNumberRegex);
-  if (!match || parseInt(match[1]) === 0) {
+  if (!match || parseInt(match[1], 10) === 0) {
     return 0;
   }
   return Math.max(

--- a/packages/components/src/utils/responsive.ts
+++ b/packages/components/src/utils/responsive.ts
@@ -28,5 +28,5 @@ export const breakpoints: Breakpoints = {
 };
 
 function cssLengthToNumber(length: string): number {
-  return parseInt(length);
+  return parseInt(length, 10);
 }

--- a/packages/components/src/utils/time.ts
+++ b/packages/components/src/utils/time.ts
@@ -116,7 +116,7 @@ export function formatTimePart(number: number | null | undefined, minLength?: nu
 }
 
 function fractionalSecondPartToMilliseconds(fractionalSecondPart: string): number {
-  return parseInt((parseFloat(`0.${fractionalSecondPart}`) / 0.001).toFixed(3));
+  return parseInt((parseFloat(`0.${fractionalSecondPart}`) / 0.001).toFixed(3), 10);
 }
 
 export function getLocaleHourFormat(locale: Locale): EffectiveHourFormat {
@@ -263,7 +263,7 @@ export function getMeridiem(hour: string | null | undefined): Meridiem | null {
   if (!isValidNumber(hour)) {
     return null;
   }
-  const hourAsNumber = parseInt(hour!);
+  const hourAsNumber = parseInt(hour!, 10);
   return hourAsNumber >= 0 && hourAsNumber <= 11 ? "AM" : "PM";
 }
 
@@ -298,9 +298,9 @@ export function isValidTime(value: string | Time | null | undefined): value is s
   if (!hour || !minute) {
     return false;
   }
-  const hourAsNumber = parseInt(hour);
-  const minuteAsNumber = parseInt(minute);
-  const secondAsNumber = parseInt(second ?? "");
+  const hourAsNumber = parseInt(hour, 10);
+  const minuteAsNumber = parseInt(minute, 10);
+  const secondAsNumber = parseInt(second ?? "", 10);
   const hourValid = isValidNumber(hour) && hourAsNumber >= 0 && hourAsNumber < 24;
   const minuteValid = isValidNumber(minute) && minuteAsNumber >= 0 && minuteAsNumber < 60;
   const secondValid = isValidNumber(second) && secondAsNumber >= 0 && secondAsNumber < 60;
@@ -357,7 +357,7 @@ export function localizeTimePart({
         numberingSystem,
       };
       const localizedZero = numberStringFormatter.localize("0");
-      if (parseInt(value) === 0) {
+      if (parseInt(value, 10) === 0) {
         localizedFractionalSecond = "".padStart(value.length, localizedZero);
       } else {
         localizedFractionalSecond = numberStringFormatter
@@ -371,7 +371,7 @@ export function localizeTimePart({
     return localizedFractionalSecond;
   }
 
-  const valueAsNumber = parseInt(value as string);
+  const valueAsNumber = parseInt(value as string, 10);
   const date = new Date(
     Date.UTC(
       0,
@@ -431,9 +431,9 @@ export function localizeTimeString({
       0,
       0,
       0,
-      parseInt(hour!),
-      parseInt(minute!),
-      includeSeconds && typeof second === "string" ? parseInt(second) : 0,
+      parseInt(hour!, 10),
+      parseInt(minute!, 10),
+      includeSeconds && typeof second === "string" ? parseInt(second, 10) : 0,
       includeSeconds && fractionalSecond ? fractionalSecondPartToMilliseconds(fractionalSecond) : 0,
     ),
   );
@@ -535,9 +535,9 @@ export function toISOTimeString(value: string | Time | null | undefined, step: n
   }
 
   if (hour && minute) {
-    isoTimeString = `${formatTimePart(parseInt(hour))}:${formatTimePart(parseInt(minute))}`;
+    isoTimeString = `${formatTimePart(parseInt(hour, 10))}:${formatTimePart(parseInt(minute, 10))}`;
     if (step < 60) {
-      isoTimeString += `:${formatTimePart(parseInt(second || "0"))}`;
+      isoTimeString += `:${formatTimePart(parseInt(second || "0", 10))}`;
       if (step < 1) {
         isoTimeString += `.${formatFractionalSecond(fractionalSecond || "0", step)}`;
       }

--- a/packages/eslint-config/core.js
+++ b/packages/eslint-config/core.js
@@ -73,7 +73,7 @@ export default tseslint.config(
           max: 1,
         },
       ],
-      radix: ["error"], // "error" severity will be restored by https://github.com/Esri/calcite-design-system/issues/14401
+      radix: ["error"],
 
       "unicorn/filename-case": [
         "error",

--- a/packages/eslint-config/core.js
+++ b/packages/eslint-config/core.js
@@ -73,7 +73,7 @@ export default tseslint.config(
           max: 1,
         },
       ],
-      radix: ["warn"], // "error" severity will be restored by https://github.com/Esri/calcite-design-system/issues/14401
+      radix: ["error"], // "error" severity will be restored by https://github.com/Esri/calcite-design-system/issues/14401
 
       "unicorn/filename-case": [
         "error",


### PR DESCRIPTION
**monday.com sync:** #12381818167

**Related Issue:** [#14401](https://github.com/Esri/calcite-design-system/issues/14401) 

## Summary
add explicit base-10 radix to parseInt calls and restore eslint radix rule from warn to error.