### PR TITLE
refactor(input, input-text, input-number): rename useInlineEditable var

### DIFF
--- a/packages/components/src/components/input-number/input-number.tsx
+++ b/packages/components/src/components/input-number/input-number.tsx
@@ -130,7 +130,7 @@ export class InputNumber
 
   private interactiveContainer = useInteractive(this);
 
-  private useInlineEditable = new UseInlineEditable({
+  private inlineEditableManager = new UseInlineEditable({
     getEditingEnabled: () => this.editingEnabled,
     setEditingEnabled: (editingEnabled) => {
       this.editingEnabled = editingEnabled;
@@ -548,7 +548,7 @@ export class InputNumber
         return;
       }
 
-      this.useInlineEditable.cancelEditing();
+      this.inlineEditableManager.cancelEditing();
       requestAnimationFrame(() => {
         this.enableInlineEditingButtonRef.value?.setFocus();
       });
@@ -571,7 +571,7 @@ export class InputNumber
 
   onLabelClick(): void {
     if (this.selfManagedInlineEditable && !this.editingEnabled) {
-      this.useInlineEditable.enable();
+      this.inlineEditableManager.enable();
       return;
     }
 
@@ -642,7 +642,7 @@ export class InputNumber
     this.calciteInternalInputNumberBlur.emit();
 
     if (this.selfManagedInlineEditable && this.editingEnabled && !this.inlineEditableControls) {
-      this.useInlineEditable.disable();
+      this.inlineEditableManager.disable();
     }
 
     this.emitChangeIfUserModified();
@@ -670,7 +670,7 @@ export class InputNumber
 
     if (this.selfManagedInlineEditable && !this.editingEnabled) {
       event.preventDefault();
-      this.useInlineEditable.enable();
+      this.inlineEditableManager.enable();
       return;
     }
 
@@ -1182,13 +1182,13 @@ export class InputNumber
                 enableEditingButtonRef={this.enableInlineEditingButtonRef}
                 enableEditingLabel={this.messages.enableInlineEditing}
                 loading={this.inlineEditableLoading}
-                onCancelEditing={() => this.useInlineEditable.cancelEditing()}
+                onCancelEditing={() => this.inlineEditableManager.cancelEditing()}
                 onConfirmChanges={() =>
-                  this.useInlineEditable.confirm(this.inlineEditableAfterConfirm, (loading) => {
+                  this.inlineEditableManager.confirm(this.inlineEditableAfterConfirm, (loading) => {
                     this.inlineEditableLoading = loading;
                   })
                 }
-                onEnableEditing={() => this.useInlineEditable.enable()}
+                onEnableEditing={() => this.inlineEditableManager.enable()}
                 scale={this.scale}
                 showControls={this.editingEnabled && this.inlineEditableControls}
               />

--- a/packages/components/src/components/input-text/input-text.tsx
+++ b/packages/components/src/components/input-text/input-text.tsx
@@ -111,7 +111,7 @@ export class InputText extends LitElement implements LabelableComponent, Textual
 
   private interactiveContainer = useInteractive(this);
 
-  private useInlineEditable = new UseInlineEditable({
+  private inlineEditableManager = new UseInlineEditable({
     getEditingEnabled: () => this.editingEnabled,
     setEditingEnabled: (editingEnabled) => {
       this.editingEnabled = editingEnabled;
@@ -436,7 +436,7 @@ export class InputText extends LitElement implements LabelableComponent, Textual
         return;
       }
 
-      this.useInlineEditable.cancelEditing();
+      this.inlineEditableManager.cancelEditing();
       requestAnimationFrame(() => {
         this.enableInlineEditingButtonRef.value?.setFocus();
       });
@@ -459,7 +459,7 @@ export class InputText extends LitElement implements LabelableComponent, Textual
 
   onLabelClick(): void {
     if (this.selfManagedInlineEditable && !this.editingEnabled) {
-      this.useInlineEditable.enable();
+      this.inlineEditableManager.enable();
       return;
     }
 
@@ -489,7 +489,7 @@ export class InputText extends LitElement implements LabelableComponent, Textual
     });
 
     if (this.selfManagedInlineEditable && this.editingEnabled && !this.inlineEditableControls) {
-      this.useInlineEditable.disable();
+      this.inlineEditableManager.disable();
     }
 
     this.emitChangeIfUserModified();
@@ -517,7 +517,7 @@ export class InputText extends LitElement implements LabelableComponent, Textual
 
     if (this.selfManagedInlineEditable && !this.editingEnabled) {
       event.preventDefault();
-      this.useInlineEditable.enable();
+      this.inlineEditableManager.enable();
       return;
     }
 
@@ -714,13 +714,13 @@ export class InputText extends LitElement implements LabelableComponent, Textual
                 enableEditingButtonRef={this.enableInlineEditingButtonRef}
                 enableEditingLabel={this.messages.enableInlineEditing}
                 loading={this.inlineEditableLoading}
-                onCancelEditing={() => this.useInlineEditable.cancelEditing()}
+                onCancelEditing={() => this.inlineEditableManager.cancelEditing()}
                 onConfirmChanges={() =>
-                  this.useInlineEditable.confirm(this.inlineEditableAfterConfirm, (loading) => {
+                  this.inlineEditableManager.confirm(this.inlineEditableAfterConfirm, (loading) => {
                     this.inlineEditableLoading = loading;
                   })
                 }
-                onEnableEditing={() => this.useInlineEditable.enable()}
+                onEnableEditing={() => this.inlineEditableManager.enable()}
                 scale={this.scale}
                 showControls={this.editingEnabled && this.inlineEditableControls}
               />

--- a/packages/components/src/components/input/input.tsx
+++ b/packages/components/src/components/input/input.tsx
@@ -144,7 +144,7 @@ export class Input
 
   private interactiveContainer = useInteractive(this);
 
-  private useInlineEditable = new UseInlineEditable({
+  private inlineEditableManager = new UseInlineEditable({
     getEditingEnabled: () => this.editingEnabled,
     setEditingEnabled: (editingEnabled) => {
       this.editingEnabled = editingEnabled;
@@ -608,7 +608,7 @@ export class Input
         return;
       }
 
-      this.useInlineEditable.cancelEditing();
+      this.inlineEditableManager.cancelEditing();
       requestAnimationFrame(() => {
         this.enableInlineEditingButtonRef.value?.setFocus();
       });
@@ -631,7 +631,7 @@ export class Input
 
   onLabelClick(): void {
     if (this.selfManagedInlineEditable && !this.editingEnabled) {
-      this.useInlineEditable.enable();
+      this.inlineEditableManager.enable();
       return;
     }
 
@@ -712,7 +712,7 @@ export class Input
     this.calciteInternalInputBlur.emit();
 
     if (this.selfManagedInlineEditable && this.editingEnabled && !this.inlineEditableControls) {
-      this.useInlineEditable.disable();
+      this.inlineEditableManager.disable();
     }
 
     this.emitChangeIfUserModified();
@@ -740,7 +740,7 @@ export class Input
 
     if (this.selfManagedInlineEditable && !this.editingEnabled) {
       event.preventDefault();
-      this.useInlineEditable.enable();
+      this.inlineEditableManager.enable();
       return;
     }
 
@@ -1292,13 +1292,13 @@ export class Input
                 enableEditingButtonRef={this.enableInlineEditingButtonRef}
                 enableEditingLabel={this.messages.enableInlineEditing}
                 loading={this.inlineEditableLoading}
-                onCancelEditing={() => this.useInlineEditable.cancelEditing()}
+                onCancelEditing={() => this.inlineEditableManager.cancelEditing()}
                 onConfirmChanges={() =>
-                  this.useInlineEditable.confirm(this.inlineEditableAfterConfirm, (loading) => {
+                  this.inlineEditableManager.confirm(this.inlineEditableAfterConfirm, (loading) => {
                     this.inlineEditableLoading = loading;
                   })
                 }
-                onEnableEditing={() => this.useInlineEditable.enable()}
+                onEnableEditing={() => this.inlineEditableManager.enable()}
                 scale={this.scale}
                 showControls={this.editingEnabled && this.inlineEditableControls}
               />

--- a/packages/components/src/controllers/useInlineEditable.browser.spec.ts
+++ b/packages/components/src/controllers/useInlineEditable.browser.spec.ts
@@ -12,7 +12,7 @@ describe("UseInlineEditable", () => {
   let emitConfirmTracker: ReturnType<typeof vi.fn<() => void>>;
   let emitEnableEditingChangeTracker: ReturnType<typeof vi.fn<() => void>>;
 
-  let useInlineEditable: UseInlineEditable;
+  let inlineEditableManager: UseInlineEditable;
 
   beforeEach(() => {
     editingEnabled = false;
@@ -55,7 +55,7 @@ describe("UseInlineEditable", () => {
       return 0;
     });
 
-    useInlineEditable = new UseInlineEditable({
+    inlineEditableManager = new UseInlineEditable({
       getEditingEnabled: () => editingEnabled,
       setEditingEnabled,
       getValue: () => value,
@@ -72,7 +72,7 @@ describe("UseInlineEditable", () => {
   });
 
   it("enable stores the current value, enables editing, focuses, and emits the enable event", () => {
-    useInlineEditable.enable();
+    inlineEditableManager.enable();
 
     expect(setEditingEnabledTracker).toHaveBeenCalledWith(true);
     expect(editingEnabled).toBe(true);
@@ -83,17 +83,17 @@ describe("UseInlineEditable", () => {
   it("disable turns editing off", () => {
     editingEnabled = true;
 
-    useInlineEditable.disable();
+    inlineEditableManager.disable();
 
     expect(setEditingEnabledTracker).toHaveBeenCalledWith(false);
     expect(editingEnabled).toBe(false);
   });
 
   it("cancelEditing restores the value captured when editing was enabled, disables editing, and emits cancel", () => {
-    useInlineEditable.enable();
+    inlineEditableManager.enable();
     value = "changed";
 
-    useInlineEditable.cancelEditing();
+    inlineEditableManager.cancelEditing();
 
     expect(setValueTracker).toHaveBeenCalledWith("initial");
     expect(value).toBe("initial");
@@ -107,7 +107,7 @@ describe("UseInlineEditable", () => {
     const setLoading = vi.fn();
     const inlineEditableAfterConfirm = vi.fn().mockResolvedValue(undefined);
 
-    await useInlineEditable.confirm(inlineEditableAfterConfirm, setLoading);
+    await inlineEditableManager.confirm(inlineEditableAfterConfirm, setLoading);
 
     expect(emitConfirmTracker).toHaveBeenCalledTimes(1);
     expect(setLoading).toHaveBeenNthCalledWith(1, true);
@@ -121,7 +121,7 @@ describe("UseInlineEditable", () => {
     editingEnabled = true;
     const setLoading = vi.fn();
 
-    await useInlineEditable.confirm(undefined, setLoading);
+    await inlineEditableManager.confirm(undefined, setLoading);
 
     expect(emitConfirmTracker).toHaveBeenCalledTimes(1);
     expect(setEditingEnabledTracker).not.toHaveBeenCalled();
@@ -136,7 +136,9 @@ describe("UseInlineEditable", () => {
     const error = new Error("confirm failed");
     const inlineEditableAfterConfirm = vi.fn().mockRejectedValue(error);
 
-    await expect(useInlineEditable.confirm(inlineEditableAfterConfirm, setLoading)).rejects.toThrow("confirm failed");
+    await expect(inlineEditableManager.confirm(inlineEditableAfterConfirm, setLoading)).rejects.toThrow(
+      "confirm failed",
+    );
 
     expect(emitConfirmTracker).toHaveBeenCalledTimes(1);
     expect(setLoading).toHaveBeenNthCalledWith(1, true);


### PR DESCRIPTION
**monday.com sync:** #12552369696

**Related Issue:** N/A

## Summary
Rename `useInlineEditable` var to `inlineEditableManager` for better readability.
