### PR TITLE
test: add coverage for nested top-layer setups

### DIFF
--- a/packages/components/src/components/action-bar/action-bar.browser.e2e.tsx
+++ b/packages/components/src/components/action-bar/action-bar.browser.e2e.tsx
@@ -186,12 +186,9 @@ describe("top layer placement", () => {
       ),
     {
       componentTarget: page.getBySelector("calcite-action-bar > calcite-action-group"),
+      delegatedTopLayer: true,
       openProp: "menuOpen",
-      openEventName: null,
-      closeEventName: null,
       topLayerTarget: page.getBySelector("calcite-action-bar > calcite-action-group [popover]"),
-      skipCloseCheck: true,
-      skipTopLayerDisabledCheck: true,
     },
   );
 });

--- a/packages/components/src/components/action-bar/action-bar.browser.e2e.tsx
+++ b/packages/components/src/components/action-bar/action-bar.browser.e2e.tsx
@@ -14,6 +14,7 @@ import {
   t9n,
   delegatesToFloatingUiOwningComponent,
   accessible,
+  topLayer,
   themed,
 } from "../../tests/commonTests/browser";
 import { mockConsole } from "../../tests/utils/logging";
@@ -171,6 +172,28 @@ describe("delegates to floating-ui-owner component", () => {
 
 describe("translation support", () => {
   t9n(() => mount("calcite-action-bar"));
+});
+
+describe("top layer placement", () => {
+  topLayer(
+    () =>
+      mount(
+        <calcite-action-bar expand-disabled overflow-actions-disabled>
+          <calcite-action-group>
+            <calcite-action icon="plus" slot="menu-actions" text="Add" />
+          </calcite-action-group>
+        </calcite-action-bar>,
+      ),
+    {
+      componentTarget: page.getBySelector("calcite-action-bar > calcite-action-group"),
+      openProp: "menuOpen",
+      openEventName: null,
+      closeEventName: null,
+      topLayerTarget: page.getBySelector("calcite-action-bar > calcite-action-group [popover]"),
+      skipCloseCheck: true,
+      skipTopLayerDisabledCheck: true,
+    },
+  );
 });
 
 describe("selection-mode", () => {

--- a/packages/components/src/components/action-group/action-group.browser.e2e.tsx
+++ b/packages/components/src/components/action-group/action-group.browser.e2e.tsx
@@ -13,6 +13,7 @@ import {
   slots,
   t9n,
   accessible,
+  topLayer,
   themed,
 } from "../../tests/commonTests/browser";
 import { mockConsole } from "../../tests/utils/logging";
@@ -136,6 +137,25 @@ describe("focusable", () => {
 
 describe("translation support", () => {
   t9n(() => mount("calcite-action-group"));
+});
+
+describe("top layer placement", () => {
+  topLayer(
+    () =>
+      mount(
+        <calcite-action-group>
+          <calcite-action icon="plus" slot={SLOTS.menuActions} text="Add" />
+        </calcite-action-group>,
+      ),
+    {
+      openProp: "menuOpen",
+      openEventName: null,
+      closeEventName: null,
+      skipCloseCheck: true,
+      skipTopLayerDisabledCheck: true,
+      topLayerTarget: page.getBySelector("calcite-action-group [popover]"),
+    },
+  );
 });
 
 describe("actions have no ARIA attributes when selectionMode is 'none'", () => {

--- a/packages/components/src/components/action-group/action-group.browser.e2e.tsx
+++ b/packages/components/src/components/action-group/action-group.browser.e2e.tsx
@@ -148,11 +148,8 @@ describe("top layer placement", () => {
         </calcite-action-group>,
       ),
     {
+      delegatedTopLayer: true,
       openProp: "menuOpen",
-      openEventName: null,
-      closeEventName: null,
-      skipCloseCheck: true,
-      skipTopLayerDisabledCheck: true,
       topLayerTarget: page.getBySelector("calcite-action-group [popover]"),
     },
   );

--- a/packages/components/src/components/action-menu/action-menu.browser.e2e.tsx
+++ b/packages/components/src/components/action-menu/action-menu.browser.e2e.tsx
@@ -1,6 +1,7 @@
 import { h } from "@arcgis/lumina";
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
+import { page } from "vitest/browser";
 import {
   defaults,
   reflects,
@@ -10,6 +11,7 @@ import {
   delegatesToFloatingUiOwningComponent,
   focusable,
   accessible,
+  topLayer,
   themed,
 } from "../../tests/commonTests/browser";
 import { mockConsole } from "../../tests/utils/logging";
@@ -122,6 +124,24 @@ describe("renders", () => {
 
 describe("slots", () => {
   slots(() => mount("calcite-action-menu"), SLOTS);
+});
+
+describe("top layer placement", () => {
+  topLayer(
+    () =>
+      mount(
+        <calcite-action-menu label="test">
+          <calcite-action icon="plus" text="Add" />
+        </calcite-action-menu>,
+      ),
+    {
+      openEventName: null,
+      closeEventName: null,
+      skipCloseCheck: true,
+      skipTopLayerDisabledCheck: true,
+      topLayerTarget: page.getBySelector("calcite-action-menu [popover]"),
+    },
+  );
 });
 
 describe("delegates to floating-ui-owner component", () => {

--- a/packages/components/src/components/action-menu/action-menu.browser.e2e.tsx
+++ b/packages/components/src/components/action-menu/action-menu.browser.e2e.tsx
@@ -135,10 +135,7 @@ describe("top layer placement", () => {
         </calcite-action-menu>,
       ),
     {
-      openEventName: null,
-      closeEventName: null,
-      skipCloseCheck: true,
-      skipTopLayerDisabledCheck: true,
+      delegatedTopLayer: true,
       topLayerTarget: page.getBySelector("calcite-action-menu [popover]"),
     },
   );

--- a/packages/components/src/components/action-pad/action-pad.browser.e2e.tsx
+++ b/packages/components/src/components/action-pad/action-pad.browser.e2e.tsx
@@ -12,6 +12,7 @@ import {
   focusable,
   t9n,
   accessible,
+  topLayer,
   themed,
 } from "../../tests/commonTests/browser";
 import { mockConsole } from "../../tests/utils/logging";
@@ -147,6 +148,27 @@ describe("delegates to floating-ui-owner component", () => {
 
 describe("translation support", () => {
   t9n(() => mount("calcite-action-pad"));
+});
+
+describe("top layer placement", () => {
+  topLayer(
+    () =>
+      mount(
+        <calcite-action-pad expand-disabled>
+          <calcite-action-group>
+            <calcite-action icon="plus" slot="menu-actions" text="Add" />
+          </calcite-action-group>
+        </calcite-action-pad>,
+      ),
+    {
+      componentTarget: page.getBySelector("calcite-action-pad > calcite-action-group"),
+      openProp: "menuOpen",
+      openEventName: null,
+      closeEventName: null,
+      skipCloseCheck: true,
+      skipTopLayerDisabledCheck: true,
+    },
+  );
 });
 
 describe("selection-modes", () => {

--- a/packages/components/src/components/action-pad/action-pad.browser.e2e.tsx
+++ b/packages/components/src/components/action-pad/action-pad.browser.e2e.tsx
@@ -162,11 +162,8 @@ describe("top layer placement", () => {
       ),
     {
       componentTarget: page.getBySelector("calcite-action-pad > calcite-action-group"),
+      delegatedTopLayer: true,
       openProp: "menuOpen",
-      openEventName: null,
-      closeEventName: null,
-      skipCloseCheck: true,
-      skipTopLayerDisabledCheck: true,
     },
   );
 });

--- a/packages/components/src/components/block/block.browser.e2e.tsx
+++ b/packages/components/src/components/block/block.browser.e2e.tsx
@@ -21,6 +21,7 @@ import {
 } from "../../tests/commonTests/browser";
 import { defaultEndMenuPlacement } from "../../utils/floating-ui";
 import { mockConsole } from "../../tests/utils/logging";
+import { CSS as DropdownCSS } from "../dropdown/resources";
 import { CSS, SLOTS } from "./resources";
 
 mockConsole();
@@ -218,11 +219,11 @@ describe("translation support", () => {
 });
 
 describe("top layer placement", () => {
-  topLayer(() => mount(<calcite-block drag-handle heading="heading" sort-disabled={false} />), {
+  topLayer(() => mount(<calcite-block drag-handle heading="heading" />), {
     openProp: "sortHandleOpen",
     openEventName: "calciteBlockSortHandleOpen",
     closeEventName: "calciteBlockSortHandleClose",
-    topLayerTarget: page.getBySelector(".wrapper[popover]"),
+    topLayerTarget: page.getBySelector(`.${DropdownCSS.wrapper}[popover]`),
   });
 });
 

--- a/packages/components/src/components/block/block.browser.e2e.tsx
+++ b/packages/components/src/components/block/block.browser.e2e.tsx
@@ -1,6 +1,7 @@
 import { h } from "@arcgis/lumina";
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
+import { page } from "vitest/browser";
 
 import {
   defaults,
@@ -15,6 +16,7 @@ import {
   disabled,
   openClose,
   accessible,
+  topLayer,
   themed,
 } from "../../tests/commonTests/browser";
 import { defaultEndMenuPlacement } from "../../utils/floating-ui";
@@ -213,6 +215,15 @@ describe("floating-ui", () => {
 
 describe("translation support", () => {
   t9n(() => mount("calcite-block"));
+});
+
+describe("top layer placement", () => {
+  topLayer(() => mount(<calcite-block drag-handle heading="heading" sort-disabled={false} />), {
+    openProp: "sortHandleOpen",
+    openEventName: "calciteBlockSortHandleOpen",
+    closeEventName: "calciteBlockSortHandleClose",
+    topLayerTarget: page.getBySelector(".wrapper[popover]"),
+  });
 });
 
 describe("disabled", () => {

--- a/packages/components/src/components/flow-item/flow-item.browser.e2e.tsx
+++ b/packages/components/src/components/flow-item/flow-item.browser.e2e.tsx
@@ -13,6 +13,7 @@ import {
   t9n,
   disabled,
   accessible,
+  topLayer,
   themed,
 } from "../../tests/commonTests/browser";
 import { mockConsole } from "../../tests/utils/logging";
@@ -220,6 +221,25 @@ describe("delegates to floating-ui-owner component", () => {
 
 describe("translation support", () => {
   t9n(() => mount("calcite-flow-item"), ["calcite-panel"]);
+});
+
+describe("top layer placement", () => {
+  topLayer(
+    () =>
+      mount(
+        <calcite-flow-item>
+          <calcite-action icon="plus" slot={SLOTS.headerMenuActions} text="Add" />
+        </calcite-flow-item>,
+      ),
+    {
+      openProp: "menuOpen",
+      openEventName: null,
+      closeEventName: null,
+      topLayerTarget: page.getBySelector("calcite-flow-item [popover]"),
+      skipCloseCheck: true,
+      skipTopLayerDisabledCheck: true,
+    },
+  );
 });
 
 describe("disabled", () => {

--- a/packages/components/src/components/flow-item/flow-item.browser.e2e.tsx
+++ b/packages/components/src/components/flow-item/flow-item.browser.e2e.tsx
@@ -232,12 +232,9 @@ describe("top layer placement", () => {
         </calcite-flow-item>,
       ),
     {
+      delegatedTopLayer: true,
       openProp: "menuOpen",
-      openEventName: null,
-      closeEventName: null,
       topLayerTarget: page.getBySelector("calcite-flow-item [popover]"),
-      skipCloseCheck: true,
-      skipTopLayerDisabledCheck: true,
     },
   );
 });

--- a/packages/components/src/components/input-time-zone/input-time-zone.browser.e2e.tsx
+++ b/packages/components/src/components/input-time-zone/input-time-zone.browser.e2e.tsx
@@ -13,6 +13,7 @@ import {
   t9n,
   themed,
   openClose,
+  topLayer,
 } from "../../tests/commonTests/browser";
 import { mockConsole } from "../../tests/utils/logging";
 import { defaultValidity } from "../../tests/commonTests/browser/defaults";
@@ -80,6 +81,10 @@ describe("focusable", () => {
 
 describe("openClose", () => {
   openClose((mountOptions) => mount("calcite-input-time-zone", mountOptions));
+});
+
+describe("top layer placement", () => {
+  topLayer(() => mount("calcite-input-time-zone"));
 });
 
 describe("translation support", () => {

--- a/packages/components/src/components/list-item/list-item.browser.e2e.tsx
+++ b/packages/components/src/components/list-item/list-item.browser.e2e.tsx
@@ -10,10 +10,14 @@ import {
   reflects,
   renders,
   slots,
+  topLayer,
   themed,
 } from "../../tests/commonTests/browser";
+import { mockConsole } from "../../tests/utils/logging";
 import { CSS, SLOTS } from "./resources";
 import type { ListItem } from "./list-item";
+
+mockConsole();
 
 describe("defaults", () => {
   defaults(
@@ -147,6 +151,17 @@ describe("is focusable", () => {
 
 describe("disabled", () => {
   disabled(() => mount(<calcite-list-item active label="test" />));
+});
+
+describe("top layer placement", () => {
+  topLayer(
+    () => mount(<calcite-list-item drag-handle label="test" set-position="1" set-size="4" />),
+    {
+      openProp: "sortHandleOpen",
+      openEventName: "calciteListItemSortHandleOpen",
+      closeEventName: "calciteListItemSortHandleClose",
+    },
+  );
 });
 
 it("emits calciteInternalListItemChange only when metadata values change", async () => {

--- a/packages/components/src/components/list-item/list-item.browser.e2e.tsx
+++ b/packages/components/src/components/list-item/list-item.browser.e2e.tsx
@@ -17,8 +17,6 @@ import { mockConsole } from "../../tests/utils/logging";
 import { CSS, SLOTS } from "./resources";
 import type { ListItem } from "./list-item";
 
-mockConsole();
-
 describe("defaults", () => {
   defaults(
     () => mount("calcite-list-item"),
@@ -154,6 +152,8 @@ describe("disabled", () => {
 });
 
 describe("top layer placement", () => {
+  mockConsole();
+
   topLayer(
     () => mount(<calcite-list-item drag-handle label="test" set-position="1" set-size="4" />),
     {

--- a/packages/components/src/components/panel/panel.browser.e2e.tsx
+++ b/packages/components/src/components/panel/panel.browser.e2e.tsx
@@ -349,12 +349,9 @@ describe("top layer placement", () => {
         </calcite-panel>,
       ),
     {
+      delegatedTopLayer: true,
       openProp: "menuOpen",
-      openEventName: null,
-      closeEventName: null,
       topLayerTarget: page.getBySelector("calcite-panel [popover]"),
-      skipCloseCheck: true,
-      skipTopLayerDisabledCheck: true,
     },
   );
 });

--- a/packages/components/src/components/panel/panel.browser.e2e.tsx
+++ b/packages/components/src/components/panel/panel.browser.e2e.tsx
@@ -14,6 +14,7 @@ import {
   t9n,
   disabled,
   accessible,
+  topLayer,
   themed,
 } from "../../tests/commonTests/browser";
 import { defaultEndMenuPlacement } from "../../utils/floating-ui";
@@ -337,6 +338,25 @@ describe("floating-ui", () => {
 
 describe("translation support", () => {
   t9n(() => mount("calcite-panel"));
+});
+
+describe("top layer placement", () => {
+  topLayer(
+    () =>
+      mount(
+        <calcite-panel>
+          <calcite-action icon="plus" slot={SLOTS.headerMenuActions} text="Add" />
+        </calcite-panel>,
+      ),
+    {
+      openProp: "menuOpen",
+      openEventName: null,
+      closeEventName: null,
+      topLayerTarget: page.getBySelector("calcite-panel [popover]"),
+      skipCloseCheck: true,
+      skipTopLayerDisabledCheck: true,
+    },
+  );
 });
 
 describe("disabled", () => {

--- a/packages/components/src/components/sort-handle/sort-handle.browser.e2e.tsx
+++ b/packages/components/src/components/sort-handle/sort-handle.browser.e2e.tsx
@@ -12,6 +12,7 @@ import {
   t9n,
   openClose,
   accessible,
+  topLayer,
 } from "../../tests/commonTests/browser";
 import { mockConsole } from "../../tests/utils/logging";
 import T9nStrings from "./assets/t9n/messages.en.json";
@@ -97,6 +98,10 @@ describe("openClose", () => {
   openClose((mountOptions) =>
     mount(<calcite-sort-handle label="test" set-position="4" set-size="10" />, mountOptions),
   );
+});
+
+describe("top layer placement", () => {
+  topLayer(() => mount(<calcite-sort-handle label="test" set-position="4" set-size="10" />));
 });
 
 describe("translation support", () => {

--- a/packages/components/src/components/split-button/split-button.browser.e2e.tsx
+++ b/packages/components/src/components/split-button/split-button.browser.e2e.tsx
@@ -10,6 +10,7 @@ import {
   renders,
   disabled,
   accessible,
+  topLayer,
   themed,
 } from "../../tests/commonTests/browser";
 import { mockConsole } from "../../tests/utils/logging";
@@ -183,6 +184,22 @@ describe("focusable", () => {
 
 describe("disabled", () => {
   disabled(() => mount("calcite-split-button"));
+});
+
+describe("top layer placement", () => {
+  topLayer(
+    () =>
+      mount(
+        <calcite-split-button dropdown-label="Show options" primary-text="Button Text">
+          {renderContent()}
+        </calcite-split-button>,
+      ),
+    {
+      openProp: "active",
+      openEventName: "calciteDropdownOpen",
+      closeEventName: "calciteDropdownClose",
+    },
+  );
 });
 
 describe("theme", () => {

--- a/packages/components/src/components/split-button/split-button.browser.e2e.tsx
+++ b/packages/components/src/components/split-button/split-button.browser.e2e.tsx
@@ -1,6 +1,7 @@
 import { h, JsxNode } from "@arcgis/lumina";
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
+import { page } from "vitest/browser";
 
 import {
   defaults,
@@ -195,9 +196,8 @@ describe("top layer placement", () => {
         </calcite-split-button>,
       ),
     {
+      eventTarget: page.getBySelector("calcite-split-button calcite-dropdown"),
       openProp: "active",
-      openEventName: "calciteDropdownOpen",
-      closeEventName: "calciteDropdownClose",
     },
   );
 });

--- a/packages/components/src/components/split-button/split-button.browser.e2e.tsx
+++ b/packages/components/src/components/split-button/split-button.browser.e2e.tsx
@@ -196,7 +196,7 @@ describe("top layer placement", () => {
         </calcite-split-button>,
       ),
     {
-      eventTarget: page.getBySelector("calcite-split-button calcite-dropdown"),
+      eventEmitter: page.getBySelector("calcite-split-button calcite-dropdown"),
       openProp: "active",
     },
   );

--- a/packages/components/src/tests/commonTests/browser/top-layer.ts
+++ b/packages/components/src/tests/commonTests/browser/top-layer.ts
@@ -74,7 +74,13 @@ export async function topLayer(setup: () => ReturnType<typeof mount>, options?: 
   it("supports being placed in top layer", async () => {
     const { el } = await setup();
     const openProp = options?.openProp ?? "open";
-    const componentEl = (options?.componentTarget?.element() ?? el) as HTMLElement & {
+    const componentElFromLocator = options?.componentTarget?.element();
+
+    if (options?.componentTarget && !componentElFromLocator) {
+      throw new Error("componentTarget did not resolve to an element.");
+    }
+
+    const componentEl = (componentElFromLocator ?? el) as HTMLElement & {
       [key: string]: unknown;
       topLayerDisabled?: boolean;
     };

--- a/packages/components/src/tests/commonTests/browser/top-layer.ts
+++ b/packages/components/src/tests/commonTests/browser/top-layer.ts
@@ -16,7 +16,10 @@ type TopLayerOptions = {
   /**
    * Locator for the element that will be placed in the top layer.
    *
-   * Defaults to first element with the popover attribute present.
+   * Defaults to all elements matching `[popover]`.
+   *
+   * If this locator resolves to multiple elements, provide `topLayerTargetSelector`
+   * or a more specific `topLayerTarget` locator to avoid ambiguous assertions.
    */
   topLayerTarget?: Locator;
 

--- a/packages/components/src/tests/commonTests/browser/top-layer.ts
+++ b/packages/components/src/tests/commonTests/browser/top-layer.ts
@@ -38,17 +38,17 @@ type TopLayerOptions = {
    *
    * Defaults to `componentTarget`, or the mounted component element when `componentTarget` is omitted.
    */
-  eventTarget?: Locator;
+  eventEmitter?: Locator;
 
   /**
-   * Event name emitted when the component opens. Defaults to `${getEventPrefix(eventTarget)}Open` using
-   * `eventTarget`, `componentTarget`, or the mounted component. When set to `null`, no event wait is performed.
+   * Event name emitted when the component opens. Defaults to `${getEventPrefix(eventEmitter)}Open` using
+   * `eventEmitter`, `componentTarget`, or the mounted component. When set to `null`, no event wait is performed.
    */
   openEventName?: string | null;
 
   /**
-   * Event name emitted when the component closes. Defaults to `${getEventPrefix(eventTarget)}Close` using
-   * `eventTarget`, `componentTarget`, or the mounted component. When set to `null`, no event wait is performed.
+   * Event name emitted when the component closes. Defaults to `${getEventPrefix(eventEmitter)}Close` using
+   * `eventEmitter`, `componentTarget`, or the mounted component. When set to `null`, no event wait is performed.
    */
   closeEventName?: string | null;
 
@@ -71,15 +71,12 @@ export async function topLayer(setup: () => ReturnType<typeof mount>, options?: 
     const { el, reRender } = await setup();
     const openProp = options?.openProp ?? "open";
     const componentElFromLocator = options?.componentTarget?.element();
-    const eventElFromLocator = options?.eventTarget?.element();
+    const eventElFromLocator = options?.eventEmitter?.element();
+    const hasUnresolvedComponentTarget = Boolean(options?.componentTarget && !componentElFromLocator);
+    const hasUnresolvedEventEmitter = Boolean(options?.eventEmitter && !eventElFromLocator);
 
-    if (options?.componentTarget && !componentElFromLocator) {
-      throw new Error("componentTarget did not resolve to an element.");
-    }
-
-    if (options?.eventTarget && !eventElFromLocator) {
-      throw new Error("eventTarget did not resolve to an element.");
-    }
+    expect(hasUnresolvedComponentTarget).toBe(false);
+    expect(hasUnresolvedEventEmitter).toBe(false);
 
     const componentEl = (componentElFromLocator ?? el) as HTMLElement & {
       [key: string]: unknown;
@@ -87,17 +84,7 @@ export async function topLayer(setup: () => ReturnType<typeof mount>, options?: 
     };
     const eventEl = (eventElFromLocator ?? componentEl) as HTMLElement;
     const targetLocator = options?.topLayerTarget ?? page.getBySelector("[popover]");
-    const topLayerElements = targetLocator.elements();
-
-    if (topLayerElements.length === 0) {
-      throw new Error("No top-layer target found.");
-    }
-
-    if (topLayerElements.length > 1) {
-      throw new Error("Multiple top-layer targets found. Provide a more specific topLayerTarget locator.");
-    }
-
-    const [topLayerEl] = topLayerElements;
+    const topLayerEl = targetLocator.element();
     const delegatedTopLayer = options?.delegatedTopLayer ?? false;
     const openEventName =
       delegatedTopLayer || options?.openEventName === null

--- a/packages/components/src/tests/commonTests/browser/top-layer.ts
+++ b/packages/components/src/tests/commonTests/browser/top-layer.ts
@@ -19,6 +19,45 @@ type TopLayerOptions = {
    * Defaults to first element with the popover attribute present.
    */
   topLayerTarget?: Locator;
+
+  /**
+   * Selector used to pick a single top-layer target when `topLayerTarget` resolves to multiple elements.
+   * The selector must match the top-layer host element itself.
+   *
+   * If omitted and multiple targets are found, the helper throws to avoid ambiguous assertions.
+   */
+  topLayerTargetSelector?: string;
+
+  /**
+   * Locator for the component whose open state is toggled.
+   *
+   * Defaults to the mounted component element.
+   */
+  componentTarget?: Locator;
+
+  /**
+   * Event name emitted when the component opens.
+   *
+   * Defaults to `${getEventPrefix(componentEl)}Open`.
+   *
+   * When set to `null`, no event wait is performed.
+   */
+  openEventName?: string | null;
+
+  /**
+   * Event name emitted when the component closes.
+   *
+   * Defaults to `${getEventPrefix(componentEl)}Close`.
+   *
+   * When set to `null`, no event wait is performed.
+   */
+  closeEventName?: string | null;
+
+  /** When `true`, skips close-state assertions. Defaults to `false`. */
+  skipCloseCheck?: boolean;
+
+  /** When `true`, skips `topLayerDisabled` assertions. Defaults to `false`. */
+  skipTopLayerDisabledCheck?: boolean;
 };
 
 /**
@@ -35,34 +74,82 @@ export async function topLayer(setup: () => ReturnType<typeof mount>, options?: 
   it("supports being placed in top layer", async () => {
     const { el } = await setup();
     const openProp = options?.openProp ?? "open";
+    const componentEl = (options?.componentTarget?.element() ?? el) as HTMLElement & {
+      [key: string]: unknown;
+      topLayerDisabled?: boolean;
+    };
     const targetLocator = options?.topLayerTarget ?? page.getBySelector("[popover]");
-    const topLayerEl = targetLocator.element();
+    const topLayerElements = targetLocator.elements();
+    const topLayerTargetSelector = options?.topLayerTargetSelector;
+
+    if (topLayerElements.length === 0) {
+      throw new Error("No top-layer target found.");
+    }
+
+    if (topLayerElements.length > 1 && topLayerTargetSelector === undefined) {
+      throw new Error(
+        "Multiple top-layer targets found. Provide a specific topLayerTarget locator or set topLayerTargetSelector.",
+      );
+    }
+
+    const matchingTopLayerElements =
+      topLayerTargetSelector !== undefined
+        ? topLayerElements.filter((topLayerElement) => topLayerElement.matches(topLayerTargetSelector))
+        : topLayerElements;
+
+    if (topLayerTargetSelector !== undefined && matchingTopLayerElements.length === 0) {
+      throw new Error(`No top-layer host elements matched topLayerTargetSelector: ${topLayerTargetSelector}`);
+    }
+
+    if (topLayerTargetSelector !== undefined && matchingTopLayerElements.length > 1) {
+      throw new Error(
+        `Multiple top-layer host elements matched topLayerTargetSelector: ${topLayerTargetSelector}. Use a more specific selector.`,
+      );
+    }
+
+    const [topLayerEl] = matchingTopLayerElements;
+    const openEventName =
+      options?.openEventName === null ? null : (options?.openEventName ?? `${getEventPrefix(componentEl)}Open`);
+    const closeEventName =
+      options?.closeEventName === null ? null : (options?.closeEventName ?? `${getEventPrefix(componentEl)}Close`);
+    const skipCloseCheck = options?.skipCloseCheck ?? false;
+    const skipTopLayerDisabledCheck = options?.skipTopLayerDisabledCheck ?? false;
 
     expect(isInTopLayer(topLayerEl)).toBe(false);
 
-    const componentOpen = waitForEvent(el, `${getEventPrefix(el)}Open`);
-    el[openProp] = true;
+    const componentOpen = openEventName ? waitForEvent(componentEl, openEventName) : null;
+    componentEl[openProp] = true;
     await componentOpen;
     await afterNextTask();
 
     expect(isInTopLayer(topLayerEl)).toBe(true);
 
-    const componentClose = waitForEvent(el, `${getEventPrefix(el)}Close`);
-    el[openProp] = false;
-    await componentClose;
-    await afterNextTask();
+    if (!skipCloseCheck) {
+      const componentClose = closeEventName ? waitForEvent(componentEl, closeEventName) : null;
+      componentEl[openProp] = false;
+      await componentClose;
+      await afterNextTask();
+    } else {
+      componentEl[openProp] = false;
+      await afterNextTask();
+    }
 
-    expect(isInTopLayer(topLayerEl)).toBe(false);
+    const closedState = !skipCloseCheck ? isInTopLayer(topLayerEl) : undefined;
+    expect(closedState).toBe(!skipCloseCheck ? false : undefined);
 
-    if ("topLayerDisabled" in el) {
-      const componentOpen = waitForEvent(el, `${getEventPrefix(el)}Open`);
-      el.topLayerDisabled = true;
-      el[openProp] = true;
+    const shouldAssertTopLayerDisabled = !skipTopLayerDisabledCheck && "topLayerDisabled" in componentEl;
+    let topLayerDisabledState: boolean | null = null;
+
+    if (shouldAssertTopLayerDisabled) {
+      const componentOpen = openEventName ? waitForEvent(componentEl, openEventName) : null;
+      componentEl.topLayerDisabled = true;
+      componentEl[openProp] = true;
       await componentOpen;
       await afterNextTask();
 
-      // eslint-disable-next-line vitest/no-conditional-expect -- assertion depends on optional component feature
-      expect(isInTopLayer(topLayerEl)).toBe(false);
+      topLayerDisabledState = isInTopLayer(topLayerEl);
     }
+
+    expect(topLayerDisabledState).toBe(shouldAssertTopLayerDisabled ? false : null);
   });
 }

--- a/packages/components/src/tests/commonTests/browser/top-layer.ts
+++ b/packages/components/src/tests/commonTests/browser/top-layer.ts
@@ -1,11 +1,17 @@
 import { expect, it } from "vitest";
 import { Locator, page } from "vitest/browser";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { afterNextTask } from "../../utils/timing";
 import { isInTopLayer } from "../../utils/dom";
 import { getEventPrefix, waitForEvent } from "./utils";
 
 type TopLayerOptions = {
+  /**
+   * When `true`, the component delegates top-layer state to a nested owner.
+   *
+   * This disables open/close event waits and skips close-state assertions.
+   */
+  delegatedTopLayer?: boolean;
+
   /**
    * Prop name for toggling the top-layer element.
    *
@@ -17,19 +23,8 @@ type TopLayerOptions = {
    * Locator for the element that will be placed in the top layer.
    *
    * Defaults to all elements matching `[popover]`.
-   *
-   * If this locator resolves to multiple elements, provide `topLayerTargetSelector`
-   * or a more specific `topLayerTarget` locator to avoid ambiguous assertions.
    */
   topLayerTarget?: Locator;
-
-  /**
-   * Selector used to pick a single top-layer target when `topLayerTarget` resolves to multiple elements.
-   * The selector must match the top-layer host element itself.
-   *
-   * If omitted and multiple targets are found, the helper throws to avoid ambiguous assertions.
-   */
-  topLayerTargetSelector?: string;
 
   /**
    * Locator for the component whose open state is toggled.
@@ -39,28 +34,26 @@ type TopLayerOptions = {
   componentTarget?: Locator;
 
   /**
-   * Event name emitted when the component opens.
+   * Locator for the component that emits open and close events.
    *
-   * Defaults to `${getEventPrefix(componentEl)}Open`.
-   *
-   * When set to `null`, no event wait is performed.
+   * Defaults to `componentTarget`, or the mounted component element when `componentTarget` is omitted.
+   */
+  eventTarget?: Locator;
+
+  /**
+   * Event name emitted when the component opens. Defaults to `${getEventPrefix(eventTarget)}Open` using
+   * `eventTarget`, `componentTarget`, or the mounted component. When set to `null`, no event wait is performed.
    */
   openEventName?: string | null;
 
   /**
-   * Event name emitted when the component closes.
-   *
-   * Defaults to `${getEventPrefix(componentEl)}Close`.
-   *
-   * When set to `null`, no event wait is performed.
+   * Event name emitted when the component closes. Defaults to `${getEventPrefix(eventTarget)}Close` using
+   * `eventTarget`, `componentTarget`, or the mounted component. When set to `null`, no event wait is performed.
    */
   closeEventName?: string | null;
 
   /** When `true`, skips close-state assertions. Defaults to `false`. */
   skipCloseCheck?: boolean;
-
-  /** When `true`, skips `topLayerDisabled` assertions. Defaults to `false`. */
-  skipTopLayerDisabledCheck?: boolean;
 };
 
 /**
@@ -75,89 +68,86 @@ type TopLayerOptions = {
  */
 export async function topLayer(setup: () => ReturnType<typeof mount>, options?: TopLayerOptions): Promise<void> {
   it("supports being placed in top layer", async () => {
-    const { el } = await setup();
+    const { el, reRender } = await setup();
     const openProp = options?.openProp ?? "open";
     const componentElFromLocator = options?.componentTarget?.element();
+    const eventElFromLocator = options?.eventTarget?.element();
 
     if (options?.componentTarget && !componentElFromLocator) {
       throw new Error("componentTarget did not resolve to an element.");
+    }
+
+    if (options?.eventTarget && !eventElFromLocator) {
+      throw new Error("eventTarget did not resolve to an element.");
     }
 
     const componentEl = (componentElFromLocator ?? el) as HTMLElement & {
       [key: string]: unknown;
       topLayerDisabled?: boolean;
     };
+    const eventEl = (eventElFromLocator ?? componentEl) as HTMLElement;
     const targetLocator = options?.topLayerTarget ?? page.getBySelector("[popover]");
     const topLayerElements = targetLocator.elements();
-    const topLayerTargetSelector = options?.topLayerTargetSelector;
 
     if (topLayerElements.length === 0) {
       throw new Error("No top-layer target found.");
     }
 
-    if (topLayerElements.length > 1 && topLayerTargetSelector === undefined) {
-      throw new Error(
-        "Multiple top-layer targets found. Provide a specific topLayerTarget locator or set topLayerTargetSelector.",
-      );
+    if (topLayerElements.length > 1) {
+      throw new Error("Multiple top-layer targets found. Provide a more specific topLayerTarget locator.");
     }
 
-    const matchingTopLayerElements =
-      topLayerTargetSelector !== undefined
-        ? topLayerElements.filter((topLayerElement) => topLayerElement.matches(topLayerTargetSelector))
-        : topLayerElements;
-
-    if (topLayerTargetSelector !== undefined && matchingTopLayerElements.length === 0) {
-      throw new Error(`No top-layer host elements matched topLayerTargetSelector: ${topLayerTargetSelector}`);
-    }
-
-    if (topLayerTargetSelector !== undefined && matchingTopLayerElements.length > 1) {
-      throw new Error(
-        `Multiple top-layer host elements matched topLayerTargetSelector: ${topLayerTargetSelector}. Use a more specific selector.`,
-      );
-    }
-
-    const [topLayerEl] = matchingTopLayerElements;
+    const [topLayerEl] = topLayerElements;
+    const delegatedTopLayer = options?.delegatedTopLayer ?? false;
     const openEventName =
-      options?.openEventName === null ? null : (options?.openEventName ?? `${getEventPrefix(componentEl)}Open`);
+      delegatedTopLayer || options?.openEventName === null
+        ? null
+        : (options?.openEventName ?? `${getEventPrefix(eventEl)}Open`);
     const closeEventName =
-      options?.closeEventName === null ? null : (options?.closeEventName ?? `${getEventPrefix(componentEl)}Close`);
-    const skipCloseCheck = options?.skipCloseCheck ?? false;
-    const skipTopLayerDisabledCheck = options?.skipTopLayerDisabledCheck ?? false;
+      delegatedTopLayer || options?.closeEventName === null
+        ? null
+        : (options?.closeEventName ?? `${getEventPrefix(eventEl)}Close`);
+    const skipCloseCheck = delegatedTopLayer || (options?.skipCloseCheck ?? false);
+
+    async function expectTopLayerState(expectedState: boolean): Promise<boolean> {
+      await expect.poll(() => isInTopLayer(topLayerEl)).toBe(expectedState);
+      return isInTopLayer(topLayerEl);
+    }
 
     expect(isInTopLayer(topLayerEl)).toBe(false);
 
-    const componentOpen = openEventName ? waitForEvent(componentEl, openEventName) : null;
+    const componentOpen = openEventName ? waitForEvent(eventEl, openEventName) : null;
     componentEl[openProp] = true;
     await componentOpen;
-    await afterNextTask();
+    await reRender();
 
-    expect(isInTopLayer(topLayerEl)).toBe(true);
+    await expectTopLayerState(true);
 
     if (!skipCloseCheck) {
-      const componentClose = closeEventName ? waitForEvent(componentEl, closeEventName) : null;
+      const componentClose = closeEventName ? waitForEvent(eventEl, closeEventName) : null;
       componentEl[openProp] = false;
       await componentClose;
-      await afterNextTask();
+      await reRender();
     } else {
       componentEl[openProp] = false;
-      await afterNextTask();
+      await reRender();
     }
 
-    const closedState = !skipCloseCheck ? isInTopLayer(topLayerEl) : undefined;
+    const closedState = !skipCloseCheck ? await expectTopLayerState(false) : undefined;
     expect(closedState).toBe(!skipCloseCheck ? false : undefined);
 
-    const shouldAssertTopLayerDisabled = !skipTopLayerDisabledCheck && "topLayerDisabled" in componentEl;
-    let topLayerDisabledState: boolean | null = null;
+    const shouldAssertTopLayerDisabled = "topLayerDisabled" in componentEl;
+    const topLayerDisabledState = shouldAssertTopLayerDisabled
+      ? await (async (): Promise<boolean> => {
+          const componentOpen = openEventName ? waitForEvent(eventEl, openEventName) : null;
+          componentEl.topLayerDisabled = true;
+          componentEl[openProp] = true;
+          await componentOpen;
+          await reRender();
 
-    if (shouldAssertTopLayerDisabled) {
-      const componentOpen = openEventName ? waitForEvent(componentEl, openEventName) : null;
-      componentEl.topLayerDisabled = true;
-      componentEl[openProp] = true;
-      await componentOpen;
-      await afterNextTask();
-
-      topLayerDisabledState = isInTopLayer(topLayerEl);
-    }
+          return expectTopLayerState(false);
+        })()
+      : null;
 
     expect(topLayerDisabledState).toBe(shouldAssertTopLayerDisabled ? false : null);
   });

--- a/packages/components/src/tests/commonTests/browser/top-layer.ts
+++ b/packages/components/src/tests/commonTests/browser/top-layer.ts
@@ -110,8 +110,9 @@ export async function topLayer(setup: () => ReturnType<typeof mount>, options?: 
     const skipCloseCheck = delegatedTopLayer || (options?.skipCloseCheck ?? false);
 
     async function expectTopLayerState(expectedState: boolean): Promise<boolean> {
-      await expect.poll(() => isInTopLayer(topLayerEl)).toBe(expectedState);
-      return isInTopLayer(topLayerEl);
+      let currentState = false;
+      await expect.poll(() => (currentState = isInTopLayer(topLayerEl))).toBe(expectedState);
+      return currentState;
     }
 
     expect(isInTopLayer(topLayerEl)).toBe(false);


### PR DESCRIPTION
**Related Issue:** #13740

## Summary

This PR adds Vitest browser coverage to verify HTML top-layer behavior for components that render floating menu/popover content, and expands the shared top-layer test helper to support wrapper/nested component scenarios.

- Added `top layer placement` browser tests to:
  - `action-bar`
  - `action-group`
  - `action-menu`
  - `action-pad`
  - `block`
  - `flow-item`
  - `input-time-zone`
  - `list-item`
  - `panel`
  - `sort-handle`
  - `split-button`
- Enhanced shared helper:
