### PR TITLE
chore: address node warning when running `input-time-zone` tests

### DIFF
--- a/packages/components/support/run-time-zone-browser-tests.ts
+++ b/packages/components/support/run-time-zone-browser-tests.ts
@@ -17,7 +17,6 @@ const childProcesses = testTimeZones.map(({ name }) => {
       ...process.env,
       BROWSER_TIME_ZONE: name,
     },
-    shell: true,
     stdio: "inherit",
   });
 });


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Addresses the following warning shown in CI test runs:


```bash
@esri/calcite-components:test:ci: Time zone Errors
@esri/calcite-components:test:ci: 
@esri/calcite-components:test:ci: (node:3984) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
@esri/calcite-components:test:ci: (Use `node --trace-deprecation ...` to show where the warning was created)
```