### PR TITLE
docs(messageOverrides): sync description with Maps SDK

### DIFF
--- a/packages/components/api-extractor.config.ts
+++ b/packages/components/api-extractor.config.ts
@@ -91,7 +91,7 @@ export const config: ApiExtractorConfig = {
             "Specifies the component's fallback `menuPlacement` when its initial or specified `menuPlacement` has insufficient space available.",
         },
         messageOverrides: {
-          description: "Overrides individual strings used by the component.",
+          description: `Replace localized message strings with your own strings.\n\n_**Note**: Individual message keys may change between releases._`,
         },
         name: {
           description:


### PR DESCRIPTION
**Related Issue:** #10439

## Summary

Updates the `messageOverrides` copyDoc description to align with the Maps SDK and communicate that messages strings may change between releaes without being considered breaking.
