### PR TITLE
chore(release-please): set `last-release-sha` to `5.1.1` commit

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
   "tag-separator": "@",
-  "last-release-sha": "5dfc16b294629dd3f459ab43132c5e9d7302d35f",
+  "last-release-sha": "c8db0a41fbf65c1b17f7dca2709f691f1792b876",
   "draft-pull-request": true,
   "include-v-in-tag": false,
   "commit-search-depth": 1000,


### PR DESCRIPTION
**Related Issue:** n/a

## Summary

Sets the `last-release-sha` variable to the `5.1.1` release commit, in preparation for the `5.1.2` release.
