### PR TITLE
docs: reformat `where:` descriptions to use markdown lists

### DIFF
--- a/packages/components/api-extractor.config.ts
+++ b/packages/components/api-extractor.config.ts
@@ -99,7 +99,7 @@ export const config: ApiExtractorConfig = {
         },
         overlayPositioning: {
           description:
-            'Specifies the type of positioning to use for overlaid content.\n\n- `"absolute"` works for most cases - positioning the component inside of overflowing parent containers, which affects the container\'s layout\n\n- `"fixed"` is used to escape an overflowing parent container, or when the reference element\'s `position` CSS property is `"fixed"`',
+            'Specifies the type of positioning to use for overlaid content.\n\n- `"absolute"` works for most cases - positioning the component inside of overflowing parent containers, which affects the container\'s layout.\n\n- `"fixed"` is used to escape an overflowing parent container, or when the reference element\'s `position` CSS property is `"fixed"`.',
         },
         referenceElement: {
           description:

--- a/packages/components/api-extractor.config.ts
+++ b/packages/components/api-extractor.config.ts
@@ -99,7 +99,7 @@ export const config: ApiExtractorConfig = {
         },
         overlayPositioning: {
           description:
-            'Specifies the type of positioning to use for overlaid content, where:\n\n`"absolute"` works for most cases - positioning the component inside of overflowing parent containers, which affects the container\'s layout, and\n\n`"fixed"` is used to escape an overflowing parent container, or when the reference element\'s `position` CSS property is `"fixed"`.',
+            'Specifies the type of positioning to use for overlaid content, where:\n\n- `"absolute"` works for most cases - positioning the component inside of overflowing parent containers, which affects the container\'s layout\n\n- `"fixed"` is used to escape an overflowing parent container, or when the reference element\'s `position` CSS property is `"fixed"`',
         },
         referenceElement: {
           description:

--- a/packages/components/api-extractor.config.ts
+++ b/packages/components/api-extractor.config.ts
@@ -99,7 +99,7 @@ export const config: ApiExtractorConfig = {
         },
         overlayPositioning: {
           description:
-            'Specifies the type of positioning to use for overlaid content, where:\n\n- `"absolute"` works for most cases - positioning the component inside of overflowing parent containers, which affects the container\'s layout\n\n- `"fixed"` is used to escape an overflowing parent container, or when the reference element\'s `position` CSS property is `"fixed"`',
+            'Specifies the type of positioning to use for overlaid content.\n\n- `"absolute"` works for most cases - positioning the component inside of overflowing parent containers, which affects the container\'s layout\n\n- `"fixed"` is used to escape an overflowing parent container, or when the reference element\'s `position` CSS property is `"fixed"`',
         },
         referenceElement: {
           description:

--- a/packages/components/src/components/accordion/accordion.tsx
+++ b/packages/components/src/components/accordion/accordion.tsx
@@ -43,11 +43,9 @@ export class Accordion extends LitElement {
   /**
    * Specifies the selection mode of the component, where:
    *
-   * `"multiple"` allows any number of selections,
-   *
-   * `"single"` allows only one selection, and
-   *
-   * `"single-persist"` allows one selection and prevents de-selection.
+   * - `"multiple"` allows any number of selections
+   * - `"single"` allows only one selection
+   * - `"single-persist"` allows one selection and prevents de-selection
    */
   @property({ reflect: true }) selectionMode: Extract<
     "single" | "single-persist" | "multiple",

--- a/packages/components/src/components/accordion/accordion.tsx
+++ b/packages/components/src/components/accordion/accordion.tsx
@@ -41,7 +41,7 @@ export class Accordion extends LitElement {
   @property({ reflect: true }) scale: Scale = "m";
 
   /**
-   * Specifies the selection mode of the component, where:
+   * Specifies the selection mode of the component.
    *
    * - `"multiple"` allows any number of selections
    * - `"single"` allows only one selection

--- a/packages/components/src/components/accordion/accordion.tsx
+++ b/packages/components/src/components/accordion/accordion.tsx
@@ -43,9 +43,9 @@ export class Accordion extends LitElement {
   /**
    * Specifies the selection mode of the component.
    *
-   * - `"multiple"` allows any number of selections
-   * - `"single"` allows only one selection
-   * - `"single-persist"` allows one selection and prevents de-selection
+   * - `"multiple"` allows any number of selections.
+   * - `"single"` allows only one selection.
+   * - `"single-persist"` allows one selection and prevents de-selection.
    */
   @property({ reflect: true }) selectionMode: Extract<
     "single" | "single-persist" | "multiple",

--- a/packages/components/src/components/action-bar/action-bar.tsx
+++ b/packages/components/src/components/action-bar/action-bar.tsx
@@ -254,8 +254,8 @@ export class ActionBar extends LitElement {
   /**
    * When `expandToggleDisabled` is `false`, specifies the expand toggle's chevron direction.
    *
-   * - `"start"` positions the expand toggle's chevron away from the start of the component when `expanded` is `false`
-   * - `"end"` positions the expand toggle's chevron away from the end of the component when `expanded` is `false`
+   * - `"start"` positions the expand toggle's chevron away from the start of the component when `expanded` is `false`.
+   * - `"end"` positions the expand toggle's chevron away from the end of the component when `expanded` is `false`.
    *
    * When `expanded` is `true`, the chevron direction is reversed.
    */

--- a/packages/components/src/components/action-bar/action-bar.tsx
+++ b/packages/components/src/components/action-bar/action-bar.tsx
@@ -252,7 +252,7 @@ export class ActionBar extends LitElement {
   @property({ reflect: true }) overlayPositioning: OverlayPositioning = "absolute";
 
   /**
-   * When `expandToggleDisabled` is `false`, specifies the expand toggle's chevron direction, where:
+   * When `expandToggleDisabled` is `false`, specifies the expand toggle's chevron direction.
    *
    * - `"start"` positions the expand toggle's chevron away from the start of the component when `expanded` is `false`
    * - `"end"` positions the expand toggle's chevron away from the end of the component when `expanded` is `false`

--- a/packages/components/src/components/action-bar/action-bar.tsx
+++ b/packages/components/src/components/action-bar/action-bar.tsx
@@ -254,8 +254,8 @@ export class ActionBar extends LitElement {
   /**
    * When `expandToggleDisabled` is `false`, specifies the expand toggle's chevron direction, where:
    *
-   * `"start"` positions the expand toggle's chevron away from the start of the component when `expanded` is `false`, and
-   * `"end"` positions the expand toggle's chevron away from the end of the component when `expanded` is `false`.
+   * - `"start"` positions the expand toggle's chevron away from the start of the component when `expanded` is `false`
+   * - `"end"` positions the expand toggle's chevron away from the end of the component when `expanded` is `false`
    *
    * When `expanded` is `true`, the chevron direction is reversed.
    */

--- a/packages/components/src/components/action-group/action-group.tsx
+++ b/packages/components/src/components/action-group/action-group.tsx
@@ -110,10 +110,10 @@ export class ActionGroup extends LitElement {
   /**
    * Specifies the selection mode of the component.
    *
-   * - `"multiple"` allows any number of selections
-   * - `"single"` allows only one selection
-   * - `"single-persist"` allows one selection and prevents de-selection
-   * - `"none"` disables selection (default)
+   * - `"multiple"` allows any number of selections.
+   * - `"single"` allows only one selection.
+   * - `"single-persist"` allows one selection and prevents de-selection.
+   * - `"none"` disables selection (default).
    */
   @property({ reflect: true }) selectionMode: Extract<
     "single" | "single-persist" | "multiple" | "none",

--- a/packages/components/src/components/action-group/action-group.tsx
+++ b/packages/components/src/components/action-group/action-group.tsx
@@ -110,13 +110,10 @@ export class ActionGroup extends LitElement {
   /**
    * Specifies the selection mode of the component, where:
    *
-   * `"multiple"` allows any number of selections,
-   *
-   * `"single"` allows only one selection,
-   *
-   * `"single-persist"` allows one selection and prevents de-selection, and
-   *
-   * `"none"` disables selection (default).
+   * - `"multiple"` allows any number of selections
+   * - `"single"` allows only one selection
+   * - `"single-persist"` allows one selection and prevents de-selection
+   * - `"none"` disables selection (default)
    */
   @property({ reflect: true }) selectionMode: Extract<
     "single" | "single-persist" | "multiple" | "none",

--- a/packages/components/src/components/action-group/action-group.tsx
+++ b/packages/components/src/components/action-group/action-group.tsx
@@ -108,7 +108,7 @@ export class ActionGroup extends LitElement {
   @property({ reflect: true }) scale: Scale = "m";
 
   /**
-   * Specifies the selection mode of the component, where:
+   * Specifies the selection mode of the component.
    *
    * - `"multiple"` allows any number of selections
    * - `"single"` allows only one selection

--- a/packages/components/src/components/block-section/block-section.tsx
+++ b/packages/components/src/components/block-section/block-section.tsx
@@ -107,9 +107,8 @@ export class BlockSection extends LitElement {
   /**
    * Specifies how the component's toggle is displayed, where:
    *
-   * `"button"` sets the toggle to a selectable header, and
-   *
-   * `"switch"` sets the toggle to a switch.
+   * - `"button"` sets the toggle to a selectable header
+   * - `"switch"` sets the toggle to a switch
    */
   @property({ reflect: true }) toggleDisplay: BlockSectionToggleDisplay = "button";
 

--- a/packages/components/src/components/block-section/block-section.tsx
+++ b/packages/components/src/components/block-section/block-section.tsx
@@ -107,8 +107,8 @@ export class BlockSection extends LitElement {
   /**
    * Specifies how the component's toggle is displayed.
    *
-   * - `"button"` sets the toggle to a selectable header
-   * - `"switch"` sets the toggle to a switch
+   * - `"button"` sets the toggle to a selectable header.
+   * - `"switch"` sets the toggle to a switch.
    */
   @property({ reflect: true }) toggleDisplay: BlockSectionToggleDisplay = "button";
 

--- a/packages/components/src/components/block-section/block-section.tsx
+++ b/packages/components/src/components/block-section/block-section.tsx
@@ -105,7 +105,7 @@ export class BlockSection extends LitElement {
   @property() text?: string;
 
   /**
-   * Specifies how the component's toggle is displayed, where:
+   * Specifies how the component's toggle is displayed.
    *
    * - `"button"` sets the toggle to a selectable header
    * - `"switch"` sets the toggle to a switch

--- a/packages/components/src/components/chip-group/chip-group.tsx
+++ b/packages/components/src/components/chip-group/chip-group.tsx
@@ -62,13 +62,10 @@ export class ChipGroup extends LitElement {
   /**
    * Specifies the selection mode of the component, where:
    *
-   * `"multiple"` allows any number of selections,
-   *
-   * `"single"` allows only one selection,
-   *
-   * `"single-persist"` allows one selection and prevents de-selection, and
-   *
-   * `"none"` does not allow any selections.
+   * - `"multiple"` allows any number of selections
+   * - `"single"` allows only one selection
+   * - `"single-persist"` allows one selection and prevents de-selection
+   * - `"none"` does not allow any selections
    */
   @property({ reflect: true }) selectionMode: Extract<
     "multiple" | "single" | "single-persist" | "none",

--- a/packages/components/src/components/chip-group/chip-group.tsx
+++ b/packages/components/src/components/chip-group/chip-group.tsx
@@ -60,7 +60,7 @@ export class ChipGroup extends LitElement {
   @property() selectedItems: Chip["el"][] = [];
 
   /**
-   * Specifies the selection mode of the component, where:
+   * Specifies the selection mode of the component.
    *
    * - `"multiple"` allows any number of selections
    * - `"single"` allows only one selection

--- a/packages/components/src/components/chip-group/chip-group.tsx
+++ b/packages/components/src/components/chip-group/chip-group.tsx
@@ -62,10 +62,10 @@ export class ChipGroup extends LitElement {
   /**
    * Specifies the selection mode of the component.
    *
-   * - `"multiple"` allows any number of selections
-   * - `"single"` allows only one selection
-   * - `"single-persist"` allows one selection and prevents de-selection
-   * - `"none"` does not allow any selections
+   * - `"multiple"` allows any number of selections.
+   * - `"single"` allows only one selection.
+   * - `"single-persist"` allows one selection and prevents de-selection.
+   * - `"none"` does not allow any selections.
    */
   @property({ reflect: true }) selectionMode: Extract<
     "multiple" | "single" | "single-persist" | "none",

--- a/packages/components/src/components/combobox-item/combobox-item.tsx
+++ b/packages/components/src/components/combobox-item/combobox-item.tsx
@@ -115,10 +115,10 @@ export class ComboboxItem extends LitElement {
   /**
    * Specifies the selection mode of the component.
    *
-   * - `"multiple"` allows any number of selections
-   * - `"single"` allows only one selection
-   * - `"single-persist"` allows one selection and prevents de-selection
-   * - `"ancestors"` allows multiple selections, but shows ancestors of selected items as selected, with only deepest children shown in chips
+   * - `"multiple"` allows any number of selections.
+   * - `"single"` allows only one selection.
+   * - `"single-persist"` allows one selection and prevents de-selection.
+   * - `"ancestors"` allows multiple selections, but shows ancestors of selected items as selected, with only deepest children shown in chips.
    *
    * @private
    */
@@ -130,8 +130,8 @@ export class ComboboxItem extends LitElement {
   /**
    * Specifies the selection appearance.
    *
-   * - `"icon"` displays a radio or checkbox
-   * - `"highlight"` displays a background highlight
+   * - `"icon"` displays a radio or checkbox.
+   * - `"highlight"` displays a background highlight.
    *
    * @private
    */

--- a/packages/components/src/components/combobox-item/combobox-item.tsx
+++ b/packages/components/src/components/combobox-item/combobox-item.tsx
@@ -115,13 +115,10 @@ export class ComboboxItem extends LitElement {
   /**
    * Specifies the selection mode of the component, where:
    *
-   * `"multiple"` allows any number of selections,
-   *
-   * `"single"` allows only one selection,
-   *
-   * `"single-persist"` allows one selection and prevents de-selection, and
-   *
-   * `"ancestors"` allows multiple selections, but shows ancestors of selected items as selected, with only deepest children shown in chips.
+   * - `"multiple"` allows any number of selections
+   * - `"single"` allows only one selection
+   * - `"single-persist"` allows one selection and prevents de-selection
+   * - `"ancestors"` allows multiple selections, but shows ancestors of selected items as selected, with only deepest children shown in chips
    *
    * @private
    */

--- a/packages/components/src/components/combobox-item/combobox-item.tsx
+++ b/packages/components/src/components/combobox-item/combobox-item.tsx
@@ -113,7 +113,7 @@ export class ComboboxItem extends LitElement {
   }
 
   /**
-   * Specifies the selection mode of the component, where:
+   * Specifies the selection mode of the component.
    *
    * - `"multiple"` allows any number of selections
    * - `"single"` allows only one selection
@@ -128,11 +128,10 @@ export class ComboboxItem extends LitElement {
   > = "multiple";
 
   /**
-   * Specifies the selection appearance, where
+   * Specifies the selection appearance.
    *
-   * `"icon"` displays a radio or checkbox, and
-   *
-   * `"highlight"` displays a background highlight.
+   * - `"icon"` displays a radio or checkbox
+   * - `"highlight"` displays a background highlight
    *
    * @private
    */

--- a/packages/components/src/components/combobox/combobox.tsx
+++ b/packages/components/src/components/combobox/combobox.tsx
@@ -458,11 +458,9 @@ export class Combobox extends LitElement implements LabelableComponent, Floating
   /**
    * When `selectionMode` is `"ancestors"` or `"multiple"`, specifies the display of multiple `calcite-combobox-item` selections, where:
    *
-   * `"all"` displays all selections with individual `calcite-chip`s,
-   *
-   * `"fit"` displays individual `calcite-chip`s that scale to the component's size, including a non-closable `calcite-chip`, which provides the number of additional `calcite-combobox-item` selections not visually displayed, and
-   *
-   * `"single"` displays one `calcite-chip` with the total number of selections.
+   * - `"all"` displays all selections with individual `calcite-chip`s
+   * - `"fit"` displays individual `calcite-chip`s that scale to the component's size, including a non-closable `calcite-chip`, which provides the number of additional `calcite-combobox-item` selections not visually displayed
+   * - `"single"` displays one `calcite-chip` with the total number of selections
    */
   @property({ reflect: true }) selectionDisplay: SelectionDisplay = "all";
 
@@ -481,13 +479,10 @@ export class Combobox extends LitElement implements LabelableComponent, Floating
   /**
    * Specifies the selection mode of the component, where:
    *
-   * `"multiple"` allows any number of selections,
-   *
-   * `"single"` allows only one selection,
-   *
-   * `"single-persist"` allows one selection and prevents de-selection, and
-   *
-   * `"ancestors"` allows multiple selections, but shows ancestors of selected items as selected, with only deepest children shown in chips.
+   * - `"multiple"` allows any number of selections
+   * - `"single"` allows only one selection
+   * - `"single-persist"` allows one selection and prevents de-selection
+   * - `"ancestors"` allows multiple selections, but shows ancestors of selected items as selected, with only deepest children shown in chips
    */
   @property({ reflect: true }) selectionMode: Extract<
     "single" | "single-persist" | "ancestors" | "multiple",

--- a/packages/components/src/components/combobox/combobox.tsx
+++ b/packages/components/src/components/combobox/combobox.tsx
@@ -456,7 +456,7 @@ export class Combobox extends LitElement implements LabelableComponent, Floating
   }
 
   /**
-   * When `selectionMode` is `"ancestors"` or `"multiple"`, specifies the display of multiple `calcite-combobox-item` selections, where:
+   * When `selectionMode` is `"ancestors"` or `"multiple"`, specifies the display of multiple `calcite-combobox-item` selections.
    *
    * - `"all"` displays all selections with individual `calcite-chip`s
    * - `"fit"` displays individual `calcite-chip`s that scale to the component's size, including a non-closable `calcite-chip`, which provides the number of additional `calcite-combobox-item` selections not visually displayed
@@ -465,11 +465,10 @@ export class Combobox extends LitElement implements LabelableComponent, Floating
   @property({ reflect: true }) selectionDisplay: SelectionDisplay = "all";
 
   /**
-   * Specifies the selection appearance, where
+   * Specifies the selection appearance.
    *
-   * `"icon"` displays a checkmark or dot, and
-   *
-   * `"highlight"` displays a background highlight.
+   * - `"icon"` displays a checkmark or dot
+   * - `"highlight"` displays a background highlight
    */
   @property({ reflect: true }) selectionAppearance: Extract<
     "icon" | "highlight",
@@ -477,7 +476,7 @@ export class Combobox extends LitElement implements LabelableComponent, Floating
   > = "icon";
 
   /**
-   * Specifies the selection mode of the component, where:
+   * Specifies the selection mode of the component.
    *
    * - `"multiple"` allows any number of selections
    * - `"single"` allows only one selection

--- a/packages/components/src/components/combobox/combobox.tsx
+++ b/packages/components/src/components/combobox/combobox.tsx
@@ -458,17 +458,17 @@ export class Combobox extends LitElement implements LabelableComponent, Floating
   /**
    * When `selectionMode` is `"ancestors"` or `"multiple"`, specifies the display of multiple `calcite-combobox-item` selections.
    *
-   * - `"all"` displays all selections with individual `calcite-chip`s
-   * - `"fit"` displays individual `calcite-chip`s that scale to the component's size, including a non-closable `calcite-chip`, which provides the number of additional `calcite-combobox-item` selections not visually displayed
-   * - `"single"` displays one `calcite-chip` with the total number of selections
+   * - `"all"` displays all selections with individual `calcite-chip`s.
+   * - `"fit"` displays individual `calcite-chip`s that scale to the component's size, including a non-closable `calcite-chip`, which provides the number of additional `calcite-combobox-item` selections not visually displayed.
+   * - `"single"` displays one `calcite-chip` with the total number of selections.
    */
   @property({ reflect: true }) selectionDisplay: SelectionDisplay = "all";
 
   /**
    * Specifies the selection appearance.
    *
-   * - `"icon"` displays a checkmark or dot
-   * - `"highlight"` displays a background highlight
+   * - `"icon"` displays a checkmark or dot.
+   * - `"highlight"` displays a background highlight.
    */
   @property({ reflect: true }) selectionAppearance: Extract<
     "icon" | "highlight",
@@ -478,10 +478,10 @@ export class Combobox extends LitElement implements LabelableComponent, Floating
   /**
    * Specifies the selection mode of the component.
    *
-   * - `"multiple"` allows any number of selections
-   * - `"single"` allows only one selection
-   * - `"single-persist"` allows one selection and prevents de-selection
-   * - `"ancestors"` allows multiple selections, but shows ancestors of selected items as selected, with only deepest children shown in chips
+   * - `"multiple"` allows any number of selections.
+   * - `"single"` allows only one selection.
+   * - `"single-persist"` allows one selection and prevents de-selection.
+   * - `"ancestors"` allows multiple selections, but shows ancestors of selected items as selected, with only deepest children shown in chips.
    */
   @property({ reflect: true }) selectionMode: Extract<
     "single" | "single-persist" | "ancestors" | "multiple",

--- a/packages/components/src/components/dialog/dialog.tsx
+++ b/packages/components/src/components/dialog/dialog.tsx
@@ -184,13 +184,13 @@ export class Dialog extends LitElement implements OpenCloseComponentWithEl {
   @property({ reflect: true }) escapeDisabled = false;
 
   /**
-   * Specifies custom focus trap configuration on the component, where
+   * Specifies custom focus trap configuration on the component, where:
    *
-   * `"allowOutsideClick`" allows outside clicks,
-   * `"initialFocus"` enables initial focus,
-   * `"returnFocusOnDeactivate"` returns focus when not active,
-   * `"extraContainers"` specifies additional focusable elements external to the trap, such as 3rd-party components appending elements to the document body, and
-   * `"setReturnFocus"` customizes the element to which focus is returned when the trap is deactivated. Return `false` to prevent focus return, or `undefined` to use the default behavior (returning focus to the element focused before activation).
+   * - `"allowOutsideClick`" allows outside clicks
+   * - `"initialFocus"` enables initial focus
+   * - `"returnFocusOnDeactivate"` returns focus when not active
+   * - `"extraContainers"` specifies additional focusable elements external to the trap, such as 3rd-party components appending elements to the document body
+   * - `"setReturnFocus"` customizes the element to which focus is returned when the trap is deactivated. Return `false` to prevent focus return, or `undefined` to use the default behavior (returning focus to the element focused before activation)
    */
   @property() focusTrapOptions?: Partial<FocusTrapOptions>;
 
@@ -212,7 +212,7 @@ export class Dialog extends LitElement implements OpenCloseComponentWithEl {
   /** Specifies an icon to display. */
   @property({ reflect: true, type: String }) icon?: IconName;
 
-  /** When `true` and the element direction is right-to-left (`"rtl"`), flips the component`s `icon`. */
+  /** When `true` and the element direction is right-to-left (`"rtl"`), flips the component's `icon`. */
   @property({ reflect: true }) iconFlipRtl = false;
 
   /** When `true`, a busy indicator is displayed. */

--- a/packages/components/src/components/dialog/dialog.tsx
+++ b/packages/components/src/components/dialog/dialog.tsx
@@ -186,11 +186,11 @@ export class Dialog extends LitElement implements OpenCloseComponentWithEl {
   /**
    * Specifies custom focus trap configuration on the component.
    *
-   * - `"allowOutsideClick`" allows outside clicks
-   * - `"initialFocus"` enables initial focus
-   * - `"returnFocusOnDeactivate"` returns focus when not active
-   * - `"extraContainers"` specifies additional focusable elements external to the trap, such as 3rd-party components appending elements to the document body
-   * - `"setReturnFocus"` customizes the element to which focus is returned when the trap is deactivated. Return `false` to prevent focus return, or `undefined` to use the default behavior (returning focus to the element focused before activation)
+   * - `"allowOutsideClick`" allows outside clicks.
+   * - `"initialFocus"` enables initial focus.
+   * - `"returnFocusOnDeactivate"` returns focus when not active.
+   * - `"extraContainers"` specifies additional focusable elements external to the trap, such as 3rd-party components appending elements to the document body.
+   * - `"setReturnFocus"` customizes the element to which focus is returned when the trap is deactivated. Return `false` to prevent focus return, or `undefined` to use the default behavior (returning focus to the element focused before activation).
    */
   @property() focusTrapOptions?: Partial<FocusTrapOptions>;
 

--- a/packages/components/src/components/dialog/dialog.tsx
+++ b/packages/components/src/components/dialog/dialog.tsx
@@ -184,7 +184,7 @@ export class Dialog extends LitElement implements OpenCloseComponentWithEl {
   @property({ reflect: true }) escapeDisabled = false;
 
   /**
-   * Specifies custom focus trap configuration on the component, where:
+   * Specifies custom focus trap configuration on the component.
    *
    * - `"allowOutsideClick`" allows outside clicks
    * - `"initialFocus"` enables initial focus

--- a/packages/components/src/components/dropdown-group/dropdown-group.tsx
+++ b/packages/components/src/components/dropdown-group/dropdown-group.tsx
@@ -56,7 +56,7 @@ export class DropdownGroup extends LitElement {
   @property({ reflect: true }) scale: Scale = "m";
 
   /**
-   * Specifies the selection mode of the component, where:
+   * Specifies the selection mode of the component.
    *
    * - `"multiple"` allows any number of selections
    * - `"single"` allows only one selection

--- a/packages/components/src/components/dropdown-group/dropdown-group.tsx
+++ b/packages/components/src/components/dropdown-group/dropdown-group.tsx
@@ -58,11 +58,9 @@ export class DropdownGroup extends LitElement {
   /**
    * Specifies the selection mode of the component, where:
    *
-   * `"multiple"` allows any number of selections,
-   *
-   * `"single"` allows only one selection, and
-   *
-   * `"none"` does not allow any selections.
+   * - `"multiple"` allows any number of selections
+   * - `"single"` allows only one selection
+   * - `"none"` does not allow any selections
    */
   @property({ reflect: true }) selectionMode: Extract<
     "none" | "single" | "multiple",

--- a/packages/components/src/components/dropdown-group/dropdown-group.tsx
+++ b/packages/components/src/components/dropdown-group/dropdown-group.tsx
@@ -58,9 +58,9 @@ export class DropdownGroup extends LitElement {
   /**
    * Specifies the selection mode of the component.
    *
-   * - `"multiple"` allows any number of selections
-   * - `"single"` allows only one selection
-   * - `"none"` does not allow any selections
+   * - `"multiple"` allows any number of selections.
+   * - `"single"` allows only one selection.
+   * - `"none"` does not allow any selections.
    */
   @property({ reflect: true }) selectionMode: Extract<
     "none" | "single" | "multiple",

--- a/packages/components/src/components/flow-item/flow-item.tsx
+++ b/packages/components/src/components/flow-item/flow-item.tsx
@@ -118,10 +118,10 @@ export class FlowItem extends LitElement {
   /**
    * Specifies custom focus trap configuration on the component.
    *
-   * - `"allowOutsideClick"` allows outside clicks
-   * - `"initialFocus"` enables initial focus
-   * - `"returnFocusOnDeactivate"` returns focus when not active
-   * - `"extraContainers"` specifies additional focusable elements external to the trap, such as 3rd-party components appending elements to the document body
+   * - `"allowOutsideClick"` allows outside clicks.
+   * - `"initialFocus"` enables initial focus.
+   * - `"returnFocusOnDeactivate"` returns focus when not active.
+   * - `"extraContainers"` specifies additional focusable elements external to the trap, such as 3rd-party components appending elements to the document body.
    * - `"setReturnFocus"` customizes the element to which focus is returned when the trap is deactivated. Return `false` to prevent focus return, or `undefined` to use the default behavior (returning focus to the element focused before activation).
    * @private
    */

--- a/packages/components/src/components/flow-item/flow-item.tsx
+++ b/packages/components/src/components/flow-item/flow-item.tsx
@@ -116,13 +116,13 @@ export class FlowItem extends LitElement {
   @property({ reflect: true }) focusTrapEnabled = false;
 
   /**
-   * Specifies custom focus trap configuration on the component, where
+   * Specifies custom focus trap configuration on the component.
    *
-   * `"allowOutsideClick"` allows outside clicks,
-   * `"initialFocus"` enables initial focus,
-   * `"returnFocusOnDeactivate"` returns focus when not active,
-   * `"extraContainers"` specifies additional focusable elements external to the trap, such as 3rd-party components appending elements to the document body, and
-   * `"setReturnFocus"` customizes the element to which focus is returned when the trap is deactivated. Return `false` to prevent focus return, or `undefined` to use the default behavior (returning focus to the element focused before activation).
+   * - `"allowOutsideClick"` allows outside clicks
+   * - `"initialFocus"` enables initial focus
+   * - `"returnFocusOnDeactivate"` returns focus when not active
+   * - `"extraContainers"` specifies additional focusable elements external to the trap, such as 3rd-party components appending elements to the document body
+   * - `"setReturnFocus"` customizes the element to which focus is returned when the trap is deactivated. Return `false` to prevent focus return, or `undefined` to use the default behavior (returning focus to the element focused before activation).
    * @private
    */
   @property() focusTrapOptions?: Partial<FocusTrapOptions>;

--- a/packages/components/src/components/focus-trap/focus-trap.tsx
+++ b/packages/components/src/components/focus-trap/focus-trap.tsx
@@ -51,13 +51,13 @@ export class FocusTrap extends LitElement {
   @property() focusTrapDisabledOverride?: () => boolean;
 
   /**
-   * Specifies custom focus trap configuration on the component, where
+   * Specifies custom focus trap configuration on the component.
    *
-   * `"allowOutsideClick"` allows outside clicks,
-   * `"initialFocus"` enables initial focus,
-   * `"returnFocusOnDeactivate"` returns focus when not active,
-   * `"extraContainers"` specifies additional focusable elements external to the trap, and
-   * `"setReturnFocus"` customizes the element to which focus is returned when the trap is deactivated.
+   * - `"allowOutsideClick"` allows outside clicks
+   * - `"initialFocus"` enables initial focus
+   * - `"returnFocusOnDeactivate"` returns focus when not active
+   * - `"extraContainers"` specifies additional focusable elements external to the trap
+   * - `"setReturnFocus"` customizes the element to which focus is returned when the trap is deactivated.
    */
   @property() focusTrapOptions?: Partial<FocusTrapOptions>;
 

--- a/packages/components/src/components/focus-trap/focus-trap.tsx
+++ b/packages/components/src/components/focus-trap/focus-trap.tsx
@@ -53,10 +53,10 @@ export class FocusTrap extends LitElement {
   /**
    * Specifies custom focus trap configuration on the component.
    *
-   * - `"allowOutsideClick"` allows outside clicks
-   * - `"initialFocus"` enables initial focus
-   * - `"returnFocusOnDeactivate"` returns focus when not active
-   * - `"extraContainers"` specifies additional focusable elements external to the trap
+   * - `"allowOutsideClick"` allows outside clicks.
+   * - `"initialFocus"` enables initial focus.
+   * - `"returnFocusOnDeactivate"` returns focus when not active.
+   * - `"extraContainers"` specifies additional focusable elements external to the trap.
    * - `"setReturnFocus"` customizes the element to which focus is returned when the trap is deactivated.
    */
   @property() focusTrapOptions?: Partial<FocusTrapOptions>;

--- a/packages/components/src/components/input-time-picker/input-time-picker.tsx
+++ b/packages/components/src/components/input-time-picker/input-time-picker.tsx
@@ -130,7 +130,7 @@ export class InputTimePicker extends LitElement implements LabelableComponent, T
   @property({ reflect: true }) form?: string;
 
   /**
-   * Specifies the component's hour format, where:
+   * Specifies the component's hour format.
    *
    * - `"user"` displays the user's locale format
    * - `"12"` displays a 12-hour format

--- a/packages/components/src/components/input-time-picker/input-time-picker.tsx
+++ b/packages/components/src/components/input-time-picker/input-time-picker.tsx
@@ -132,9 +132,9 @@ export class InputTimePicker extends LitElement implements LabelableComponent, T
   /**
    * Specifies the component's hour format.
    *
-   * - `"user"` displays the user's locale format
-   * - `"12"` displays a 12-hour format
-   * - `"24"` displays a 24-hour format
+   * - `"user"` displays the user's locale format.
+   * - `"12"` displays a 12-hour format.
+   * - `"24"` displays a 24-hour format.
    */
   @property({ reflect: true }) hourFormat: HourFormat = "user";
 

--- a/packages/components/src/components/input-time-picker/input-time-picker.tsx
+++ b/packages/components/src/components/input-time-picker/input-time-picker.tsx
@@ -132,9 +132,9 @@ export class InputTimePicker extends LitElement implements LabelableComponent, T
   /**
    * Specifies the component's hour format, where:
    *
-   * `"user"` displays the user's locale format,
-   * `"12"` displays a 12-hour format, and
-   * `"24"` displays a 24-hour format.
+   * - `"user"` displays the user's locale format
+   * - `"12"` displays a 12-hour format
+   * - `"24"` displays a 24-hour format
    */
   @property({ reflect: true }) hourFormat: HourFormat = "user";
 

--- a/packages/components/src/components/input-time-zone/input-time-zone.tsx
+++ b/packages/components/src/components/input-time-zone/input-time-zone.tsx
@@ -135,11 +135,11 @@ export class InputTimeZone extends LitElement implements LabelableComponent {
   @property({ reflect: true }) name?: string;
 
   /**
-   * When `mode` is `"offset"`, specifies how the offset will be displayed, where
+   * When `mode` is `"offset"`, specifies how the offset will be displayed.
    *
-   * `"user"` uses `UTC` or `GMT` depending on the user's locale,
-   * `"gmt"` always uses `GMT`, and
-   * `"utc"` always uses `UTC`.
+   * - `"user"` uses `UTC` or `GMT` depending on the user's locale
+   * - `"gmt"` always uses `GMT`
+   * - `"utc"` always uses `UTC`
    */
   @property({ reflect: true }) offsetStyle: OffsetStyle = "user";
 

--- a/packages/components/src/components/input-time-zone/input-time-zone.tsx
+++ b/packages/components/src/components/input-time-zone/input-time-zone.tsx
@@ -137,9 +137,9 @@ export class InputTimeZone extends LitElement implements LabelableComponent {
   /**
    * When `mode` is `"offset"`, specifies how the offset will be displayed.
    *
-   * - `"user"` uses `UTC` or `GMT` depending on the user's locale
-   * - `"gmt"` always uses `GMT`
-   * - `"utc"` always uses `UTC`
+   * - `"user"` uses `UTC` or `GMT` depending on the user's locale.
+   * - `"gmt"` always uses `GMT`.
+   * - `"utc"` always uses `UTC`.
    */
   @property({ reflect: true }) offsetStyle: OffsetStyle = "user";
 

--- a/packages/components/src/components/label/label.tsx
+++ b/packages/components/src/components/label/label.tsx
@@ -31,7 +31,11 @@ export class Label extends LitElement {
   /** Specifies the `id` of the component the label is bound to. Use when the component the label is bound to does not reside within the component. */
   @property({ reflect: true }) for?: string;
 
-  /** Defines the component's layout in relation to the slotted component. Use `"inline"` positions to wrap the label and slotted component on the same line.  [Deprecated] The `"default"` value is deprecated, use `"block"` instead. */
+  /**
+   * Defines the component's layout in relation to the slotted component. Use `"inline"` positions to wrap the label and slotted component on the same line.
+   *
+   * [Deprecated] The `"default"` value is deprecated in v3.3.0, removal target v6.0.0 - use `"block"` instead.
+   */
   @property({ reflect: true }) layout: "block" | "inline" | "inline-space-between" | "default" =
     "default";
 

--- a/packages/components/src/components/list-item/list-item.tsx
+++ b/packages/components/src/components/list-item/list-item.tsx
@@ -232,7 +232,11 @@ export class ListItem extends LitElement implements SortableComponentItem {
   @property({ reflect: true }) selected = false;
 
   /**
-   * Specifies the selection appearance - `"icon"` (displays a checkmark or dot), `"border"` (displays a border) or `"highlight"` (displays background highlight). [Deprecated] The `"border"` value is deprecated, use `"highlight"` instead.
+   * Specifies the selection appearance.
+   *
+   * - `"icon"` displays a checkmark or dot.
+   * - `"highlight"` displays background highlight.
+   * - `"border"` displays a border. [Deprecated] in v5.0.0, removal target v7.0.0 - use `"highlight"` instead.
    *
    * @private
    */
@@ -242,7 +246,12 @@ export class ListItem extends LitElement implements SortableComponentItem {
   >;
 
   /**
-   * Specifies the selection mode - `"multiple"` (allow any number of selected items), `"single"` (allow one selected item), `"single-persist"` (allow one selected item and prevent de-selection), or `"none"` (no selected items).
+   * Specifies the selection mode of the component.
+   *
+   * - `"multiple"` allows any number of selections.
+   * - `"single"` allows only one selection.
+   * - `"single-persist"` allows one selection and prevents de-selection.
+   * - `"none"` does not allow any selections.
    *
    * @private
    */

--- a/packages/components/src/components/list-item/list-item.tsx
+++ b/packages/components/src/components/list-item/list-item.tsx
@@ -236,7 +236,7 @@ export class ListItem extends LitElement implements SortableComponentItem {
    *
    * - `"icon"` displays a checkmark or dot.
    * - `"highlight"` displays background highlight.
-   * - `"border"` displays a border. [Deprecated] in v5.0.0, removal target v7.0.0 - use `"highlight"` instead.
+   * - `"border"` displays a border. [Deprecated] in v5.0.0, removal target v6.0.0 - use `"highlight"` instead.
    *
    * @private
    */

--- a/packages/components/src/components/list/list.tsx
+++ b/packages/components/src/components/list/list.tsx
@@ -245,13 +245,10 @@ export class List extends LitElement {
   @property({ reflect: true }) group?: string;
 
   /**
-   * Specifies the interaction mode of the component, where
+   * Specifies the interaction mode of the component.
    *
-   * `"interactive"` allows interaction styling and pointer changes on hover,
-   *
-   * `"static"` does not allow interaction styling and pointer changes on hover -
-   *
-   * the `"static"` value should only be used when `selectionMode` is `"none"`.
+   * - `"interactive"` allows interaction styling and pointer changes on hover
+   * - `"static"` does not allow interaction styling and pointer changes on hover. Should only be used when `selectionMode` is `"none"`.
    */
   @property({ reflect: true }) interactionMode: InteractionMode = "interactive";
 
@@ -271,14 +268,12 @@ export class List extends LitElement {
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /**
-   * Specifies the nesting behavior of `calcite-list-item`s, where
+   * Specifies the nesting behavior of `calcite-list-item`s.
    *
-   * `"flat"` displays `calcite-list-item`s in a uniform list, and
-   *
-   * `"nested"` displays `calcite-list-item`s under their parent element.
+   * - `"flat"` displays `calcite-list-item`s in a uniform list
+   * - `"nested"` displays `calcite-list-item`s under their parent element
    *
    *  The parent component's behavior should follow throughout its child elements.
-   *
    */
   @property({ reflect: true }) displayMode: ListDisplayMode = "flat";
 
@@ -296,14 +291,11 @@ export class List extends LitElement {
   @property() selectedItems: ListItem["el"][] = [];
 
   /**
-   * Specifies the selection appearance, where
+   * Specifies the selection appearance.
    *
-   * `"icon"` displays a checkmark or dot,
-   *
-   * `"border"` [Deprecated] - Use `"highlight"` instead - displays a border, or
-   *
-   * `"highlight"` displays background highlight.
-   *
+   * - `"icon"` displays a checkmark or dot
+   * - `"border"` [Deprecated] - Use `"highlight"` instead - displays a border
+   * - `"highlight"` displays background highlight
    */
   @property({ reflect: true }) selectionAppearance: Extract<
     "icon" | "border" | "highlight",
@@ -311,7 +303,7 @@ export class List extends LitElement {
   > = "icon";
 
   /**
-   * Specifies the selection mode of the component, where:
+   * Specifies the selection mode of the component.
    *
    * - `"multiple"` allows any number of selections
    * - `"single"` allows only one selection

--- a/packages/components/src/components/list/list.tsx
+++ b/packages/components/src/components/list/list.tsx
@@ -294,8 +294,8 @@ export class List extends LitElement {
    * Specifies the selection appearance.
    *
    * - `"icon"` displays a checkmark or dot.
-   * - `"border"` [Deprecated] - Use `"highlight"` instead - displays a border.
    * - `"highlight"` displays background highlight.
+   * - `"border"` displays a border. [Deprecated] in v5.0.0, removal target v7.0.0 - use `"highlight"` instead.
    */
   @property({ reflect: true }) selectionAppearance: Extract<
     "icon" | "border" | "highlight",

--- a/packages/components/src/components/list/list.tsx
+++ b/packages/components/src/components/list/list.tsx
@@ -313,13 +313,10 @@ export class List extends LitElement {
   /**
    * Specifies the selection mode of the component, where:
    *
-   * `"multiple"` allows any number of selections,
-   *
-   * `"single"` allows only one selection,
-   *
-   * `"single-persist"` allows one selection and prevents de-selection, and
-   *
-   * `"none"` does not allow any selections.
+   * - `"multiple"` allows any number of selections
+   * - `"single"` allows only one selection
+   * - `"single-persist"` allows one selection and prevents de-selection
+   * - `"none"` does not allow any selections
    */
   @property({ reflect: true }) selectionMode: Extract<
     "none" | "multiple" | "single" | "single-persist",

--- a/packages/components/src/components/list/list.tsx
+++ b/packages/components/src/components/list/list.tsx
@@ -247,7 +247,7 @@ export class List extends LitElement {
   /**
    * Specifies the interaction mode of the component.
    *
-   * - `"interactive"` allows interaction styling and pointer changes on hover
+   * - `"interactive"` allows interaction styling and pointer changes on hover.
    * - `"static"` does not allow interaction styling and pointer changes on hover. Should only be used when `selectionMode` is `"none"`.
    */
   @property({ reflect: true }) interactionMode: InteractionMode = "interactive";
@@ -270,8 +270,8 @@ export class List extends LitElement {
   /**
    * Specifies the nesting behavior of `calcite-list-item`s.
    *
-   * - `"flat"` displays `calcite-list-item`s in a uniform list
-   * - `"nested"` displays `calcite-list-item`s under their parent element
+   * - `"flat"` displays `calcite-list-item`s in a uniform list.
+   * - `"nested"` displays `calcite-list-item`s under their parent element.
    *
    *  The parent component's behavior should follow throughout its child elements.
    */
@@ -293,9 +293,9 @@ export class List extends LitElement {
   /**
    * Specifies the selection appearance.
    *
-   * - `"icon"` displays a checkmark or dot
-   * - `"border"` [Deprecated] - Use `"highlight"` instead - displays a border
-   * - `"highlight"` displays background highlight
+   * - `"icon"` displays a checkmark or dot.
+   * - `"border"` [Deprecated] - Use `"highlight"` instead - displays a border.
+   * - `"highlight"` displays background highlight.
    */
   @property({ reflect: true }) selectionAppearance: Extract<
     "icon" | "border" | "highlight",
@@ -305,10 +305,10 @@ export class List extends LitElement {
   /**
    * Specifies the selection mode of the component.
    *
-   * - `"multiple"` allows any number of selections
-   * - `"single"` allows only one selection
-   * - `"single-persist"` allows one selection and prevents de-selection
-   * - `"none"` does not allow any selections
+   * - `"multiple"` allows any number of selections.
+   * - `"single"` allows only one selection.
+   * - `"single-persist"` allows one selection and prevents de-selection.
+   * - `"none"` does not allow any selections.
    */
   @property({ reflect: true }) selectionMode: Extract<
     "none" | "multiple" | "single" | "single-persist",

--- a/packages/components/src/components/list/list.tsx
+++ b/packages/components/src/components/list/list.tsx
@@ -295,7 +295,7 @@ export class List extends LitElement {
    *
    * - `"icon"` displays a checkmark or dot.
    * - `"highlight"` displays background highlight.
-   * - `"border"` displays a border. [Deprecated] in v5.0.0, removal target v7.0.0 - use `"highlight"` instead.
+   * - `"border"` displays a border. [Deprecated] in v5.0.0, removal target v6.0.0 - use `"highlight"` instead.
    */
   @property({ reflect: true }) selectionAppearance: Extract<
     "icon" | "border" | "highlight",

--- a/packages/components/src/components/meter/meter.tsx
+++ b/packages/components/src/components/meter/meter.tsx
@@ -85,9 +85,10 @@ export class Meter extends LitElement {
   @property({ reflect: true }) disabled = false;
 
   /**
-   * Specifies the component's display, where
-   * `"single"` displays a single color, and
-   * `"range"` displays a range of colors based on provided `low`, `high`, `min` or `max` values.
+   * Specifies the component's display.
+   *
+   * - `"single"` displays a single color
+   * - `"range"` displays a range of colors based on provided `low`, `high`, `min` or `max` values
    */
   @property({ reflect: true }) fillType: MeterFillType = "range";
 

--- a/packages/components/src/components/meter/meter.tsx
+++ b/packages/components/src/components/meter/meter.tsx
@@ -87,8 +87,8 @@ export class Meter extends LitElement {
   /**
    * Specifies the component's display.
    *
-   * - `"single"` displays a single color
-   * - `"range"` displays a range of colors based on provided `low`, `high`, `min` or `max` values
+   * - `"single"` displays a single color.
+   * - `"range"` displays a range of colors based on provided `low`, `high`, `min` or `max` values.
    */
   @property({ reflect: true }) fillType: MeterFillType = "range";
 

--- a/packages/components/src/components/notice/notice.tsx
+++ b/packages/components/src/components/notice/notice.tsx
@@ -108,7 +108,11 @@ export class Notice extends LitElement {
   /** Specifies the size of the component. */
   @property({ reflect: true }) scale: Scale = "m";
 
-  /** Specifies the width of the component. [Deprecated] The `"half"` value is deprecated, use `"full"` instead. */
+  /**
+   * Specifies the width of the component.
+   *
+   * [Deprecated] The `"half"` value is deprecated in v3.0.0, removal target v6.0.0 - use `"full"` instead.
+   */
   @property({ reflect: true }) width: Extract<Width, "auto" | "half" | "full"> = "auto";
 
   //#endregion

--- a/packages/components/src/components/panel/panel.tsx
+++ b/packages/components/src/components/panel/panel.tsx
@@ -195,13 +195,13 @@ export class Panel extends LitElement {
   @property({ reflect: true }) focusTrapEnabled = false;
 
   /**
-   * Specifies custom focus trap configuration on the component, where
+   * Specifies custom focus trap configuration on the component.
    *
-   * `"allowOutsideClick"` allows outside clicks,
-   * `"initialFocus"` enables initial focus,
-   * `"returnFocusOnDeactivate"` returns focus when not active,
-   * `"extraContainers"` specifies additional focusable elements external to the trap, such as 3rd-party components appending elements to the document body, and
-   * `"setReturnFocus"` customizes the element to which focus is returned when the trap is deactivated. Return `false` to prevent focus return, or `undefined` to use the default behavior (returning focus to the element focused before activation).
+   * - `"allowOutsideClick"` allows outside clicks
+   * - `"initialFocus"` enables initial focus
+   * - `"returnFocusOnDeactivate"` returns focus when not active
+   * - `"extraContainers"` specifies additional focusable elements external to the trap, such as 3rd-party components appending elements to the document body
+   * - `"setReturnFocus"` customizes the element to which focus is returned when the trap is deactivated. Return `false` to prevent focus return, or `undefined` to use the default behavior (returning focus to the element focused before activation).
    * @private
    */
   @property() focusTrapOptions?: Partial<FocusTrapOptions>;

--- a/packages/components/src/components/panel/panel.tsx
+++ b/packages/components/src/components/panel/panel.tsx
@@ -197,10 +197,10 @@ export class Panel extends LitElement {
   /**
    * Specifies custom focus trap configuration on the component.
    *
-   * - `"allowOutsideClick"` allows outside clicks
-   * - `"initialFocus"` enables initial focus
-   * - `"returnFocusOnDeactivate"` returns focus when not active
-   * - `"extraContainers"` specifies additional focusable elements external to the trap, such as 3rd-party components appending elements to the document body
+   * - `"allowOutsideClick"` allows outside clicks.
+   * - `"initialFocus"` enables initial focus.
+   * - `"returnFocusOnDeactivate"` returns focus when not active.
+   * - `"extraContainers"` specifies additional focusable elements external to the trap, such as 3rd-party components appending elements to the document body.
    * - `"setReturnFocus"` customizes the element to which focus is returned when the trap is deactivated. Return `false` to prevent focus return, or `undefined` to use the default behavior (returning focus to the element focused before activation).
    * @private
    */

--- a/packages/components/src/components/popover/popover.tsx
+++ b/packages/components/src/components/popover/popover.tsx
@@ -133,10 +133,10 @@ export class Popover extends LitElement implements FloatingUIComponent, Referenc
   /**
    * Specifies custom focus trap configuration on the component.
    *
-   * - `"allowOutsideClick`" allows outside clicks
-   * - `"initialFocus"` enables initial focus
-   * - `"returnFocusOnDeactivate"` returns focus when not active
-   * - `"extraContainers"` specifies additional focusable elements external to the trap, such as 3rd-party components appending elements to the document body
+   * - `"allowOutsideClick`" allows outside clicks.
+   * - `"initialFocus"` enables initial focus.
+   * - `"returnFocusOnDeactivate"` returns focus when not active.
+   * - `"extraContainers"` specifies additional focusable elements external to the trap, such as 3rd-party components appending elements to the document body.
    * - `"setReturnFocus"` customizes the element to which focus is returned when the trap is deactivated. Return `false` to prevent focus return, or `undefined` to use the default behavior (returning focus to the element focused before activation).
    */
   @property() focusTrapOptions?: Partial<FocusTrapOptions>;

--- a/packages/components/src/components/popover/popover.tsx
+++ b/packages/components/src/components/popover/popover.tsx
@@ -131,13 +131,13 @@ export class Popover extends LitElement implements FloatingUIComponent, Referenc
   @property({ reflect: true }) focusTrapDisabled = false;
 
   /**
-   * Specifies custom focus trap configuration on the component, where
+   * Specifies custom focus trap configuration on the component.
    *
-   * `"allowOutsideClick`" allows outside clicks,
-   * `"initialFocus"` enables initial focus,
-   * `"returnFocusOnDeactivate"` returns focus when not active,
-   * `"extraContainers"` specifies additional focusable elements external to the trap, such as 3rd-party components appending elements to the document body, and
-   * `"setReturnFocus"` customizes the element to which focus is returned when the trap is deactivated. Return `false` to prevent focus return, or `undefined` to use the default behavior (returning focus to the element focused before activation).
+   * - `"allowOutsideClick`" allows outside clicks
+   * - `"initialFocus"` enables initial focus
+   * - `"returnFocusOnDeactivate"` returns focus when not active
+   * - `"extraContainers"` specifies additional focusable elements external to the trap, such as 3rd-party components appending elements to the document body
+   * - `"setReturnFocus"` customizes the element to which focus is returned when the trap is deactivated. Return `false` to prevent focus return, or `undefined` to use the default behavior (returning focus to the element focused before activation).
    */
   @property() focusTrapOptions?: Partial<FocusTrapOptions>;
 

--- a/packages/components/src/components/segmented-control/segmented-control.tsx
+++ b/packages/components/src/components/segmented-control/segmented-control.tsx
@@ -139,7 +139,11 @@ export class SegmentedControl extends LitElement implements LabelableComponent {
   // @ts-expect-error -- updating public type at v6.0.0 (see #14582)
   @property() value: string = null;
 
-  /** Specifies the width of the component. [Deprecated] The `"half"` value is deprecated, use `"full"` instead. */
+  /**
+   * Specifies the width of the component.
+   *
+   * [Deprecated] The `"half"` value is deprecated in v3.0.0, removal target v6.0.0 - use `"full"` instead.
+   */
   @property({ reflect: true }) width: Extract<"auto" | "full", Width> = "auto";
 
   //#endregion

--- a/packages/components/src/components/select/select.tsx
+++ b/packages/components/src/components/select/select.tsx
@@ -147,7 +147,11 @@ export class Select extends LitElement implements LabelableComponent {
   // @ts-expect-error -- updating public type at v6.0.0 (see #14582)
   @property() value: string = null;
 
-  /** Specifies the width of the component. [Deprecated] The `"half"` value is deprecated, use `"full"` instead. */
+  /**
+   * Specifies the width of the component.
+   *
+   * [Deprecated] The `"half"` value is deprecated in v3.0.0, removal target v6.0.0 - use `"full"` instead.
+   */
   @property({ reflect: true }) width: Extract<Width, "auto" | "half" | "full"> = "auto";
 
   /** @copyDoc */

--- a/packages/components/src/components/sheet/sheet.tsx
+++ b/packages/components/src/components/sheet/sheet.tsx
@@ -168,10 +168,10 @@ export class Sheet extends LitElement {
   /**
    * Specifies custom focus trap configuration on the component.
    *
-   * - `"allowOutsideClick"` allows outside clicks
-   * - `"initialFocus"` enables initial focus
-   * - `"returnFocusOnDeactivate"` returns focus when not active
-   * - `"extraContainers"` specifies additional focusable elements external to the trap, such as 3rd-party components appending elements to the document body
+   * - `"allowOutsideClick"` allows outside clicks.
+   * - `"initialFocus"` enables initial focus.
+   * - `"returnFocusOnDeactivate"` returns focus when not active.
+   * - `"extraContainers"` specifies additional focusable elements external to the trap, such as 3rd-party components appending elements to the document body.
    * - `"setReturnFocus"` customizes the element to which focus is returned when the trap is deactivated. Return `false` to prevent focus return, or `undefined` to use the default behavior (returning focus to the element focused before activation).
    */
   @property() focusTrapOptions?: Partial<FocusTrapOptions>;

--- a/packages/components/src/components/sheet/sheet.tsx
+++ b/packages/components/src/components/sheet/sheet.tsx
@@ -166,13 +166,13 @@ export class Sheet extends LitElement {
   @property({ reflect: true }) focusTrapDisabled = false;
 
   /**
-   * Specifies custom focus trap configuration on the component, where
+   * Specifies custom focus trap configuration on the component.
    *
-   * `"allowOutsideClick"` allows outside clicks,
-   * `"initialFocus"` enables initial focus,
-   * `"returnFocusOnDeactivate"` returns focus when not active,
-   * `"extraContainers"` specifies additional focusable elements external to the trap, such as 3rd-party components appending elements to the document body, and
-   * `"setReturnFocus"` customizes the element to which focus is returned when the trap is deactivated. Return `false` to prevent focus return, or `undefined` to use the default behavior (returning focus to the element focused before activation).
+   * - `"allowOutsideClick"` allows outside clicks
+   * - `"initialFocus"` enables initial focus
+   * - `"returnFocusOnDeactivate"` returns focus when not active
+   * - `"extraContainers"` specifies additional focusable elements external to the trap, such as 3rd-party components appending elements to the document body
+   * - `"setReturnFocus"` customizes the element to which focus is returned when the trap is deactivated. Return `false` to prevent focus return, or `undefined` to use the default behavior (returning focus to the element focused before activation).
    */
   @property() focusTrapOptions?: Partial<FocusTrapOptions>;
 

--- a/packages/components/src/components/shell-panel/shell-panel.tsx
+++ b/packages/components/src/components/shell-panel/shell-panel.tsx
@@ -124,11 +124,9 @@ export class ShellPanel extends LitElement {
   /**
    * Specifies the component's display mode, where:
    *
-   * `"dock"` displays at full height adjacent to center content,
-   *
-   * `"overlay"` displays at full height on top of center content, and
-   *
-   * `"float"` [Deprecated] does not display at full height with content separately detached from `calcite-action-bar` on top of center content.
+   * - `"dock"` displays at full height adjacent to center content
+   * - `"overlay"` displays at full height on top of center content
+   * - `"float"` [Deprecated] does not display at full height with content separately detached from `calcite-action-bar` on top of center content
    *
    * `"float-content"` does not display at full height with content separately detached from `calcite-action-bar` on top of center content.
    *

--- a/packages/components/src/components/shell-panel/shell-panel.tsx
+++ b/packages/components/src/components/shell-panel/shell-panel.tsx
@@ -122,7 +122,7 @@ export class ShellPanel extends LitElement {
   @property({ reflect: true }) collapsed = false;
 
   /**
-   * Specifies the component's display mode, where:
+   * Specifies the component's display mode.
    *
    * - `"dock"` displays at full height adjacent to center content
    * - `"overlay"` displays at full height on top of center content

--- a/packages/components/src/components/shell-panel/shell-panel.tsx
+++ b/packages/components/src/components/shell-panel/shell-panel.tsx
@@ -124,9 +124,9 @@ export class ShellPanel extends LitElement {
   /**
    * Specifies the component's display mode.
    *
-   * - `"dock"` displays at full height adjacent to center content
-   * - `"overlay"` displays at full height on top of center content
-   * - `"float"` [Deprecated] does not display at full height with content separately detached from `calcite-action-bar` on top of center content
+   * - `"dock"` displays at full height adjacent to center content.
+   * - `"overlay"` displays at full height on top of center content.
+   * - `"float"` [Deprecated] does not display at full height with content separately detached from `calcite-action-bar` on top of center content.
    *
    * `"float-content"` does not display at full height with content separately detached from `calcite-action-bar` on top of center content.
    *

--- a/packages/components/src/components/shell-panel/shell-panel.tsx
+++ b/packages/components/src/components/shell-panel/shell-panel.tsx
@@ -126,11 +126,9 @@ export class ShellPanel extends LitElement {
    *
    * - `"dock"` displays at full height adjacent to center content.
    * - `"overlay"` displays at full height on top of center content.
-   * - `"float"` [Deprecated] does not display at full height with content separately detached from `calcite-action-bar` on top of center content.
-   *
-   * `"float-content"` does not display at full height with content separately detached from `calcite-action-bar` on top of center content.
-   *
-   * `"float-all"` detaches the `calcite-panel` and `calcite-action-bar` on top of center content.
+   * - `"float-content"` does not display at full height with content separately detached from `calcite-action-bar` on top of center content.
+   * - `"float-all"` detaches the `calcite-panel` and `calcite-action-bar` on top of center content.
+   * - `"float"` does not display at full height with content separately detached from `calcite-action-bar` on top of center content. [Deprecated] in v2.11.0, removal target v6.0.0 - use `"float-content"` instead.
    */
   @property({ reflect: true }) displayMode: DisplayMode = "dock";
 

--- a/packages/components/src/components/split-button/split-button.tsx
+++ b/packages/components/src/components/split-button/split-button.tsx
@@ -142,7 +142,11 @@ export class SplitButton extends LitElement {
    */
   @property({ reflect: true }) topLayerDisabled = false;
 
-  /** Specifies the width of the component. [Deprecated] The `"half"` value is deprecated, use `"full"` instead. */
+  /**
+   * Specifies the width of the component.
+   *
+   * [Deprecated] The `"half"` value is deprecated in v3.0.0, removal target v6.0.0 - use `"full"` instead.
+   */
   @property({ reflect: true }) width: Extract<Width, "auto" | "half" | "full"> = "auto";
 
   //#endregion

--- a/packages/components/src/components/swatch-group/swatch-group.tsx
+++ b/packages/components/src/components/swatch-group/swatch-group.tsx
@@ -59,10 +59,10 @@ export class SwatchGroup extends LitElement {
   /**
    * Specifies the selection mode of the component.
    *
-   * - `"multiple"` allows any number of selections
-   * - `"single"` allows only one selection
-   * - `"single-persist"` allows one selection and prevents de-selection
-   * - `"none"` does not allow any selections
+   * - `"multiple"` allows any number of selections.
+   * - `"single"` allows only one selection.
+   * - `"single-persist"` allows one selection and prevents de-selection.
+   * - `"none"` does not allow any selections.
    */
   @property({ reflect: true }) selectionMode: Extract<
     "multiple" | "single" | "single-persist" | "none",

--- a/packages/components/src/components/swatch-group/swatch-group.tsx
+++ b/packages/components/src/components/swatch-group/swatch-group.tsx
@@ -59,13 +59,10 @@ export class SwatchGroup extends LitElement {
   /**
    * Specifies the selection mode of the component, where:
    *
-   * `"multiple"` allows any number of selections,
-   *
-   * `"single"` allows only one selection,
-   *
-   * `"single-persist"` allows one selection and prevents de-selection, and
-   *
-   * `"none"` does not allow any selections.
+   * - `"multiple"` allows any number of selections
+   * - `"single"` allows only one selection
+   * - `"single-persist"` allows one selection and prevents de-selection
+   * - `"none"` does not allow any selections
    */
   @property({ reflect: true }) selectionMode: Extract<
     "multiple" | "single" | "single-persist" | "none",

--- a/packages/components/src/components/swatch-group/swatch-group.tsx
+++ b/packages/components/src/components/swatch-group/swatch-group.tsx
@@ -57,7 +57,7 @@ export class SwatchGroup extends LitElement {
   @property() selectedItems: Swatch["el"][] = [];
 
   /**
-   * Specifies the selection mode of the component, where:
+   * Specifies the selection mode of the component.
    *
    * - `"multiple"` allows any number of selections
    * - `"single"` allows only one selection

--- a/packages/components/src/components/table-cell/table-cell.tsx
+++ b/packages/components/src/components/table-cell/table-cell.tsx
@@ -59,9 +59,10 @@ export class TableCell extends LitElement {
 
   /**
    * Specifies the horizontal alignment of content within the component, where:
-   * `"start"` positions content at the start of the component,
-   * `"center"` positions content in the middle of the component, and
-   * `"end"` positions content at the end of the component.
+   *
+   * - `"start"` positions content at the start of the component
+   * - `"center"` positions content in the middle of the component
+   * - `"end"` positions content at the end of the component
    */
   @property({ reflect: true }) alignment: Alignment = "start";
 

--- a/packages/components/src/components/table-cell/table-cell.tsx
+++ b/packages/components/src/components/table-cell/table-cell.tsx
@@ -58,7 +58,7 @@ export class TableCell extends LitElement {
   //#region Public Properties
 
   /**
-   * Specifies the horizontal alignment of content within the component, where:
+   * Specifies the horizontal alignment of content within the component.
    *
    * - `"start"` positions content at the start of the component
    * - `"center"` positions content in the middle of the component

--- a/packages/components/src/components/table-cell/table-cell.tsx
+++ b/packages/components/src/components/table-cell/table-cell.tsx
@@ -60,9 +60,9 @@ export class TableCell extends LitElement {
   /**
    * Specifies the horizontal alignment of content within the component.
    *
-   * - `"start"` positions content at the start of the component
-   * - `"center"` positions content in the middle of the component
-   * - `"end"` positions content at the end of the component
+   * - `"start"` positions content at the start of the component.
+   * - `"center"` positions content in the middle of the component.
+   * - `"end"` positions content at the end of the component.
    */
   @property({ reflect: true }) alignment: Alignment = "start";
 

--- a/packages/components/src/components/table-row/table-row.tsx
+++ b/packages/components/src/components/table-row/table-row.tsx
@@ -71,7 +71,7 @@ export class TableRow extends LitElement {
   //#region Public Properties
 
   /**
-   * Specifies the vertical alignment of content within child `calcite-table-cell`s, where:
+   * Specifies the vertical alignment of content within child `calcite-table-cell`s.
    *
    * - `"start"` positions content at the top of a `calcite-table-cell`
    * - `"center"` positions content in the middle of a `calcite-table-cell`

--- a/packages/components/src/components/table-row/table-row.tsx
+++ b/packages/components/src/components/table-row/table-row.tsx
@@ -72,9 +72,10 @@ export class TableRow extends LitElement {
 
   /**
    * Specifies the vertical alignment of content within child `calcite-table-cell`s, where:
-   * `"start"` positions content at the top of a `calcite-table-cell`,
-   * `"center"` positions content in the middle of a `calcite-table-cell`, and
-   * `"end"` positions content at the bottom of a `calcite-table-cell`.
+   *
+   * - `"start"` positions content at the top of a `calcite-table-cell`
+   * - `"center"` positions content in the middle of a `calcite-table-cell`
+   * - `"end"` positions content at the bottom of a `calcite-table-cell`
    */
   @property({ reflect: true }) alignment!: Alignment;
 

--- a/packages/components/src/components/table-row/table-row.tsx
+++ b/packages/components/src/components/table-row/table-row.tsx
@@ -73,9 +73,9 @@ export class TableRow extends LitElement {
   /**
    * Specifies the vertical alignment of content within child `calcite-table-cell`s.
    *
-   * - `"start"` positions content at the top of a `calcite-table-cell`
-   * - `"center"` positions content in the middle of a `calcite-table-cell`
-   * - `"end"` positions content at the bottom of a `calcite-table-cell`
+   * - `"start"` positions content at the top of a `calcite-table-cell`.
+   * - `"center"` positions content in the middle of a `calcite-table-cell`.
+   * - `"end"` positions content at the bottom of a `calcite-table-cell`.
    */
   @property({ reflect: true }) alignment!: Alignment;
 

--- a/packages/components/src/components/table/table.tsx
+++ b/packages/components/src/components/table/table.tsx
@@ -148,11 +148,9 @@ export class Table extends LitElement {
   /**
    * Specifies the selection mode of the component, where:
    *
-   * `"multiple"` allows any number of selections,
-   *
-   * `"single"` allows only one selection, and
-   *
-   * `"none"` does not allow any selections.
+   * - `"multiple"` allows any number of selections
+   * - `"single"` allows only one selection
+   * - `"none"` does not allow any selections
    */
   @property({ reflect: true }) selectionMode: Extract<
     "none" | "multiple" | "single",

--- a/packages/components/src/components/table/table.tsx
+++ b/packages/components/src/components/table/table.tsx
@@ -148,9 +148,9 @@ export class Table extends LitElement {
   /**
    * Specifies the selection mode of the component.
    *
-   * - `"multiple"` allows any number of selections
-   * - `"single"` allows only one selection
-   * - `"none"` does not allow any selections
+   * - `"multiple"` allows any number of selections.
+   * - `"single"` allows only one selection.
+   * - `"none"` does not allow any selections.
    */
   @property({ reflect: true }) selectionMode: Extract<
     "none" | "multiple" | "single",

--- a/packages/components/src/components/table/table.tsx
+++ b/packages/components/src/components/table/table.tsx
@@ -146,7 +146,7 @@ export class Table extends LitElement {
   @property({ reflect: true }) selectionDisplay: TableSelectionDisplay = "top";
 
   /**
-   * Specifies the selection mode of the component, where:
+   * Specifies the selection mode of the component.
    *
    * - `"multiple"` allows any number of selections
    * - `"single"` allows only one selection

--- a/packages/components/src/components/tile-group/tile-group.tsx
+++ b/packages/components/src/components/tile-group/tile-group.tsx
@@ -70,9 +70,9 @@ export class TileGroup extends LitElement implements SelectableGroupComponent {
   /**
    * Specifies the selection appearance, where:
    *
-   * - `"icon"` (displays a checkmark or dot),
-   * - `"highlight"` (changes the background color), and
-   * - `"border"` (displays a border). [Deprecated] The `"border"` value is deprecated in v5.0.0, removal target v6.0.0 - Use `"highlight"` instead.
+   * - `"icon"` (displays a checkmark or dot)
+   * - `"highlight"` (changes the background color)
+   * - `"border"` (displays a border). [Deprecated] The `"border"` value is deprecated in v5.0.0, removal target v6.0.0 - Use `"highlight"` instead
    */
   @property({ reflect: true }) selectionAppearance: Extract<
     "icon" | "highlight" | "border",
@@ -82,10 +82,10 @@ export class TileGroup extends LitElement implements SelectableGroupComponent {
   /**
    * Specifies the selection mode, where:
    *
-   * - `"multiple"` (allows any number of selected items),
-   * - `"single"` (allows only one selected item),
-   * - `"single-persist"` (allows only one selected item and prevents de-selection), and
-   * - `"none"` (allows no selected items).
+   * - `"multiple"` (allows any number of selected items)
+   * - `"single"` (allows only one selected item)
+   * - `"single-persist"` (allows only one selected item and prevents de-selection)
+   * - `"none"` (allows no selected items)
    */
   @property({ reflect: true }) selectionMode: Extract<
     "multiple" | "none" | "single" | "single-persist",

--- a/packages/components/src/components/tile-group/tile-group.tsx
+++ b/packages/components/src/components/tile-group/tile-group.tsx
@@ -72,7 +72,7 @@ export class TileGroup extends LitElement implements SelectableGroupComponent {
    *
    * - `"icon"` displays a checkmark or dot.
    * - `"highlight"` changes the background color.
-   * - `"border"` displays a border. [Deprecated] in v5.0.0, removal target v7.0.0 - use `"highlight"` instead.
+   * - `"border"` displays a border. [Deprecated] in v5.0.0, removal target v6.0.0 - use `"highlight"` instead.
    */
   @property({ reflect: true }) selectionAppearance: Extract<
     "icon" | "highlight" | "border",

--- a/packages/components/src/components/tile-group/tile-group.tsx
+++ b/packages/components/src/components/tile-group/tile-group.tsx
@@ -68,7 +68,7 @@ export class TileGroup extends LitElement implements SelectableGroupComponent {
   @property() selectedItems: Tile["el"][] = [];
 
   /**
-   * Specifies the selection appearance, where:
+   * Specifies the selection appearance.
    *
    * - `"icon"` (displays a checkmark or dot)
    * - `"highlight"` (changes the background color)
@@ -80,7 +80,7 @@ export class TileGroup extends LitElement implements SelectableGroupComponent {
   > = "icon";
 
   /**
-   * Specifies the selection mode, where:
+   * Specifies the selection mode.
    *
    * - `"multiple"` (allows any number of selected items)
    * - `"single"` (allows only one selected item)

--- a/packages/components/src/components/tile-group/tile-group.tsx
+++ b/packages/components/src/components/tile-group/tile-group.tsx
@@ -70,9 +70,9 @@ export class TileGroup extends LitElement implements SelectableGroupComponent {
   /**
    * Specifies the selection appearance.
    *
-   * - `"icon"` (displays a checkmark or dot)
-   * - `"highlight"` (changes the background color)
-   * - `"border"` (displays a border). [Deprecated] The `"border"` value is deprecated in v5.0.0, removal target v6.0.0 - Use `"highlight"` instead
+   * - `"icon"` (displays a checkmark or dot).
+   * - `"highlight"` (changes the background color).
+   * - `"border"` (displays a border). [Deprecated] The `"border"` value is deprecated in v5.0.0, removal target v6.0.0 - Use `"highlight"` instead.
    */
   @property({ reflect: true }) selectionAppearance: Extract<
     "icon" | "highlight" | "border",
@@ -82,10 +82,10 @@ export class TileGroup extends LitElement implements SelectableGroupComponent {
   /**
    * Specifies the selection mode.
    *
-   * - `"multiple"` (allows any number of selected items)
-   * - `"single"` (allows only one selected item)
-   * - `"single-persist"` (allows only one selected item and prevents de-selection)
-   * - `"none"` (allows no selected items)
+   * - `"multiple"` (allows any number of selected items).
+   * - `"single"` (allows only one selected item).
+   * - `"single-persist"` (allows only one selected item and prevents de-selection).
+   * - `"none"` (allows no selected items).
    */
   @property({ reflect: true }) selectionMode: Extract<
     "multiple" | "none" | "single" | "single-persist",

--- a/packages/components/src/components/tile-group/tile-group.tsx
+++ b/packages/components/src/components/tile-group/tile-group.tsx
@@ -70,9 +70,9 @@ export class TileGroup extends LitElement implements SelectableGroupComponent {
   /**
    * Specifies the selection appearance.
    *
-   * - `"icon"` (displays a checkmark or dot).
-   * - `"highlight"` (changes the background color).
-   * - `"border"` (displays a border). [Deprecated] The `"border"` value is deprecated in v5.0.0, removal target v6.0.0 - Use `"highlight"` instead.
+   * - `"icon"` displays a checkmark or dot.
+   * - `"highlight"` changes the background color.
+   * - `"border"` displays a border. [Deprecated] in v5.0.0, removal target v7.0.0 - use `"highlight"` instead.
    */
   @property({ reflect: true }) selectionAppearance: Extract<
     "icon" | "highlight" | "border",
@@ -82,10 +82,10 @@ export class TileGroup extends LitElement implements SelectableGroupComponent {
   /**
    * Specifies the selection mode.
    *
-   * - `"multiple"` (allows any number of selected items).
-   * - `"single"` (allows only one selected item).
-   * - `"single-persist"` (allows only one selected item and prevents de-selection).
-   * - `"none"` (allows no selected items).
+   * - `"multiple"` allows any number of selected items.
+   * - `"single"` allows only one selected item.
+   * - `"single-persist"` allows only one selected item and prevents de-selection.
+   * - `"none"` allows no selected items.
    */
   @property({ reflect: true }) selectionMode: Extract<
     "multiple" | "none" | "single" | "single-persist",

--- a/packages/components/src/components/tile/tile.tsx
+++ b/packages/components/src/components/tile/tile.tsx
@@ -115,9 +115,9 @@ export class Tile extends LitElement implements SelectableComponent {
   /**
    * Specifies the selection appearance.
    *
-   * - `"icon"` (displays a checkmark or dot)
-   * - `"highlight"` (changes the background color)
-   * - `"border"` (displays a border). [Deprecated] The `"border"` value is deprecated in v5.0.0, removal target v6.0.0 - Use `"highlight"` instead
+   * - `"icon"` (displays a checkmark or dot).
+   * - `"highlight"` (changes the background color).
+   * - `"border"` (displays a border). [Deprecated] The `"border"` value is deprecated in v5.0.0, removal target v6.0.0 - Use `"highlight"` instead.
    *
    * This property is set by the parent tile-group.
    *
@@ -131,10 +131,10 @@ export class Tile extends LitElement implements SelectableComponent {
   /**
    * Specifies the selection mode.
    *
-   * - `"multiple"` (allows any number of selected items)
-   * - `"single"` (allows only one selected item)
-   * - `"single-persist"` (allows only one selected item and prevents de-selection)
-   * - `"none"` (allows no selected items)
+   * - `"multiple"` (allows any number of selected items).
+   * - `"single"` (allows only one selected item).
+   * - `"single-persist"` (allows only one selected item and prevents de-selection).
+   * - `"none"` (allows no selected items).
    *
    * This property is set by the parent tile-group.
    *

--- a/packages/components/src/components/tile/tile.tsx
+++ b/packages/components/src/components/tile/tile.tsx
@@ -115,9 +115,9 @@ export class Tile extends LitElement implements SelectableComponent {
   /**
    * Specifies the selection appearance.
    *
-   * - `"icon"` (displays a checkmark or dot).
-   * - `"highlight"` (changes the background color).
-   * - `"border"` (displays a border). [Deprecated] The `"border"` value is deprecated in v5.0.0, removal target v6.0.0 - Use `"highlight"` instead.
+   * - `"icon"` displays a checkmark or dot.
+   * - `"highlight"` changes the background color.
+   * - `"border"` displays a border. [Deprecated] in v5.0.0, removal target v7.0.0 - use `"highlight"` instead.
    *
    * This property is set by the parent tile-group.
    *
@@ -131,10 +131,10 @@ export class Tile extends LitElement implements SelectableComponent {
   /**
    * Specifies the selection mode.
    *
-   * - `"multiple"` (allows any number of selected items).
-   * - `"single"` (allows only one selected item).
-   * - `"single-persist"` (allows only one selected item and prevents de-selection).
-   * - `"none"` (allows no selected items).
+   * - `"multiple"` allows any number of selected items.
+   * - `"single"` allows only one selected item.
+   * - `"single-persist"` allows only one selected item and prevents de-selection.
+   * - `"none"` allows no selected items.
    *
    * This property is set by the parent tile-group.
    *

--- a/packages/components/src/components/tile/tile.tsx
+++ b/packages/components/src/components/tile/tile.tsx
@@ -115,9 +115,9 @@ export class Tile extends LitElement implements SelectableComponent {
   /**
    * Specifies the selection appearance, where:
    *
-   * - `"icon"` (displays a checkmark or dot),
-   * - `"highlight"` (changes the background color), or
-   * - `"border"` (displays a border). [Deprecated] The `"border"` value is deprecated in v5.0.0, removal target v6.0.0 - Use `"highlight"` instead.
+   * - `"icon"` (displays a checkmark or dot)
+   * - `"highlight"` (changes the background color)
+   * - `"border"` (displays a border). [Deprecated] The `"border"` value is deprecated in v5.0.0, removal target v6.0.0 - Use `"highlight"` instead
    *
    * This property is set by the parent tile-group.
    *
@@ -131,10 +131,10 @@ export class Tile extends LitElement implements SelectableComponent {
   /**
    * Specifies the selection mode, where:
    *
-   * - `"multiple"` (allows any number of selected items),
-   * - `"single"` (allows only one selected item),
-   * - `"single-persist"` (allows only one selected item and prevents de-selection),
-   * - `"none"` (allows no selected items).
+   * - `"multiple"` (allows any number of selected items)
+   * - `"single"` (allows only one selected item)
+   * - `"single-persist"` (allows only one selected item and prevents de-selection)
+   * - `"none"` (allows no selected items)
    *
    * This property is set by the parent tile-group.
    *

--- a/packages/components/src/components/tile/tile.tsx
+++ b/packages/components/src/components/tile/tile.tsx
@@ -117,7 +117,7 @@ export class Tile extends LitElement implements SelectableComponent {
    *
    * - `"icon"` displays a checkmark or dot.
    * - `"highlight"` changes the background color.
-   * - `"border"` displays a border. [Deprecated] in v5.0.0, removal target v7.0.0 - use `"highlight"` instead.
+   * - `"border"` displays a border. [Deprecated] in v5.0.0, removal target v6.0.0 - use `"highlight"` instead.
    *
    * This property is set by the parent tile-group.
    *

--- a/packages/components/src/components/tile/tile.tsx
+++ b/packages/components/src/components/tile/tile.tsx
@@ -113,7 +113,7 @@ export class Tile extends LitElement implements SelectableComponent {
   @property({ reflect: true }) selected = false;
 
   /**
-   * Specifies the selection appearance, where:
+   * Specifies the selection appearance.
    *
    * - `"icon"` (displays a checkmark or dot)
    * - `"highlight"` (changes the background color)
@@ -129,7 +129,7 @@ export class Tile extends LitElement implements SelectableComponent {
   > = "icon";
 
   /**
-   * Specifies the selection mode, where:
+   * Specifies the selection mode.
    *
    * - `"multiple"` (allows any number of selected items)
    * - `"single"` (allows only one selected item)

--- a/packages/components/src/components/time-picker/time-picker.tsx
+++ b/packages/components/src/components/time-picker/time-picker.tsx
@@ -80,9 +80,9 @@ export class TimePicker extends LitElement implements TimeComponent {
   /**
    * Specifies the component's hour format.
    *
-   * - `"user"` displays the user's locale format
-   * - `"12"` displays a 12-hour format
-   * - `"24"` displays a 24-hour format
+   * - `"user"` displays the user's locale format.
+   * - `"12"` displays a 12-hour format.
+   * - `"24"` displays a 24-hour format.
    */
   @property({ reflect: true }) hourFormat: HourFormat = "user";
 

--- a/packages/components/src/components/time-picker/time-picker.tsx
+++ b/packages/components/src/components/time-picker/time-picker.tsx
@@ -80,9 +80,9 @@ export class TimePicker extends LitElement implements TimeComponent {
   /**
    * Specifies the component's hour format, where:
    *
-   * `"user"` displays the user's locale format,
-   * `"12"` displays a 12-hour format, and
-   * `"24"` displays a 24-hour format.
+   * - `"user"` displays the user's locale format
+   * - `"12"` displays a 12-hour format
+   * - `"24"` displays a 24-hour format
    */
   @property({ reflect: true }) hourFormat: HourFormat = "user";
 

--- a/packages/components/src/components/time-picker/time-picker.tsx
+++ b/packages/components/src/components/time-picker/time-picker.tsx
@@ -78,7 +78,7 @@ export class TimePicker extends LitElement implements TimeComponent {
   @property() time: ReturnType<typeof useTime> = useTime(this);
 
   /**
-   * Specifies the component's hour format, where:
+   * Specifies the component's hour format.
    *
    * - `"user"` displays the user's locale format
    * - `"12"` displays a 12-hour format

--- a/packages/components/src/components/tree/tree.tsx
+++ b/packages/components/src/components/tree/tree.tsx
@@ -58,7 +58,7 @@ export class Tree extends LitElement {
   @property() selectedItems: TreeItem["el"][] = [];
 
   /**
-   * Specifies the selection mode of the component, where:
+   * Specifies the selection mode of the component.
    *
    * - `"ancestors"` displays with a checkbox and allows any number of selections from corresponding parent and child selections
    * - `"children"` allows any number of selections from one parent from corresponding parent and child selections

--- a/packages/components/src/components/tree/tree.tsx
+++ b/packages/components/src/components/tree/tree.tsx
@@ -60,19 +60,13 @@ export class Tree extends LitElement {
   /**
    * Specifies the selection mode of the component, where:
    *
-   * `"ancestors"` displays with a checkbox and allows any number of selections from corresponding parent and child selections,
-   *
-   * `"children"` allows any number of selections from one parent from corresponding parent and child selections,
-   *
-   * `"multichildren"` allows any number of selections from corresponding parent and child selections,
-   *
-   * `"multiple"` allows any number of selections,
-   *
-   * `"none"` allows no selections,
-   *
-   * `"single"` allows one selection, and
-   *
-   * `"single-persist"` allows and requires one selection.
+   * - `"ancestors"` displays with a checkbox and allows any number of selections from corresponding parent and child selections
+   * - `"children"` allows any number of selections from one parent from corresponding parent and child selections
+   * - `"multichildren"` allows any number of selections from corresponding parent and child selections
+   * - `"multiple"` allows any number of selections
+   * - `"none"` allows no selections
+   * - `"single"` allows one selection
+   * - `"single-persist"` allows and requires one selection
    */
   @property({ reflect: true }) selectionMode: SelectionMode = "single";
 

--- a/packages/components/src/components/tree/tree.tsx
+++ b/packages/components/src/components/tree/tree.tsx
@@ -60,13 +60,13 @@ export class Tree extends LitElement {
   /**
    * Specifies the selection mode of the component.
    *
-   * - `"ancestors"` displays with a checkbox and allows any number of selections from corresponding parent and child selections
-   * - `"children"` allows any number of selections from one parent from corresponding parent and child selections
-   * - `"multichildren"` allows any number of selections from corresponding parent and child selections
-   * - `"multiple"` allows any number of selections
-   * - `"none"` allows no selections
-   * - `"single"` allows one selection
-   * - `"single-persist"` allows and requires one selection
+   * - `"ancestors"` displays with a checkbox and allows any number of selections from corresponding parent and child selections.
+   * - `"children"` allows any number of selections from one parent from corresponding parent and child selections.
+   * - `"multichildren"` allows any number of selections from corresponding parent and child selections.
+   * - `"multiple"` allows any number of selections.
+   * - `"none"` allows no selections.
+   * - `"single"` allows one selection.
+   * - `"single-persist"` allows and requires one selection.
    */
   @property({ reflect: true }) selectionMode: SelectionMode = "single";
 

--- a/packages/components/src/controllers/useTime.ts
+++ b/packages/components/src/controllers/useTime.ts
@@ -31,9 +31,9 @@ export interface TimeComponent extends LitElement {
   /**
    * Specifies the component's hour format, where:
    *
-   * `"user"` displays the user's locale format,
-   * `"12"` displays a 12-hour format, and
-   * `"24"` displays a 24-hour format.
+   * - `"user"` displays the user's locale format
+   * - `"12"` displays a 12-hour format
+   * - `"24"` displays a 24-hour format
    */
   hourFormat: HourFormat;
   /**

--- a/packages/components/src/controllers/useTime.ts
+++ b/packages/components/src/controllers/useTime.ts
@@ -29,7 +29,7 @@ import { numberKeys } from "../utils/key";
 
 export interface TimeComponent extends LitElement {
   /**
-   * Specifies the component's hour format, where:
+   * Specifies the component's hour format.
    *
    * - `"user"` displays the user's locale format
    * - `"12"` displays a 12-hour format

--- a/packages/components/src/controllers/useTime.ts
+++ b/packages/components/src/controllers/useTime.ts
@@ -31,9 +31,9 @@ export interface TimeComponent extends LitElement {
   /**
    * Specifies the component's hour format.
    *
-   * - `"user"` displays the user's locale format
-   * - `"12"` displays a 12-hour format
-   * - `"24"` displays a 24-hour format
+   * - `"user"` displays the user's locale format.
+   * - `"12"` displays a 12-hour format.
+   * - `"24"` displays a 24-hour format.
    */
   hourFormat: HourFormat;
   /**


### PR DESCRIPTION
**Related Issue:** #14350

## Summary

With support for full markdown rendering coming shortly on the Documentation site (PR open), this PR updates our `where:` API descriptions to use markdown lists and newlines for better readability.

Adjusted the formatting to have no puncutation at the end of lines, and removed the trailing `, and` from the second to last item. Would appreciate feedback on this. cc @Esri/calcite-pes

Quick references of what it would look like:
<img width="629" height="262" alt="CleanShot 2026-07-21 at 15 28 32" src="https://github.com/user-attachments/assets/3c644219-68ed-4801-846e-1917355e21d8" />
<img width="683" height="371" alt="CleanShot 2026-07-21 at 15 29 14" src="https://github.com/user-attachments/assets/91efe628-8630-4a28-9d71-90f413520c7a" />
