### PR TITLE
fix(rating): fix block size to not encroach on neighboring elements

### DIFF
--- a/packages/components/src/components/rating/rating.scss
+++ b/packages/components/src/components/rating/rating.scss
@@ -28,17 +28,17 @@
 @include includes.disabled();
 
 :host([scale="s"]) {
-  @apply h-6;
+  min-block-size: var(--calcite-space-2xl);
   --calcite-internal-rating-spacing: theme("spacing.1");
 }
 
 :host([scale="m"]) {
-  @apply h-8;
+  min-block-size: var(--calcite-space-3xl);
   --calcite-internal-rating-spacing: theme("spacing.2");
 }
 
 :host([scale="l"]) {
-  @apply h-11;
+  min-block-size: var(--calcite-space-4xl);
   --calcite-internal-rating-spacing: theme("spacing.3");
 }
 

--- a/packages/components/src/components/rating/rating.stories.ts
+++ b/packages/components/src/components/rating/rating.stories.ts
@@ -99,8 +99,8 @@ export const validationMessageAllScales = (): string => html`
     .container {
       display: flex;
       flex-direction: column;
-      width: 400px;
-      height: 200px;
+      min-inline-size: 400px;
+      min-block-size: 200px;
       gap: 40px;
     }
   </style>


### PR DESCRIPTION
**Related Issue:** #14708 

## Summary

This PR fixes an issue where `calcite-rating` renders too close to neighboring elements in a vertical flex layout with a gap.
