### PR TITLE
fix(components): harden sortable touch drag ghost lifecycle

### DIFF
--- a/packages/components/src/controllers/useSortable.browser.spec.tsx
+++ b/packages/components/src/controllers/useSortable.browser.spec.tsx
@@ -124,6 +124,7 @@ it("does not leave global drag state active when component disconnects mid-drag"
 
   await mountDragEnabled();
 
+  expect(component.onGlobalDragEnd).not.toHaveBeenCalled();
   expect(destroySpy).toHaveBeenCalledTimes(1);
   expect(createSpy).toHaveBeenCalledTimes(2);
 });

--- a/packages/components/src/controllers/useSortable.browser.spec.tsx
+++ b/packages/components/src/controllers/useSortable.browser.spec.tsx
@@ -20,6 +20,12 @@ class Test extends LitElement {
   handleSelector = "calcite-sort-handle";
   sortable = useSortable<this>()(this);
 
+  onGlobalDragStart = vi.fn();
+  onGlobalDragEnd = vi.fn();
+  onDragEnd = vi.fn();
+  onDragStart = vi.fn();
+  onDragSort = vi.fn();
+
   @property({ type: Boolean }) dragEnabled = false;
 
   canPull(): boolean {
@@ -29,12 +35,6 @@ class Test extends LitElement {
   canPut(): boolean {
     return true;
   }
-
-  onGlobalDragStart(): void {}
-  onGlobalDragEnd(): void {}
-  onDragEnd(): void {}
-  onDragStart(): void {}
-  onDragSort(): void {}
 }
 
 beforeEach(() => {
@@ -59,6 +59,16 @@ it("creates Sortable when dragEnabled is true", async () => {
   expect(createSpy).toHaveBeenCalledTimes(1);
 });
 
+it("sets fallbackOnBody for stable fallback ghost placement", async () => {
+  await mountDragEnabled();
+
+  const sortableOptions = createSpy.mock.calls[0]?.[1] as {
+    fallbackOnBody?: boolean;
+  };
+
+  expect(sortableOptions.fallbackOnBody).toBe(true);
+});
+
 it("destroys Sortable when dragEnabled becomes false and reset runs", async () => {
   const { component } = await mountDragEnabled();
 
@@ -67,4 +77,77 @@ it("destroys Sortable when dragEnabled becomes false and reset runs", async () =
 
   expect(destroySpy).toHaveBeenCalledTimes(1);
   expect(createSpy).toHaveBeenCalledTimes(1);
+});
+
+it("does not teardown Sortable when reset runs during choose/start drag window", async () => {
+  const { component } = await mountDragEnabled();
+  const sortableOptions = createSpy.mock.calls[0]?.[1] as {
+    onChoose?: () => void;
+    onUnchoose?: () => void;
+  };
+
+  sortableOptions.onChoose?.();
+  component.sortable.reset();
+
+  expect(destroySpy).not.toHaveBeenCalled();
+  expect(createSpy).toHaveBeenCalledTimes(1);
+
+  sortableOptions.onUnchoose?.();
+  component.sortable.reset();
+
+  expect(destroySpy).toHaveBeenCalledTimes(1);
+  expect(createSpy).toHaveBeenCalledTimes(2);
+});
+
+it("dedupes global drag notifications across choose/start and end/unchoose", async () => {
+  const { component } = await mountDragEnabled();
+  const sortableOptions = createSpy.mock.calls[0]?.[1] as {
+    onChoose?: () => void;
+    onUnchoose?: () => void;
+    onStart?: (detail: {
+      from: HTMLElement;
+      item: HTMLElement;
+      to: HTMLElement;
+      newDraggableIndex: number;
+      oldDraggableIndex: number;
+    }) => void;
+    onEnd?: (detail: {
+      from: HTMLElement;
+      item: HTMLElement;
+      to: HTMLElement;
+      newDraggableIndex: number;
+      oldDraggableIndex: number;
+    }) => void;
+  };
+
+  const dragDetail = {
+    from: component.el,
+    item: component.el,
+    to: component.el,
+    newDraggableIndex: 0,
+    oldDraggableIndex: 0,
+  };
+
+  sortableOptions.onChoose?.();
+  sortableOptions.onStart?.(dragDetail);
+  sortableOptions.onEnd?.(dragDetail);
+  sortableOptions.onUnchoose?.();
+
+  expect(component.onGlobalDragStart).toHaveBeenCalledTimes(1);
+  expect(component.onGlobalDragEnd).toHaveBeenCalledTimes(1);
+});
+
+it("does not leave global drag state active when component disconnects mid-drag", async () => {
+  const { component } = await mountDragEnabled();
+  const sortableOptions = createSpy.mock.calls[0]?.[1] as {
+    onChoose?: () => void;
+  };
+
+  sortableOptions.onChoose?.();
+  component.remove();
+
+  await mountDragEnabled();
+
+  expect(destroySpy).toHaveBeenCalledTimes(1);
+  expect(createSpy).toHaveBeenCalledTimes(2);
 });

--- a/packages/components/src/controllers/useSortable.browser.spec.tsx
+++ b/packages/components/src/controllers/useSortable.browser.spec.tsx
@@ -62,9 +62,7 @@ it("creates Sortable when dragEnabled is true", async () => {
 it("sets fallbackOnBody for stable fallback ghost placement", async () => {
   await mountDragEnabled();
 
-  const sortableOptions = createSpy.mock.calls[0]?.[1] as {
-    fallbackOnBody?: boolean;
-  };
+  const [, sortableOptions] = createSpy.mock.calls[0];
 
   expect(sortableOptions.fallbackOnBody).toBe(true);
 });
@@ -81,10 +79,7 @@ it("destroys Sortable when dragEnabled becomes false and reset runs", async () =
 
 it("does not teardown Sortable when reset runs during choose/start drag window", async () => {
   const { component } = await mountDragEnabled();
-  const sortableOptions = createSpy.mock.calls[0]?.[1] as {
-    onChoose?: () => void;
-    onUnchoose?: () => void;
-  };
+  const [, sortableOptions] = createSpy.mock.calls[0];
 
   sortableOptions.onChoose?.();
   component.sortable.reset();
@@ -101,24 +96,7 @@ it("does not teardown Sortable when reset runs during choose/start drag window",
 
 it("dedupes global drag notifications across choose/start and end/unchoose", async () => {
   const { component } = await mountDragEnabled();
-  const sortableOptions = createSpy.mock.calls[0]?.[1] as {
-    onChoose?: () => void;
-    onUnchoose?: () => void;
-    onStart?: (detail: {
-      from: HTMLElement;
-      item: HTMLElement;
-      to: HTMLElement;
-      newDraggableIndex: number;
-      oldDraggableIndex: number;
-    }) => void;
-    onEnd?: (detail: {
-      from: HTMLElement;
-      item: HTMLElement;
-      to: HTMLElement;
-      newDraggableIndex: number;
-      oldDraggableIndex: number;
-    }) => void;
-  };
+  const [, sortableOptions] = createSpy.mock.calls[0];
 
   const dragDetail = {
     from: component.el,
@@ -139,9 +117,7 @@ it("dedupes global drag notifications across choose/start and end/unchoose", asy
 
 it("does not leave global drag state active when component disconnects mid-drag", async () => {
   const { component } = await mountDragEnabled();
-  const sortableOptions = createSpy.mock.calls[0]?.[1] as {
-    onChoose?: () => void;
-  };
+  const [, sortableOptions] = createSpy.mock.calls[0];
 
   sortableOptions.onChoose?.();
   component.remove();

--- a/packages/components/src/controllers/useSortable.ts
+++ b/packages/components/src/controllers/useSortable.ts
@@ -254,6 +254,8 @@ export const useSortable = <T extends SortableComponent>(): ReturnType<
     });
 
     controller.onDisconnected(() => {
+      sortableComponentSet.delete(component);
+
       // If unchoose/end is skipped due to abrupt teardown, clear active drag
       // state to avoid blocking sortable setup for other components.
       markDragInactive(component);

--- a/packages/components/src/controllers/useSortable.ts
+++ b/packages/components/src/controllers/useSortable.ts
@@ -110,6 +110,34 @@ interface UseSortable {
 }
 
 const globalDragState: { active: boolean } = { active: false };
+const activeSortableComponentSet = new Set<SortableComponent>();
+
+function syncGlobalDragState(): void {
+  const active = activeSortableComponentSet.size > 0;
+
+  if (globalDragState.active === active) {
+    return;
+  }
+
+  globalDragState.active = active;
+
+  if (active) {
+    onGlobalDragStart();
+    return;
+  }
+
+  onGlobalDragEnd();
+}
+
+function markDragActive(component: SortableComponent): void {
+  activeSortableComponentSet.add(component);
+  syncGlobalDragState();
+}
+
+function markDragInactive(component: SortableComponent): void {
+  activeSortableComponentSet.delete(component);
+  syncGlobalDragState();
+}
 
 function createSortable(component: SortableComponent): ReturnType<(typeof Sortable)["create"]> {
   const dataIdAttr = "id";
@@ -118,6 +146,9 @@ function createSortable(component: SortableComponent): ReturnType<(typeof Sortab
   return Sortable.create(el, {
     dataIdAttr,
     swapThreshold: 0.5,
+    // Keep the fallback ghost out of nested list DOM updates during touch drag startup.
+    // Applied globally so all sortable hosts use the same stable fallback behavior.
+    fallbackOnBody: true,
     ...CSS,
     ...(!!draggable && { draggable }),
     ...(!!group && {
@@ -157,14 +188,20 @@ function createSortable(component: SortableComponent): ReturnType<(typeof Sortab
     },
     handle,
     filter: `${handle}[disabled]`,
+    onChoose: () => {
+      // Touch fallback starts before `onStart`, so mark drag active earlier
+      // to avoid teardown/reset while Sortable appends the ghost element.
+      markDragActive(component);
+    },
+    onUnchoose: () => {
+      markDragInactive(component);
+    },
     onStart: ({ from: fromEl, item: dragEl, to: toEl, newDraggableIndex: newIndex, oldDraggableIndex: oldIndex }) => {
-      globalDragState.active = true;
-      onGlobalDragStart();
+      markDragActive(component);
       component.onDragStart({ fromEl, dragEl, toEl, newIndex, oldIndex });
     },
     onEnd: ({ from: fromEl, item: dragEl, to: toEl, newDraggableIndex: newIndex, oldDraggableIndex: oldIndex }) => {
-      globalDragState.active = false;
-      onGlobalDragEnd();
+      markDragInactive(component);
       component.onDragEnd({ fromEl, dragEl, toEl, newIndex, oldIndex });
     },
     onSort: ({ from: fromEl, item: dragEl, to: toEl, newDraggableIndex: newIndex, oldDraggableIndex: oldIndex }) => {
@@ -217,6 +254,9 @@ export const useSortable = <T extends SortableComponent>(): ReturnType<
     });
 
     controller.onDisconnected(() => {
+      // If unchoose/end is skipped due to abrupt teardown, clear active drag
+      // state to avoid blocking sortable setup for other components.
+      markDragInactive(component);
       tearDownSortable(component);
     });
 


### PR DESCRIPTION
**Related Issue:** #14678

On mobile touch devices, fallback drag can begin before the normal start event. During that window, list updates/reset logic could tear down Sortable, which could leave ghost setup in an invalid state and trigger runtime errors.  
These changes make drag lifecycle handling resilient to that timing and protect against stuck drag state across component lifecycles.

- Tracks active drag state per component (set-based) instead of relying on a single boolean flip at start/end.
- Marks drag as active earlier on choose (before start) and clears on unchoose/end.
- Clears active drag state during disconnect to avoid stale global drag state after abrupt teardown.
- Keeps `fallbackOnBody: true` with inline rationale for stable fallback ghost placement in nested sortable DOM.
