### PR TITLE
feat(input-date-picker): update vertical layout divider line padding

### DIFF
--- a/packages/components/src/components/input-date-picker/input-date-picker.scss
+++ b/packages/components/src/components/input-date-picker/input-date-picker.scss
@@ -249,9 +249,11 @@
 }
 
 :host([layout="vertical"]) .divider-container {
-  @apply w-full h-px border-t-0 border-b-0;
+  @apply h-px border-t-0 border-b-0;
   border-inline-start-width: var(--calcite-border-width-sm);
   border-inline-end-width: var(--calcite-border-width-none);
+  inline-size: calc(100% - var(--calcite-space-md));
+  padding-inline: var(--calcite-space-md);
   & .divider {
     @apply w-full h-px my-0;
   }
@@ -304,6 +306,11 @@
     padding-inline-start: var(--calcite-space-sm);
   }
 
+  .divider-container {
+    inline-size: calc(100% - var(--calcite-space-sm));
+    padding-inline: var(--calcite-space-sm);
+  }
+
   .clear-button {
     margin-inline-start: var(--calcite-space-sm);
   }
@@ -316,6 +323,11 @@
 
   .vertical-actions-container:not(:has(.clear-button)) .toggle-icon {
     padding-inline-start: var(--calcite-space-lg);
+  }
+
+  .divider-container {
+    inline-size: calc(100% - var(--calcite-space-lg));
+    padding-inline: var(--calcite-space-lg);
   }
 
   .clear-button {


### PR DESCRIPTION
**Related Issue:** [#9440](https://github.com/Esri/calcite-design-system/issues/9440)

## Summary
When `range` is true and `layout="vertical"`, update the divider line's left padding.