### PR TITLE
chore(linting): drop warning on `page.getBySelector` usage in favor of test guidelines doc

### DIFF
--- a/packages/components/eslint.config.mjs
+++ b/packages/components/eslint.config.mjs
@@ -133,22 +133,6 @@ export default tseslint.config(
   },
 
   {
-    files: ["**/*.browser.*.tsx"],
-    extends: [calciteCoreConfig],
-    rules: {
-      "no-restricted-properties": [
-        "warn",
-        {
-          object: "page",
-          property: "getBySelector",
-          message:
-            "Prefer using more specific locators when possible for better test reliability – see https://vitest.dev/api/browser/locators",
-        },
-      ],
-    },
-  },
-
-  {
     plugins: {
       unicorn: unicornPlugin,
     },


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

This warning was originally intended to encourage more semantic locators, but that transition may take longer than anticipated. In the meantime, it adds a lot of lint noise. This PR removes the warning and instead treats this locator as a less preferred alternative to `getByTestId`, as documented in the [testing guidelines](https://github.com/Esri/calcite-design-system/wiki/testing-conventions#locators).