### PR TITLE
feat(slider): add accessible label support

### DIFF
--- a/packages/components/src/components/slider/slider.browser.e2e.tsx
+++ b/packages/components/src/components/slider/slider.browser.e2e.tsx
@@ -139,6 +139,25 @@ describe("accessible", () => {
     await expect.element(minThumb).toHaveAttribute("aria-label", "Minimum");
     await expect.element(maxThumb).toHaveAttribute("aria-label", "Maximum");
   });
+
+  it("uses label as fallback aria-label for single-value thumb", async () => {
+    await mount(<calcite-slider label="Single fallback label" value={25} />);
+
+    const thumb = page.getByRole("slider");
+
+    await expect.element(thumb).toHaveAttribute("aria-label", "Single fallback label");
+  });
+
+  it("uses label as fallback aria-label for range thumbs and labels container as group", async () => {
+    await mount(<calcite-slider label="Range fallback label" max-value="75" min-value="50" />);
+
+    const container = page.getByRole("group", { name: "Range fallback label" });
+    const [minThumb, maxThumb] = page.getByRole("slider").all();
+
+    await expect.element(container).toHaveAttribute("aria-label", "Range fallback label");
+    await expect.element(minThumb).toHaveAttribute("aria-label", "Range fallback label");
+    await expect.element(maxThumb).toHaveAttribute("aria-label", "Range fallback label");
+  });
 });
 
 describe("honors hidden attribute", () => {

--- a/packages/components/src/components/slider/slider.browser.e2e.tsx
+++ b/packages/components/src/components/slider/slider.browser.e2e.tsx
@@ -5,6 +5,7 @@ import { Locator, page, userEvent } from "vitest/browser";
 import { commands } from "../../tests/browser/commands";
 
 import {
+  accessible,
   defaults,
   disabled,
   formAssociated,
@@ -41,6 +42,10 @@ describe("defaults", () => {
       },
       {
         propertyName: "labelFormatter",
+        defaultValue: undefined,
+      },
+      {
+        propertyName: "label",
         defaultValue: undefined,
       },
       {
@@ -100,6 +105,40 @@ describe("reflects", () => {
       },
     ],
   );
+});
+
+describe("accessible", () => {
+  accessible(() =>
+    mount(
+      <calcite-slider
+        label="hello world"
+        max-label="Maximum"
+        max-value="75"
+        min-label="Minimum"
+        min-value="50"
+      />,
+    ),
+  );
+
+  it("applies min and max labels to the corresponding thumbs", async () => {
+    await mount<Slider>(
+      <calcite-slider
+        label="Group label"
+        max-label="Maximum"
+        max-value="75"
+        min-label="Minimum"
+        min-value="50"
+      />,
+    );
+
+    const container = page.getByLabelText("Group label");
+    await expect.element(container).toHaveAttribute("aria-label", "Group label");
+
+    const [minThumb, maxThumb] = page.getByRole("slider").all();
+
+    await expect.element(minThumb).toHaveAttribute("aria-label", "Minimum");
+    await expect.element(maxThumb).toHaveAttribute("aria-label", "Maximum");
+  });
 });
 
 describe("honors hidden attribute", () => {

--- a/packages/components/src/components/slider/slider.tsx
+++ b/packages/components/src/components/slider/slider.tsx
@@ -236,6 +236,9 @@ export class Slider extends LitElement implements LabelableComponent {
   /** Specifies a list of single color stops for a histogram, sorted by offset in ascending order. */
   @property() histogramStops?: ColorStop[];
 
+  /** @copyDoc */
+  @property() label?: string;
+
   /** When specified, allows users to customize handle labels. */
   @property() labelFormatter?: (
     value: number,

--- a/packages/components/src/components/slider/slider.tsx
+++ b/packages/components/src/components/slider/slider.tsx
@@ -1105,11 +1105,14 @@ export class Slider extends LitElement implements LabelableComponent {
     const maxInterval = this.getUnitInterval(value) * 100;
     const mirror = this.shouldMirror();
     const valueIsRange = isRange(this.value);
+    const containerAriaLabel = getLabelText(this);
+    const useGroupRole = valueIsRange && !!containerAriaLabel;
 
     const thumbTypes = this.buildThumbType("max");
     const thumb = this.renderThumb({
       type: thumbTypes,
       thumbPlacement: thumbTypes.includes("histogram") ? "below" : "above",
+      labelFallback: containerAriaLabel,
       maxInterval,
       minInterval,
       mirror,
@@ -1123,6 +1126,7 @@ export class Slider extends LitElement implements LabelableComponent {
             minThumbTypes.includes("histogram") || minThumbTypes.includes("precise")
               ? "below"
               : "above",
+          labelFallback: containerAriaLabel,
           maxInterval,
           minInterval,
           mirror,
@@ -1162,13 +1166,14 @@ export class Slider extends LitElement implements LabelableComponent {
         <div
           aria-errormessage={IDS.validationMessage}
           ariaInvalid={this.status === "invalid"}
-          ariaLabel={getLabelText(this)}
+          ariaLabel={containerAriaLabel}
           ariaRequired={this.required}
           class={{
             [CSS.container]: true,
             [CSS.containerRange]: valueIsRange,
             [CSS.scale(this.scale)]: true,
           }}
+          role={useGroupRole ? "group" : undefined}
         >
           {this.renderGraph()}
           <div class={CSS.track} ref={this.trackRef}>
@@ -1234,7 +1239,9 @@ export class Slider extends LitElement implements LabelableComponent {
     thumbPlacement,
     minInterval,
     maxInterval,
+    labelFallback,
   }: {
+    labelFallback: string;
     maxInterval: number;
     minInterval: number;
     mirror: boolean;
@@ -1252,7 +1259,11 @@ export class Slider extends LitElement implements LabelableComponent {
         ? this.maxValue
         : (this.value as number);
     const valueProp = isMinThumb ? "minValue" : valueIsRange ? "maxValue" : "value";
-    const ariaLabel = isMinThumb ? this.minLabel : valueIsRange ? this.maxLabel : this.minLabel;
+    const ariaLabel = isMinThumb
+      ? this.minLabel || labelFallback
+      : valueIsRange
+        ? this.maxLabel || labelFallback
+        : this.minLabel || labelFallback;
     const ariaValuenow = isMinThumb ? this.minValue : value;
     const displayedValue =
       valueProp === "minValue"


### PR DESCRIPTION
**Related Issue:** #13529

## Summary

This PR adds a public `label` property to `calcite-slider` and wires it into the component's accessibility behavior.

The change updates slider rendering so:
- single-value sliders use `label` as the thumb's fallback `aria-label`
- range sliders use `label` as a fallback `aria-label` for both thumbs when `min-label` and `max-label` are not provided
- range sliders with a label expose the outer container as an ARIA `group` with that label
- explicit `min-label` and `max-label` values still take precedence for the corresponding thumbs

