### PR TITLE
fix(text-area): prevent repeated textarea height growth

### DIFF
--- a/packages/components/src/components/text-area/text-area.browser.e2e.tsx
+++ b/packages/components/src/components/text-area/text-area.browser.e2e.tsx
@@ -18,6 +18,7 @@ import {
 } from "../../tests/commonTests/browser";
 import { defaultValidity } from "../../tests/commonTests/browser/defaults";
 import { CSS } from "./resources";
+import { TextArea } from "./text-area";
 
 describe("cancelable", () => {
   cancelable("calcite-text-area");
@@ -227,7 +228,7 @@ describe("theme", () => {
 });
 
 it("does not grow textarea height on repeated key presses", async () => {
-  const { el } = await mount(
+  const { el } = await mount<TextArea>(
     <calcite-text-area label-text="Description" limit-text max-length="600" />,
   );
 

--- a/packages/components/src/components/text-area/text-area.browser.e2e.tsx
+++ b/packages/components/src/components/text-area/text-area.browser.e2e.tsx
@@ -19,6 +19,7 @@ import {
 import { defaultValidity } from "../../tests/commonTests/browser/defaults";
 import { CSS } from "./resources";
 import type { TextArea } from "./text-area";
+import { afterNextFrame } from "../../tests/utils/timing";
 
 describe("cancelable", () => {
   cancelable("calcite-text-area");
@@ -232,13 +233,13 @@ it("does not grow textarea height on repeated key presses", async () => {
     <calcite-text-area label-text="Description" limit-text max-length="600" />,
   );
 
-  const textArea = page.getBySelector("calcite-text-area textarea");
+  const textArea = page.getByRole("textbox", { name: "Description" });
   await userEvent.click(textArea);
 
   const initialHeight = textArea.element().getBoundingClientRect().height;
 
   await userEvent.keyboard("aaaaaaaaaa");
-  await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+  await afterNextFrame();
 
   const finalHeight = textArea.element().getBoundingClientRect().height;
   expect(Math.abs(finalHeight - initialHeight)).toBeLessThanOrEqual(1);

--- a/packages/components/src/components/text-area/text-area.browser.e2e.tsx
+++ b/packages/components/src/components/text-area/text-area.browser.e2e.tsx
@@ -1,6 +1,7 @@
 import { h } from "@arcgis/lumina";
-import { describe } from "vitest";
+import { describe, expect, it } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
+import { page, userEvent } from "vitest/browser";
 import {
   cancelable,
   accessible,
@@ -223,4 +224,21 @@ describe("theme", () => {
       },
     });
   });
+});
+
+it("does not grow textarea height on repeated key presses", async () => {
+  const { el } = await mount(
+    <calcite-text-area label-text="Description" limit-text max-length="600" />,
+  );
+
+  const textArea = page.getBySelector("calcite-text-area textarea");
+  await userEvent.click(textArea);
+
+  const initialHeight = textArea.element().getBoundingClientRect().height;
+
+  await userEvent.keyboard("aaaaaaaaaa");
+
+  const finalHeight = textArea.element().getBoundingClientRect().height;
+  expect(finalHeight).toEqual(initialHeight);
+  expect(el.value).toBe("aaaaaaaaaa");
 });

--- a/packages/components/src/components/text-area/text-area.browser.e2e.tsx
+++ b/packages/components/src/components/text-area/text-area.browser.e2e.tsx
@@ -238,8 +238,9 @@ it("does not grow textarea height on repeated key presses", async () => {
   const initialHeight = textArea.element().getBoundingClientRect().height;
 
   await userEvent.keyboard("aaaaaaaaaa");
+  await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
 
   const finalHeight = textArea.element().getBoundingClientRect().height;
-  expect(finalHeight).toEqual(initialHeight);
+  expect(Math.abs(finalHeight - initialHeight)).toBeLessThanOrEqual(1);
   expect(el.value).toBe("aaaaaaaaaa");
 });

--- a/packages/components/src/components/text-area/text-area.browser.e2e.tsx
+++ b/packages/components/src/components/text-area/text-area.browser.e2e.tsx
@@ -18,7 +18,7 @@ import {
 } from "../../tests/commonTests/browser";
 import { defaultValidity } from "../../tests/commonTests/browser/defaults";
 import { CSS } from "./resources";
-import { TextArea } from "./text-area";
+import type { TextArea } from "./text-area";
 
 describe("cancelable", () => {
   cancelable("calcite-text-area");

--- a/packages/components/src/components/text-area/text-area.browser.e2e.tsx
+++ b/packages/components/src/components/text-area/text-area.browser.e2e.tsx
@@ -233,7 +233,7 @@ it("does not grow textarea height on repeated key presses", async () => {
     <calcite-text-area label-text="Description" limit-text max-length="600" />,
   );
 
-  const textArea = page.getByRole("textbox", { name: "Description" });
+  const textArea = page.elementLocator(el).getByRole("textbox").first();
   await userEvent.click(textArea);
 
   const initialHeight = textArea.element().getBoundingClientRect().height;

--- a/packages/components/src/components/text-area/text-area.e2e.ts
+++ b/packages/components/src/components/text-area/text-area.e2e.ts
@@ -165,6 +165,25 @@ it("does not change height & width when status changes from valid to invalid", a
   expect(textAreaInvalidRect.height).toEqual(textAreaRect.height);
 });
 
+it("does not grow textarea height on repeated key presses", async () => {
+  const page = await newE2EPage();
+  await page.setContent(`<calcite-text-area label-text="Description" limit-text max-length="600"></calcite-text-area>`);
+
+  const element = await page.find("calcite-text-area");
+  await element.callMethod("setFocus");
+  await page.waitForChanges();
+
+  const initialRect = await getElementRect(page, "calcite-text-area", "textarea");
+
+  for (let i = 0; i < 10; i++) {
+    await page.keyboard.press("a");
+    await page.waitForChanges();
+  }
+
+  const finalRect = await getElementRect(page, "calcite-text-area", "textarea");
+  expect(finalRect.height).toEqual(initialRect.height);
+});
+
 // Ref https://github.com/Esri/calcite-design-system/issues/8456
 it("should not set width and height to auto when resizing viewport to narrow height", async () => {
   const page = await newE2EPage();

--- a/packages/components/src/components/text-area/text-area.e2e.ts
+++ b/packages/components/src/components/text-area/text-area.e2e.ts
@@ -165,25 +165,6 @@ it("does not change height & width when status changes from valid to invalid", a
   expect(textAreaInvalidRect.height).toEqual(textAreaRect.height);
 });
 
-it("does not grow textarea height on repeated key presses", async () => {
-  const page = await newE2EPage();
-  await page.setContent(`<calcite-text-area label-text="Description" limit-text max-length="600"></calcite-text-area>`);
-
-  const element = await page.find("calcite-text-area");
-  await element.callMethod("setFocus");
-  await page.waitForChanges();
-
-  const initialRect = await getElementRect(page, "calcite-text-area", "textarea");
-
-  for (let i = 0; i < 10; i++) {
-    await page.keyboard.press("a");
-    await page.waitForChanges();
-  }
-
-  const finalRect = await getElementRect(page, "calcite-text-area", "textarea");
-  expect(finalRect.height).toEqual(initialRect.height);
-});
-
 // Ref https://github.com/Esri/calcite-design-system/issues/8456
 it("should not set width and height to auto when resizing viewport to narrow height", async () => {
   const page = await newE2EPage();

--- a/packages/components/src/components/text-area/text-area.tsx
+++ b/packages/components/src/components/text-area/text-area.tsx
@@ -34,6 +34,8 @@ import T9nStrings from "./assets/t9n/messages.en.json";
 import { CSS, IDS, NO_DIMENSIONS, RESIZE_TIMEOUT, SLOTS } from "./resources";
 import { styles } from "./text-area.scss";
 
+const DIMENSION_EPSILON = 1;
+
 declare global {
   interface DeclareElements {
     "calcite-text-area": TextArea;
@@ -96,10 +98,16 @@ export class TextArea
     }
 
     const { width: elStyleWidth, height: elStyleHeight } = getComputedStyle(this.el);
-    if (elWidth !== textAreaWidth && elStyleWidth !== "auto") {
+    if (this.dimensionsDiffer(elWidth, textAreaWidth) && elStyleWidth !== "auto") {
       this.updateSizeToAuto("width");
     }
-    if (loaderHeight !== textAreaHeight + footerHeight && elStyleHeight !== "auto") {
+    if (
+      loaderHeight > 0 &&
+      textAreaHeight > 0 &&
+      footerHeight > 0 &&
+      this.dimensionsDiffer(loaderHeight, textAreaHeight + footerHeight) &&
+      elStyleHeight !== "auto"
+    ) {
       this.updateSizeToAuto("height");
     }
   });
@@ -342,6 +350,10 @@ export class TextArea
 
   //#region Private Methods
 
+  private dimensionsDiffer(dimensionA: number, dimensionB: number): boolean {
+    return Math.abs(dimensionA - dimensionB) > DIMENSION_EPSILON;
+  }
+
   private updateNumberFormatter(): void {
     numberStringFormatter.numberFormatOptions = {
       locale: this.messages._lang,
@@ -399,7 +411,11 @@ export class TextArea
 
   private setTextAreaHeight(): void {
     const { textAreaHeight, loaderHeight, footerHeight } = this.getHeightAndWidthOfElements();
-    if (footerHeight > 0 && textAreaHeight + footerHeight !== loaderHeight) {
+    if (loaderHeight <= 0 || textAreaHeight <= 0 || footerHeight <= 0) {
+      return;
+    }
+
+    if (this.dimensionsDiffer(textAreaHeight + footerHeight, loaderHeight)) {
       this.textAreaEl!.style.height = `${loaderHeight - footerHeight}px`;
     }
   }

--- a/packages/components/src/components/text-area/text-area.tsx
+++ b/packages/components/src/components/text-area/text-area.tsx
@@ -87,15 +87,8 @@ export class TextArea
 
   private resizeObserver = createObserver("resize", async () => {
     await this.componentOnReady();
-    const {
-      textAreaHeight,
-      textAreaWidth,
-      elHeight,
-      elWidth,
-      footerHeight,
-      footerWidth,
-      validationMessageHeight,
-    } = this.getHeightAndWidthOfElements();
+    const { textAreaHeight, textAreaWidth, loaderHeight, elWidth, footerHeight, footerWidth } =
+      this.getHeightAndWidthOfElements();
     if (footerWidth > 0 && footerWidth !== textAreaWidth) {
       this.footerRef.value!.style.width = `${textAreaWidth}px`;
     }
@@ -108,10 +101,7 @@ export class TextArea
     if (elWidth !== textAreaWidth && elStyleWidth !== "auto") {
       this.updateSizeToAuto("width");
     }
-    if (
-      elHeight !== textAreaHeight + footerHeight + validationMessageHeight &&
-      elStyleHeight !== "auto"
-    ) {
+    if (loaderHeight !== textAreaHeight + footerHeight && elStyleHeight !== "auto") {
       this.updateSizeToAuto("height");
     }
   });

--- a/packages/components/src/components/text-area/text-area.tsx
+++ b/packages/components/src/components/text-area/text-area.tsx
@@ -69,6 +69,8 @@ export class TextArea
 
   private footerRef = createRef<HTMLElement>();
 
+  private loaderContainerRef = createRef<HTMLDivElement>();
+
   private validationMessageEl?: HTMLDivElement;
 
   formSupport = useForm<this>({
@@ -408,16 +410,16 @@ export class TextArea
   }
 
   private setTextAreaHeight(): void {
-    const { textAreaHeight, elHeight, footerHeight, validationMessageHeight } =
-      this.getHeightAndWidthOfElements();
-    if (footerHeight > 0 && textAreaHeight + footerHeight + validationMessageHeight != elHeight) {
-      this.textAreaEl!.style.height = `${elHeight - footerHeight}px`;
+    const { textAreaHeight, loaderHeight, footerHeight } = this.getHeightAndWidthOfElements();
+    if (footerHeight > 0 && textAreaHeight + footerHeight !== loaderHeight) {
+      this.textAreaEl!.style.height = `${loaderHeight - footerHeight}px`;
     }
   }
 
   private getHeightAndWidthOfElements(): {
     textAreaHeight: number;
     textAreaWidth: number;
+    loaderHeight: number;
     elHeight: number;
     elWidth: number;
     footerHeight: number;
@@ -426,6 +428,9 @@ export class TextArea
   } {
     const { height: textAreaHeight, width: textAreaWidth } = this.textAreaEl
       ? this.textAreaEl.getBoundingClientRect()
+      : NO_DIMENSIONS;
+    const { height: loaderHeight } = this.loaderContainerRef.value
+      ? this.loaderContainerRef.value.getBoundingClientRect()
       : NO_DIMENSIONS;
     const { height: elHeight, width: elWidth } = this.el.getBoundingClientRect();
     const { height: footerHeight, width: footerWidth } = this.footerRef.value
@@ -439,6 +444,7 @@ export class TextArea
     return {
       textAreaHeight,
       textAreaWidth,
+      loaderHeight,
       elHeight,
       elWidth,
       footerHeight,
@@ -486,7 +492,7 @@ export class TextArea
               tooltipText={this.messages.required}
             />
           )}
-          <div class={CSS.loaderContainer}>
+          <div class={CSS.loaderContainer} ref={this.loaderContainerRef}>
             {this.loading ? loader : null}
             <textarea
               aria-describedby={this.guid}

--- a/packages/components/src/components/text-area/text-area.tsx
+++ b/packages/components/src/components/text-area/text-area.tsx
@@ -410,11 +410,9 @@ export class TextArea
     textAreaHeight: number;
     textAreaWidth: number;
     loaderHeight: number;
-    elHeight: number;
     elWidth: number;
     footerHeight: number;
     footerWidth: number;
-    validationMessageHeight: number;
   } {
     const { height: textAreaHeight, width: textAreaWidth } = this.textAreaEl
       ? this.textAreaEl.getBoundingClientRect()
@@ -422,24 +420,18 @@ export class TextArea
     const { height: loaderHeight } = this.loaderContainerRef.value
       ? this.loaderContainerRef.value.getBoundingClientRect()
       : NO_DIMENSIONS;
-    const { height: elHeight, width: elWidth } = this.el.getBoundingClientRect();
+    const { width: elWidth } = this.el.getBoundingClientRect();
     const { height: footerHeight, width: footerWidth } = this.footerRef.value
       ? this.footerRef.value.getBoundingClientRect()
-      : NO_DIMENSIONS;
-
-    const { height: validationMessageHeight } = this.validationMessageEl
-      ? this.validationMessageEl.getBoundingClientRect()
       : NO_DIMENSIONS;
 
     return {
       textAreaHeight,
       textAreaWidth,
       loaderHeight,
-      elHeight,
       elWidth,
       footerHeight,
       footerWidth,
-      validationMessageHeight,
     };
   }
 

--- a/packages/components/src/components/text-area/text-area.tsx
+++ b/packages/components/src/components/text-area/text-area.tsx
@@ -71,8 +71,6 @@ export class TextArea
 
   private loaderContainerRef = createRef<HTMLDivElement>();
 
-  private validationMessageEl?: HTMLDivElement;
-
   formSupport = useForm<this>({
     inputType: "text",
   })(this);
@@ -445,13 +443,6 @@ export class TextArea
     return (this.maxLength !== undefined && this.value?.length > this.maxLength) || false;
   }
 
-  private setValidationRef(el: HTMLDivElement): void {
-    if (!el) {
-      return;
-    }
-    this.validationMessageEl = el;
-  }
-
   //#endregion
 
   //#region Rendering
@@ -547,7 +538,6 @@ export class TextArea
               icon={this.validationIcon}
               id={IDS.validationMessage}
               message={this.validationMessage}
-              ref={this.setValidationRef}
               scale={this.scale}
               status={this.status}
             />

--- a/packages/components/src/components/text-area/text-area.tsx
+++ b/packages/components/src/components/text-area/text-area.tsx
@@ -34,8 +34,6 @@ import T9nStrings from "./assets/t9n/messages.en.json";
 import { CSS, IDS, NO_DIMENSIONS, RESIZE_TIMEOUT, SLOTS } from "./resources";
 import { styles } from "./text-area.scss";
 
-const DIMENSION_EPSILON = 1;
-
 declare global {
   interface DeclareElements {
     "calcite-text-area": TextArea;
@@ -351,7 +349,8 @@ export class TextArea
   //#region Private Methods
 
   private dimensionsDiffer(dimensionA: number, dimensionB: number): boolean {
-    return Math.abs(dimensionA - dimensionB) > DIMENSION_EPSILON;
+    const dimensionTolerance = 1;
+    return Math.abs(dimensionA - dimensionB) > dimensionTolerance;
   }
 
   private updateNumberFormatter(): void {


### PR DESCRIPTION
**Related Issue:** #14567

## Summary

This PR fixes a `calcite-text-area` sizing regression where the textarea height could grow on repeated key presses under certain layouts.

- Updated `text-area` sizing logic to use the loader-container height as the baseline when reconciling textarea/footer dimensions.
- Added a `loaderContainerRef` and wired it into the render tree for consistent measurements.
- Removed now-obsolete validation-message measurement wiring used by the previous height calculation path.
- Added a browser test regression case that verifies textarea height remains stable during repeated typing.