### PR TITLE
fix(components): use layoutViewport boundary for floating-ui positioning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2378,28 +2378,28 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
-      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/utils": "^0.2.11"
+        "@floating-ui/utils": "^0.2.12"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
-      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+      "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^1.7.5",
-        "@floating-ui/utils": "^0.2.11"
+        "@floating-ui/core": "^1.8.0",
+        "@floating-ui/utils": "^0.2.12"
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
-      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+      "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
       "license": "MIT",
       "peer": true
     },
@@ -28850,13 +28850,13 @@
         "@arcgis/lumina": ">=5.1.0-next.96 <6.0.0",
         "@arcgis/toolkit": ">=5.1.0-next.96 <6.0.0",
         "@esri/calcite-ui-icons": "4.6.0-next.7",
-        "@floating-ui/dom": "^1.6.12",
+        "@floating-ui/dom": "^1.8.0",
         "@floating-ui/utils": "^0.2.8",
         "@types/sortablejs": "^1.15.8",
         "color": "^5.0.3",
         "composed-offset-position": "^0.0.6",
         "es-toolkit": "^1.39.8",
-        "focus-trap": "8.2.1",
+        "focus-trap": "^8.2.1",
         "interactjs": "^1.10.27",
         "lit": "^3.3.0",
         "sortablejs": "^1.15.6",

--- a/packages/components/index.html
+++ b/packages/components/index.html
@@ -8,14 +8,16 @@
   </head>
 
   <body>
-    <demo-dom-swapper>
-      <!-- demo snippet start -->
-
-      <!-- use this page for quickly setting up your page for a bug fix/repro cases or feature enhancement -->
-      <!-- you can add a demo snippet by running `npx snippet` -->
-
-      <!-- demo snippet end -->
-    </demo-dom-swapper>
-    <demo-options></demo-options>
+    <button id="ref">Reference element</button>
+    <calcite-popover open reference-element="ref">
+      <div style="display: flex; flex-direction: column; justify-content: end; width: 300px; background-color: white">
+        <p>
+          On a mobile device oriented horizontally, the virtual keyboard auto-closes as soon as you focus the input
+          below. This is not an issue if you render the same popover content outside an expand, on its own. The element
+          will shrink in height to ensure the input is always visible.
+        </p>
+        <calcite-input placeholder="Focus me if you can! (You can't)"></calcite-input>
+      </div>
+    </calcite-popover>
   </body>
 </html>

--- a/packages/components/index.html
+++ b/packages/components/index.html
@@ -8,16 +8,14 @@
   </head>
 
   <body>
-    <button id="ref">Reference element</button>
-    <calcite-popover open reference-element="ref">
-      <div style="display: flex; flex-direction: column; justify-content: end; width: 300px; background-color: white">
-        <p>
-          On a mobile device oriented horizontally, the virtual keyboard auto-closes as soon as you focus the input
-          below. This is not an issue if you render the same popover content outside an expand, on its own. The element
-          will shrink in height to ensure the input is always visible.
-        </p>
-        <calcite-input placeholder="Focus me if you can! (You can't)"></calcite-input>
-      </div>
-    </calcite-popover>
+    <demo-dom-swapper>
+      <!-- demo snippet start -->
+
+      <!-- use this page for quickly setting up your page for a bug fix/repro cases or feature enhancement -->
+      <!-- you can add a demo snippet by running `npx snippet` -->
+
+      <!-- demo snippet end -->
+    </demo-dom-swapper>
+    <demo-options></demo-options>
   </body>
 </html>

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -76,7 +76,7 @@
     "@arcgis/lumina": ">=5.1.0-next.96 <6.0.0",
     "@arcgis/toolkit": ">=5.1.0-next.96 <6.0.0",
     "@esri/calcite-ui-icons": "4.6.0-next.7",
-    "@floating-ui/dom": "^1.6.12",
+    "@floating-ui/dom": "^1.8.0",
     "@floating-ui/utils": "^0.2.8",
     "@types/sortablejs": "^1.15.8",
     "color": "^5.0.3",

--- a/packages/components/src/utils/floating-ui.browser.spec.ts
+++ b/packages/components/src/utils/floating-ui.browser.spec.ts
@@ -14,6 +14,7 @@ const {
   flipPlacements,
   filterValidFlipPlacements,
   getEffectivePlacement,
+  getMiddleware,
   placements,
   reposition,
 } = floatingUI;
@@ -225,6 +226,38 @@ describe("connect/disconnect helpers", () => {
 
 it("should have correct value for defaultOffsetDistance", () => {
   expect(defaultOffsetDistance).toBe(6);
+});
+
+it("should use layoutViewport rootBoundary in viewport-aware middleware", () => {
+  const middleware = getMiddleware({
+    placement: "auto",
+    type: "menu",
+  });
+
+  const viewportAwareMiddleware = middleware.filter(({ name }) =>
+    ["shift", "flip", "autoPlacement", "hide"].includes(name),
+  );
+
+  expect(viewportAwareMiddleware).toHaveLength(4);
+
+  viewportAwareMiddleware.forEach((middleware) => {
+    expect(middleware.options?.rootBoundary).toBe("layoutViewport");
+  });
+});
+
+it("should use layoutViewport rootBoundary in non-auto flip middleware", () => {
+  const middleware = getMiddleware({
+    placement: "top",
+    type: "popover",
+  });
+
+  const viewportAwareMiddleware = middleware.filter(({ name }) => ["shift", "flip", "hide"].includes(name));
+
+  expect(viewportAwareMiddleware).toHaveLength(3);
+
+  viewportAwareMiddleware.forEach((middleware) => {
+    expect(middleware.options?.rootBoundary).toBe("layoutViewport");
+  });
 });
 
 describe("filterValidFlipPlacements", () => {

--- a/packages/components/src/utils/floating-ui.browser.spec.ts
+++ b/packages/components/src/utils/floating-ui.browser.spec.ts
@@ -260,6 +260,35 @@ it("should use layoutViewport rootBoundary in non-auto flip middleware", () => {
   });
 });
 
+it("should only add one flip middleware for non-auto menu placements", () => {
+  const middleware = getMiddleware({
+    placement: "top",
+    type: "menu",
+  });
+
+  expect(middleware.filter(({ name }) => name === "flip")).toHaveLength(1);
+});
+
+it("should not add menu flip middleware when flipDisabled is true", () => {
+  const middleware = getMiddleware({
+    flipDisabled: true,
+    placement: "top",
+    type: "menu",
+  });
+
+  expect(middleware.filter(({ name }) => name === "flip")).toHaveLength(0);
+});
+
+it("should not add menu flip middleware for auto placements when flipDisabled is true", () => {
+  const middleware = getMiddleware({
+    flipDisabled: true,
+    placement: "auto",
+    type: "menu",
+  });
+
+  expect(middleware.filter(({ name }) => name === "flip")).toHaveLength(0);
+});
+
 describe("filterValidFlipPlacements", () => {
   mockConsole();
 

--- a/packages/components/src/utils/floating-ui.ts
+++ b/packages/components/src/utils/floating-ui.ts
@@ -5,7 +5,6 @@ import {
   autoUpdate,
   computePosition,
   flip,
-  FlipOptions,
   hide,
   Middleware,
   offset,
@@ -360,15 +359,6 @@ export function getMiddleware({
     }),
   ];
 
-  if (type === "menu") {
-    middleware.push(
-      flip({
-        fallbackPlacements: flipPlacements || ["top-start", "top", "top-end", "bottom-start", "bottom", "bottom-end"],
-        rootBoundary,
-      }),
-    );
-  }
-
   middleware.push(
     offset({
       mainAxis: typeof offsetDistance === "number" ? offsetDistance : 0,
@@ -383,9 +373,19 @@ export function getMiddleware({
         rootBoundary,
       }),
     );
-  } else if (!flipDisabled) {
-    const flipOptions: FlipOptions = { rootBoundary };
-    middleware.push(flip(flipPlacements ? { fallbackPlacements: flipPlacements, ...flipOptions } : flipOptions));
+  }
+
+  const shouldAddFlip =
+    !flipDisabled &&
+    (!(placement === "auto" || placement === "auto-start" || placement === "auto-end") || type === "menu");
+
+  if (shouldAddFlip) {
+    const fallbackPlacements =
+      type === "menu"
+        ? flipPlacements || ["top-start", "top", "top-end", "bottom-start", "bottom", "bottom-end"]
+        : flipPlacements;
+
+    middleware.push(flip(fallbackPlacements ? { fallbackPlacements, rootBoundary } : { rootBoundary }));
   }
 
   if (arrowEl) {

--- a/packages/components/src/utils/floating-ui.ts
+++ b/packages/components/src/utils/floating-ui.ts
@@ -4,8 +4,8 @@ import {
   autoPlacement,
   autoUpdate,
   computePosition,
-  detectOverflow,
   flip,
+  FlipOptions,
   hide,
   Middleware,
   offset,
@@ -351,12 +351,19 @@ function getMiddleware({
   arrowEl?: SVGSVGElement;
   type: UIType;
 }): Middleware[] {
-  const middleware = [shift()];
+  const rootBoundary = "layoutViewport";
+
+  const middleware = [
+    shift({
+      rootBoundary,
+    }),
+  ];
 
   if (type === "menu") {
     middleware.push(
       flip({
         fallbackPlacements: flipPlacements || ["top-start", "top", "top-end", "bottom-start", "bottom", "bottom-end"],
+        rootBoundary,
       }),
     );
   }
@@ -370,10 +377,14 @@ function getMiddleware({
 
   if (placement === "auto" || placement === "auto-start" || placement === "auto-end") {
     middleware.push(
-      autoPlacement({ alignment: placement === "auto-start" ? "start" : placement === "auto-end" ? "end" : null }),
+      autoPlacement({
+        alignment: placement === "auto-start" ? "start" : placement === "auto-end" ? "end" : null,
+        rootBoundary,
+      }),
     );
   } else if (!flipDisabled) {
-    middleware.push(flip(flipPlacements ? { fallbackPlacements: flipPlacements } : {}));
+    const flipOptions: FlipOptions = { rootBoundary };
+    middleware.push(flip(flipPlacements ? { fallbackPlacements: flipPlacements, ...flipOptions } : flipOptions));
   }
 
   if (arrowEl) {
@@ -384,18 +395,11 @@ function getMiddleware({
     );
   }
 
-  middleware.push({
-    name: "detectOverflow",
-    async fn(state) {
-      await detectOverflow(state, {
-        rootBoundary: "layoutViewport",
-      });
-
-      return {};
-    },
-  });
-
-  middleware.push(hide());
+  middleware.push(
+    hide({
+      rootBoundary,
+    }),
+  );
 
   return middleware;
 }

--- a/packages/components/src/utils/floating-ui.ts
+++ b/packages/components/src/utils/floating-ui.ts
@@ -334,7 +334,8 @@ export const FloatingCSS = {
   arrowStroke: "calcite-floating-ui-arrow__stroke",
 };
 
-function getMiddleware({
+/** Exported for testing purposes only */
+export function getMiddleware({
   placement,
   flipDisabled,
   flipPlacements,

--- a/packages/components/src/utils/floating-ui.ts
+++ b/packages/components/src/utils/floating-ui.ts
@@ -333,7 +333,10 @@ export const FloatingCSS = {
   arrowStroke: "calcite-floating-ui-arrow__stroke",
 };
 
-/** Exported for testing purposes only */
+/**
+ * Exported for testing purposes only
+ * @private
+ */
 export function getMiddleware({
   placement,
   flipDisabled,

--- a/packages/components/src/utils/floating-ui.ts
+++ b/packages/components/src/utils/floating-ui.ts
@@ -4,6 +4,7 @@ import {
   autoPlacement,
   autoUpdate,
   computePosition,
+  detectOverflow,
   flip,
   hide,
   Middleware,
@@ -350,7 +351,7 @@ function getMiddleware({
   arrowEl?: SVGSVGElement;
   type: UIType;
 }): Middleware[] {
-  const middleware = [shift(), hide()];
+  const middleware = [shift()];
 
   if (type === "menu") {
     middleware.push(
@@ -382,6 +383,19 @@ function getMiddleware({
       }),
     );
   }
+
+  middleware.push({
+    name: "detectOverflow",
+    async fn(state) {
+      await detectOverflow(state, {
+        rootBoundary: "layoutViewport",
+      });
+
+      return {};
+    },
+  });
+
+  middleware.push(hide());
 
   return middleware;
 }

--- a/packages/components/src/utils/floating-ui.ts
+++ b/packages/components/src/utils/floating-ui.ts
@@ -352,6 +352,7 @@ export function getMiddleware({
   type: UIType;
 }): Middleware[] {
   const rootBoundary = "layoutViewport";
+  const isAutoPlacement = placement === "auto" || placement === "auto-start" || placement === "auto-end";
 
   const middleware = [
     shift({
@@ -366,7 +367,7 @@ export function getMiddleware({
     }),
   );
 
-  if (placement === "auto" || placement === "auto-start" || placement === "auto-end") {
+  if (isAutoPlacement) {
     middleware.push(
       autoPlacement({
         alignment: placement === "auto-start" ? "start" : placement === "auto-end" ? "end" : null,
@@ -375,9 +376,7 @@ export function getMiddleware({
     );
   }
 
-  const shouldAddFlip =
-    !flipDisabled &&
-    (!(placement === "auto" || placement === "auto-start" || placement === "auto-end") || type === "menu");
+  const shouldAddFlip = !flipDisabled && (!isAutoPlacement || type === "menu");
 
   if (shouldAddFlip) {
     const fallbackPlacements =


### PR DESCRIPTION
**Related Issue:** #13426

## Summary
This PR updates the floating UI positioning middleware to consistently use `layoutViewport` as the `rootBoundary` for viewport-aware calculations.

On constrained/mobile viewport scenarios (including virtual keyboard interactions), default viewport boundary behavior can produce unstable or incorrect floating element positioning. Using `layoutViewport` makes middleware decisions align better with the visible layout viewport and reduces regressions in those cases.

**Note**: bumps `@floating-ui/dom` to [v1.8.0](https://github.com/floating-ui/floating-ui/releases/tag/%40floating-ui%2Fdom%401.8.0)