### PR TITLE
chore: add ArcGIS Imagery and Remote Sensing team to issue template and alphabetize teams

### DIFF
--- a/.github/ISSUE_TEMPLATE/accessibility.yml
+++ b/.github/ISSUE_TEMPLATE/accessibility.yml
@@ -229,7 +229,6 @@ body:
       options:
         - N/A
         - Application Protoype Lab - APL
-        - ArcGIS Solutions
         - ArcGIS AppStudio
         - ArcGIS Business/Community Analyst
         - ArcGIS Charts
@@ -251,20 +250,21 @@ body:
         - ArcGIS Knowledge
         - ArcGIS Living Atlas
         - ArcGIS Map Viewer
+        - ArcGIS Maps for Adobe Creative Cloud
+        - ArcGIS Maps SDK for JavaScript
         - ArcGIS Marketplace
         - ArcGIS Mission
         - ArcGIS Monitor
         - ArcGIS Network Analyst
         - ArcGIS Online
         - ArcGIS Pro
-        - ArcGIS Maps for Adobe Creative Cloud
-        - ArcGIS Maps SDK for JavaScript
         - ArcGIS Scene Viewer
         - ArcGIS Site Scan
+        - ArcGIS Solutions
         - ArcGIS StoryMaps
         - ArcGIS Survey123
-        - ArcGIS Web Analysis
         - ArcGIS Urban
+        - ArcGIS Web Analysis
         - Esri Marketing
         - Professional Services - Midwest Delivery Center
         - Professional Services - Services Delivery

--- a/.github/ISSUE_TEMPLATE/accessibility.yml
+++ b/.github/ISSUE_TEMPLATE/accessibility.yml
@@ -244,6 +244,7 @@ body:
         - ArcGIS GeoBIM
         - ArcGIS GeoPlanner
         - ArcGIS Hub
+        - ArcGIS Imagery and Remote Sensing
         - ArcGIS Indoors
         - ArcGIS Insights
         - ArcGIS Instant Apps

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -224,7 +224,6 @@ body:
       options:
         - N/A
         - Application Protoype Lab - APL
-        - ArcGIS Solutions
         - ArcGIS AppStudio
         - ArcGIS Business/Community Analyst
         - ArcGIS Charts
@@ -246,20 +245,21 @@ body:
         - ArcGIS Knowledge
         - ArcGIS Living Atlas
         - ArcGIS Map Viewer
+        - ArcGIS Maps for Adobe Creative Cloud
+        - ArcGIS Maps SDK for JavaScript
         - ArcGIS Marketplace
         - ArcGIS Mission
         - ArcGIS Monitor
         - ArcGIS Network Analyst
         - ArcGIS Online
         - ArcGIS Pro
-        - ArcGIS Maps for Adobe Creative Cloud
-        - ArcGIS Maps SDK for JavaScript
         - ArcGIS Scene Viewer
         - ArcGIS Site Scan
+        - ArcGIS Solutions
         - ArcGIS StoryMaps
         - ArcGIS Survey123
-        - ArcGIS Web Analysis
         - ArcGIS Urban
+        - ArcGIS Web Analysis
         - Esri Marketing
         - Professional Services - Midwest Delivery Center
         - Professional Services - Services Delivery

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -239,6 +239,7 @@ body:
         - ArcGIS GeoBIM
         - ArcGIS GeoPlanner
         - ArcGIS Hub
+        - ArcGIS Imagery and Remote Sensing
         - ArcGIS Indoors
         - ArcGIS Insights
         - ArcGIS Instant Apps

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -187,7 +187,6 @@ body:
       options:
         - N/A
         - Application Protoype Lab - APL
-        - ArcGIS Solutions
         - ArcGIS AppStudio
         - ArcGIS Business/Community Analyst
         - ArcGIS Charts
@@ -209,20 +208,21 @@ body:
         - ArcGIS Knowledge
         - ArcGIS Living Atlas
         - ArcGIS Map Viewer
+        - ArcGIS Maps for Adobe Creative Cloud
+        - ArcGIS Maps SDK for JavaScript
         - ArcGIS Marketplace
         - ArcGIS Mission
         - ArcGIS Monitor
         - ArcGIS Network Analyst
         - ArcGIS Online
         - ArcGIS Pro
-        - ArcGIS Maps for Adobe Creative Cloud
-        - ArcGIS Maps SDK for JavaScript
         - ArcGIS Scene Viewer
         - ArcGIS Site Scan
+        - ArcGIS Solutions
         - ArcGIS StoryMaps
         - ArcGIS Survey123
-        - ArcGIS Web Analysis
         - ArcGIS Urban
+        - ArcGIS Web Analysis
         - Esri Marketing
         - Professional Services - Midwest Delivery Center
         - Professional Services - Services Delivery

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -202,6 +202,7 @@ body:
         - ArcGIS GeoBIM
         - ArcGIS GeoPlanner
         - ArcGIS Hub
+        - ArcGIS Imagery and Remote Sensing
         - ArcGIS Indoors
         - ArcGIS Insights
         - ArcGIS Instant Apps

--- a/.github/ISSUE_TEMPLATE/new-component.yml
+++ b/.github/ISSUE_TEMPLATE/new-component.yml
@@ -81,6 +81,7 @@ body:
         - ArcGIS GeoBIM
         - ArcGIS GeoPlanner
         - ArcGIS Hub
+        - ArcGIS Imagery and Remote Sensing
         - ArcGIS Indoors
         - ArcGIS Insights
         - ArcGIS Instant Apps

--- a/.github/ISSUE_TEMPLATE/new-component.yml
+++ b/.github/ISSUE_TEMPLATE/new-component.yml
@@ -66,7 +66,6 @@ body:
       options:
         - N/A
         - Application Protoype Lab - APL
-        - ArcGIS Solutions
         - ArcGIS AppStudio
         - ArcGIS Business/Community Analyst
         - ArcGIS Charts
@@ -88,20 +87,21 @@ body:
         - ArcGIS Knowledge
         - ArcGIS Living Atlas
         - ArcGIS Map Viewer
+        - ArcGIS Maps for Adobe Creative Cloud
+        - ArcGIS Maps SDK for JavaScript
         - ArcGIS Marketplace
         - ArcGIS Mission
         - ArcGIS Monitor
         - ArcGIS Network Analyst
         - ArcGIS Online
         - ArcGIS Pro
-        - ArcGIS Maps for Adobe Creative Cloud
-        - ArcGIS Maps SDK for JavaScript
         - ArcGIS Scene Viewer
         - ArcGIS Site Scan
+        - ArcGIS Solutions
         - ArcGIS StoryMaps
         - ArcGIS Survey123
-        - ArcGIS Web Analysis
         - ArcGIS Urban
+        - ArcGIS Web Analysis
         - Esri Marketing
         - Professional Services - Midwest Delivery Center
         - Professional Services - Services Delivery


### PR DESCRIPTION
**Related Issue:** n/a

## Summary

- Add ArcGIS Imagery and Remote Sensing team to issue templates
- Alphabetize the list of teams in issue templates
