### PR TITLE
ci(actions): sync `bounce back` label to Monday

### DIFF
--- a/.github/scripts/support/monday.js
+++ b/.github/scripts/support/monday.js
@@ -181,7 +181,7 @@ module.exports = function Monday(issue, core, updateIssueBody) {
       },
     ],
     [
-      issueWorkflow.bounceBack,
+      planning.bounceBack,
       {
         column: mondayColumns.bounceBack,
         value: "Bounce Back",

--- a/.github/scripts/support/monday.js
+++ b/.github/scripts/support/monday.js
@@ -159,6 +159,7 @@ module.exports = function Monday(issue, core, updateIssueBody) {
     paused: { id: "color_mkv79bbx", title: "Paused" },
     blocked: { id: "color_mkv7x1gw", title: "Blocked" },
     breaking: { id: "color_mm48xr8j", title: "Breaking" },
+    bounceBack: { id: getColumnId({ calcite: "color_mm4vksav", docs: "color_mm4vh9j8" }), title: "Bounce Back" },
     spike: { id: "color_mkrt20dy", title: "Spike" },
     figmaChanges: { id: "color_mkrvmhg7", title: "Figma Changes" },
     open: { id: "color_mknkrb2n", title: "Open/Closed" },
@@ -177,6 +178,13 @@ module.exports = function Monday(issue, core, updateIssueBody) {
       {
         column: mondayColumns.status,
         value: "Needs Triage",
+      },
+    ],
+    [
+      issueWorkflow.bounceBack,
+      {
+        column: mondayColumns.bounceBack,
+        value: "Bounce Back",
       },
     ],
     [

--- a/.github/scripts/support/monday.js
+++ b/.github/scripts/support/monday.js
@@ -185,6 +185,7 @@ module.exports = function Monday(issue, core, updateIssueBody) {
       {
         column: mondayColumns.bounceBack,
         value: "Bounce Back",
+        clearable: true,
       },
     ],
     [

--- a/.github/scripts/support/resources.js
+++ b/.github/scripts/support/resources.js
@@ -27,6 +27,7 @@ const resources = {
     },
     issueWorkflow: {
       needsTriage: "needs triage",
+      bounceBack: "bounce back",
       inDesign: "1 - in design",
       readyForDev: "2 - ready for dev",
       inDevelopment: "3 - in development",

--- a/.github/scripts/support/resources.js
+++ b/.github/scripts/support/resources.js
@@ -27,7 +27,6 @@ const resources = {
     },
     issueWorkflow: {
       needsTriage: "needs triage",
-      bounceBack: "bounce back",
       inDesign: "1 - in design",
       readyForDev: "2 - ready for dev",
       inDevelopment: "3 - in development",
@@ -41,6 +40,7 @@ const resources = {
       noChangelogEntry: "no changelog entry",
       blocked: "blocked",
       breakingChange: "breaking change",
+      bounceBack: "bounce back",
       futureBreakingChange: "future breaking change",
       monday: "monday.com sync",
       paused: "paused",


### PR DESCRIPTION
**Related Issue:** #14740

## Summary

Syncs the new `bounce back` label to Monday.com, into its own column.

Tested the action runs via triggers from this branch:
- [Add label](https://github.com/Esri/calcite-design-system/actions/runs/28537513650)
- [Remove label](https://github.com/Esri/calcite-design-system/actions/runs/28537547772)
