### PR TITLE
ci(actions): add and sync new `estimate - design` labels for 1, 3, 8, and 34

### DIFF
--- a/.github/scripts/support/monday.js
+++ b/.github/scripts/support/monday.js
@@ -509,6 +509,14 @@ module.exports = function Monday(issue, core, updateIssueBody) {
       },
     ],
     [
+      designEstimate.eight,
+      {
+        column: mondayColumns.designEstimate,
+        value: 8,
+        clearable: true,
+      },
+    ],
+    [
       designEstimate.thirteen,
       {
         column: mondayColumns.designEstimate,

--- a/.github/scripts/support/monday.js
+++ b/.github/scripts/support/monday.js
@@ -477,10 +477,26 @@ module.exports = function Monday(issue, core, updateIssueBody) {
       },
     ],
     [
+      designEstimate.one,
+      {
+        column: mondayColumns.designEstimate,
+        value: 1,
+        clearable: true,
+      },
+    ],
+    [
       designEstimate.two,
       {
         column: mondayColumns.designEstimate,
         value: 2,
+        clearable: true,
+      },
+    ],
+    [
+      designEstimate.three,
+      {
+        column: mondayColumns.designEstimate,
+        value: 3,
         clearable: true,
       },
     ],
@@ -505,6 +521,14 @@ module.exports = function Monday(issue, core, updateIssueBody) {
       {
         column: mondayColumns.designEstimate,
         value: 21,
+        clearable: true,
+      },
+    ],
+    [
+      designEstimate.thirtyFour,
+      {
+        column: mondayColumns.designEstimate,
+        value: 34,
         clearable: true,
       },
     ],

--- a/.github/scripts/support/resources.js
+++ b/.github/scripts/support/resources.js
@@ -69,10 +69,13 @@ const resources = {
       thirtyFour: "estimate - 34",
     },
     designEstimate: {
+      one: "estimate - design - 1",
       two: "estimate - design - 2",
+      three: "estimate - design - 3",
       five: "estimate - design - 5",
       thirteen: "estimate - design - 13",
       twentyOne: "estimate - design - 21",
+      thirtyFour: "estimate - design - 34",
     },
     productColor: "006B75",
   },

--- a/.github/scripts/support/resources.js
+++ b/.github/scripts/support/resources.js
@@ -73,6 +73,7 @@ const resources = {
       two: "estimate - design - 2",
       three: "estimate - design - 3",
       five: "estimate - design - 5",
+      eight: "estimate - design - 8",
       thirteen: "estimate - design - 13",
       twentyOne: "estimate - design - 21",
       thirtyFour: "estimate - design - 34",


### PR DESCRIPTION
**Related Issue:** #14774 

## Summary
Adds the new `estimate - design - 1`, `estimate - design - 3`, `estimate - design - 8`, and `estimate - design - 34` labels to resources, and maps its value for syncing to Monday.com.