### PR TITLE
test(storybook): add missing component Storybook controls

### DIFF
--- a/packages/components/src/components/autocomplete/autocomplete.stories.ts
+++ b/packages/components/src/components/autocomplete/autocomplete.stories.ts
@@ -14,6 +14,7 @@ type AutocompleteStoryArgs = Pick<
   | "inputValue"
   | "iconFlipRtl"
   | "label"
+  | "labelText"
   | "loading"
   | "maxLength"
   | "minLength"
@@ -40,6 +41,7 @@ export default {
     icon: "",
     iconFlipRtl: false,
     inputValue: "",
+    labelText: "Label text",
     loading: false,
     maxLength: undefined,
     minLength: undefined,
@@ -114,6 +116,7 @@ export const simple = (args: AutocompleteStoryArgs): string => html`
         ${optionalAttribute("icon", args.icon)}
         input-value="${args.inputValue}"
         label="${args.label}"
+        ${optionalAttribute("label-text", args.labelText)}
         ${optionalAttribute("max-length", args.maxLength)}
         ${optionalAttribute("min-length", args.minLength)}
         overlay-positioning="${args.overlayPositioning}"

--- a/packages/components/src/components/button/button.stories.ts
+++ b/packages/components/src/components/button/button.stories.ts
@@ -26,7 +26,7 @@ interface ButtonStoryArgs extends Pick<
 export default {
   title: "Components/Buttons/Button",
   args: {
-    alignment: alignment.defaultValue,
+    alignment: "center",
     appearance: appearance.defaultValue,
     kind: kind.defaultValue,
     scale: scale.defaultValue,

--- a/packages/components/src/components/button/button.stories.ts
+++ b/packages/components/src/components/button/button.stories.ts
@@ -4,11 +4,21 @@ import { html } from "../../../support/formatting";
 import { ATTRIBUTES } from "../../../.storybook/resources";
 import { Button } from "./button";
 
-const { appearance, kind, scale, width } = ATTRIBUTES;
+const { alignment, appearance, kind, scale, width } = ATTRIBUTES;
 
 interface ButtonStoryArgs extends Pick<
   Button,
-  "appearance" | "disabled" | "href" | "iconEnd" | "iconStart" | "kind" | "loading" | "round" | "scale" | "width"
+  | "alignment"
+  | "appearance"
+  | "disabled"
+  | "href"
+  | "iconEnd"
+  | "iconStart"
+  | "kind"
+  | "loading"
+  | "round"
+  | "scale"
+  | "width"
 > {
   text: string;
 }
@@ -16,6 +26,7 @@ interface ButtonStoryArgs extends Pick<
 export default {
   title: "Components/Buttons/Button",
   args: {
+    alignment: alignment.defaultValue,
     appearance: appearance.defaultValue,
     kind: kind.defaultValue,
     scale: scale.defaultValue,
@@ -29,6 +40,10 @@ export default {
     text: "button text here",
   },
   argTypes: {
+    alignment: {
+      options: alignment.values,
+      control: { type: "select" },
+    },
     appearance: {
       options: appearance.values,
       control: { type: "select" },
@@ -58,6 +73,7 @@ export default {
 
 export const simple = (args: ButtonStoryArgs): string => html`
   <calcite-button
+    alignment="${args.alignment}"
     appearance="${args.appearance}"
     kind="${args.kind}"
     scale="${args.scale}"

--- a/packages/components/src/components/card/card.stories.ts
+++ b/packages/components/src/components/card/card.stories.ts
@@ -6,11 +6,12 @@ import { Card } from "./card";
 
 const { scale, logicalFlowPosition } = ATTRIBUTES;
 
-type CardStoryArgs = Pick<Card, "loading" | "scale" | "selectable" | "selected" | "thumbnailPosition">;
+type CardStoryArgs = Pick<Card, "disabled" | "loading" | "scale" | "selectable" | "selected" | "thumbnailPosition">;
 
 export default {
   title: "Components/Card",
   args: {
+    disabled: false,
     loading: false,
     scale: scale.defaultValue,
     selectable: false,
@@ -67,6 +68,7 @@ const footerEndButtonsHtml = html`
 export const simple = (args: CardStoryArgs): string => html`
   <div style="width: 260px">
     <calcite-card
+      ${boolean("disabled", args.disabled)}
       ${boolean("loading", args.loading)}
       scale="${args.scale}"
       ${boolean("selectable", args.selectable)}
@@ -81,6 +83,7 @@ export const simple = (args: CardStoryArgs): string => html`
 export const simpleWithFooterLinks = (args: CardStoryArgs): string => html`
   <div style="width:260px">
     <calcite-card
+      ${boolean("disabled", args.disabled)}
       ${boolean("loading", args.loading)}
       scale="${args.scale}"
       ${boolean("selected", args.selected)}
@@ -94,6 +97,7 @@ export const simpleWithFooterLinks = (args: CardStoryArgs): string => html`
 export const simpleWithFooterButton = (args: CardStoryArgs): string => html`
   <div style="width:260px">
     <calcite-card
+      ${boolean("disabled", args.disabled)}
       ${boolean("loading", args.loading)}
       scale="${args.scale}"
       ${boolean("selected", args.selected)}

--- a/packages/components/src/components/checkbox/checkbox.stories.ts
+++ b/packages/components/src/components/checkbox/checkbox.stories.ts
@@ -7,7 +7,7 @@ const { scale, status } = ATTRIBUTES;
 
 type CheckboxStoryArgs = Pick<
   Checkbox,
-  "checked" | "disabled" | "indeterminate" | "labelText" | "required" | "scale" | "status"
+  "checked" | "disabled" | "indeterminate" | "label" | "labelText" | "required" | "scale" | "status"
 >;
 
 export default {
@@ -20,6 +20,7 @@ export default {
     required: false,
     scale: scale.defaultValue,
     status: status.defaultValue,
+    label: "Checkbox",
   },
   argTypes: {
     scale: {

--- a/packages/components/src/components/checkbox/checkbox.stories.ts
+++ b/packages/components/src/components/checkbox/checkbox.stories.ts
@@ -1,11 +1,14 @@
-import { boolean, modesDarkDefault } from "../../../.storybook/utils";
+import { boolean, modesDarkDefault, optionalAttribute } from "../../../.storybook/utils";
 import { html } from "../../../support/formatting";
 import { ATTRIBUTES } from "../../../.storybook/resources";
 import { Checkbox } from "./checkbox";
 
 const { scale, status } = ATTRIBUTES;
 
-type CheckboxStoryArgs = Pick<Checkbox, "checked" | "disabled" | "indeterminate" | "scale" | "status" | "label">;
+type CheckboxStoryArgs = Pick<
+  Checkbox,
+  "checked" | "disabled" | "indeterminate" | "labelText" | "required" | "scale" | "status" | "label"
+>;
 
 export default {
   title: "Components/Controls/Checkbox",
@@ -13,6 +16,8 @@ export default {
     checked: true,
     disabled: false,
     indeterminate: false,
+    labelText: "Checkbox label text",
+    required: false,
     scale: scale.defaultValue,
     status: status.defaultValue,
     label: "Checkbox",
@@ -35,6 +40,8 @@ export const simple = (args: CheckboxStoryArgs): string => html`
       ${boolean("checked", args.checked)}
       ${boolean("disabled", args.disabled)}
       ${boolean("indeterminate", args.indeterminate)}
+      ${optionalAttribute("label-text", args.labelText)}
+      ${boolean("required", args.required)}
       scale="${args.scale}"
       status="${args.status}"
     ></calcite-checkbox>

--- a/packages/components/src/components/checkbox/checkbox.stories.ts
+++ b/packages/components/src/components/checkbox/checkbox.stories.ts
@@ -16,7 +16,7 @@ export default {
     checked: true,
     disabled: false,
     indeterminate: false,
-    labelText: "Checkbox label text",
+    labelText: "Label text",
     required: false,
     scale: scale.defaultValue,
     status: status.defaultValue,

--- a/packages/components/src/components/checkbox/checkbox.stories.ts
+++ b/packages/components/src/components/checkbox/checkbox.stories.ts
@@ -7,7 +7,7 @@ const { scale, status } = ATTRIBUTES;
 
 type CheckboxStoryArgs = Pick<
   Checkbox,
-  "checked" | "disabled" | "indeterminate" | "labelText" | "required" | "scale" | "status" | "label"
+  "checked" | "disabled" | "indeterminate" | "labelText" | "required" | "scale" | "status"
 >;
 
 export default {
@@ -20,7 +20,6 @@ export default {
     required: false,
     scale: scale.defaultValue,
     status: status.defaultValue,
-    label: "Checkbox",
   },
   argTypes: {
     scale: {
@@ -35,18 +34,15 @@ export default {
 };
 
 export const simple = (args: CheckboxStoryArgs): string => html`
-  <calcite-label layout="inline">
-    <calcite-checkbox
-      ${boolean("checked", args.checked)}
-      ${boolean("disabled", args.disabled)}
-      ${boolean("indeterminate", args.indeterminate)}
-      ${optionalAttribute("label-text", args.labelText)}
-      ${boolean("required", args.required)}
-      scale="${args.scale}"
-      status="${args.status}"
-    ></calcite-checkbox>
-    ${args.label}
-  </calcite-label>
+  <calcite-checkbox
+    ${boolean("checked", args.checked)}
+    ${boolean("disabled", args.disabled)}
+    ${boolean("indeterminate", args.indeterminate)}
+    ${optionalAttribute("label-text", args.labelText)}
+    ${boolean("required", args.required)}
+    scale="${args.scale}"
+    status="${args.status}"
+  ></calcite-checkbox>
 `;
 
 export const disabled = (): string => html`<calcite-checkbox checked disabled></calcite-checkbox>`;

--- a/packages/components/src/components/chip/chip.stories.ts
+++ b/packages/components/src/components/chip/chip.stories.ts
@@ -7,7 +7,10 @@ import { Chip } from "./chip";
 
 const { scale, appearance, kind } = ATTRIBUTES;
 
-type ChipStoryArgs = Pick<Chip, "appearance" | "closable" | "icon" | "kind" | "label" | "scale" | "selected">;
+type ChipStoryArgs = Pick<
+  Chip,
+  "appearance" | "closable" | "disabled" | "icon" | "kind" | "label" | "scale" | "selected"
+>;
 
 export default {
   title: "Components/Chip",
@@ -17,6 +20,7 @@ export default {
     icon: "",
     kind: kind.values[4],
     closable: false,
+    disabled: false,
     selected: false,
     label: "My great chip",
   },
@@ -54,6 +58,7 @@ export const simple = (args: ChipStoryArgs): string => html`
       ${optionalAttribute("icon", args.icon)}
       label="${args.label}"
       ${boolean("closable", args.closable)}
+      ${boolean("disabled", args.disabled)}
       ${boolean("selected", args.selected)}
       >My great chip</calcite-chip
     >

--- a/packages/components/src/components/combobox/combobox.stories.ts
+++ b/packages/components/src/components/combobox/combobox.stories.ts
@@ -1,7 +1,32 @@
-import { modesDarkDefault } from "../../../.storybook/utils";
+import { iconNames } from "../../../.storybook/helpers";
+import { ATTRIBUTES } from "../../../.storybook/resources";
+import { boolean, modesDarkDefault, optionalAttribute } from "../../../.storybook/utils";
 import { html } from "../../../support/formatting";
 import type { Scale } from "../interfaces";
 import type { Combobox } from "./combobox";
+
+const { menuPlacement, overlayPositioning, scale, selectionMode, status } = ATTRIBUTES;
+
+type ComboboxStoryArgs = Pick<
+  Combobox,
+  | "clearDisabled"
+  | "disabled"
+  | "label"
+  | "labelText"
+  | "maxItems"
+  | "open"
+  | "overlayPositioning"
+  | "placeholder"
+  | "placement"
+  | "readOnly"
+  | "required"
+  | "scale"
+  | "selectionDisplay"
+  | "selectionMode"
+  | "status"
+  | "validationIcon"
+  | "validationMessage"
+>;
 
 /**
  * This decorator takes HTML for items and will create a composite story for all scales for each specified selection mode.
@@ -67,18 +92,79 @@ function allScaleComboboxBuilder(
 
 export default {
   title: "Components/Controls/Combobox",
+  args: {
+    clearDisabled: false,
+    disabled: false,
+    label: "demo",
+    labelText: "Label text",
+    maxItems: 0,
+    open: false,
+    overlayPositioning: overlayPositioning.defaultValue,
+    placeholder: "placeholder",
+    placement: menuPlacement.defaultValue,
+    readOnly: false,
+    required: false,
+    scale: scale.defaultValue,
+    selectionDisplay: "all",
+    selectionMode: "single",
+    status: status.defaultValue,
+    validationIcon: "",
+    validationMessage: "",
+  },
+  argTypes: {
+    overlayPositioning: {
+      options: overlayPositioning.values,
+      control: { type: "select" },
+    },
+    placement: {
+      options: menuPlacement.values,
+      control: { type: "select" },
+    },
+    scale: {
+      options: scale.values,
+      control: { type: "select" },
+    },
+    selectionDisplay: {
+      options: ["all", "fit", "single"],
+      control: { type: "select" },
+    },
+    selectionMode: {
+      options: selectionMode.values.filter(
+        (mode) => mode !== "children" && mode !== "multichildren" && mode !== "none",
+      ),
+      control: { type: "select" },
+    },
+    status: {
+      options: status.values,
+      control: { type: "select" },
+    },
+    validationIcon: {
+      options: iconNames,
+      control: { type: "select" },
+    },
+  },
 };
 
-export const single = (): string => html`
+export const simple = (args: ComboboxStoryArgs): string => html`
   <div style="width:400px;max-width:100%;background-color:white;padding:100px">
     <calcite-combobox
-      selection-display="all"
-      selection-mode="single"
-      label="demo"
-      max-items="0"
-      placeholder="placeholder"
-      scale="m"
-      status="idle"
+      ${boolean("clear-disabled", args.clearDisabled)}
+      ${boolean("disabled", args.disabled)}
+      label="${args.label}"
+      ${optionalAttribute("label-text", args.labelText)}
+      max-items="${args.maxItems}"
+      ${boolean("open", args.open)}
+      overlay-positioning="${args.overlayPositioning}"
+      placeholder="${args.placeholder}"
+      placement="${args.placement}"
+      ${boolean("read-only", args.readOnly)}
+      ${boolean("required", args.required)}
+      scale="${args.scale}"
+      selection-display="${args.selectionDisplay}"
+      selection-mode="${args.selectionMode}"
+      status="${args.status}"
+      ${optionalAttribute("validation-icon", args.validationIcon)}
+      validation-message="${args.validationMessage}"
     >
       <calcite-combobox-item icon="altitude" value="altitude" heading="Altitude" selected></calcite-combobox-item>
       <calcite-combobox-item icon="article" value="article" heading="Article"></calcite-combobox-item>

--- a/packages/components/src/components/input-date-picker/input-date-picker.stories.ts
+++ b/packages/components/src/components/input-date-picker/input-date-picker.stories.ts
@@ -12,6 +12,7 @@ interface InputDatePickerStoryArgs extends Pick<
   | "calendars"
   | "clearable"
   | "disabled"
+  | "labelText"
   | "layout"
   | "max"
   | "min"
@@ -20,6 +21,7 @@ interface InputDatePickerStoryArgs extends Pick<
   | "placement"
   | "range"
   | "readOnly"
+  | "required"
   | "scale"
   | "status"
   | "validationIcon"
@@ -34,6 +36,7 @@ export default {
   args: {
     calendars: calendarCount.defaultValue,
     disabled: false,
+    labelText: "Label text",
     layout: horizontalVerticalLayout.defaultValue,
     scale: scale.defaultValue,
     status: status.defaultValue,
@@ -47,6 +50,7 @@ export default {
     placement: menuPlacement.defaultValue,
     range: false,
     readOnly: false,
+    required: false,
     validationMessage: "",
     validationIcon: "",
   },
@@ -97,6 +101,7 @@ export const simple = (args: InputDatePickerStoryArgs): string => html`
       value="${args.value}"
       calendars="${args.calendars}"
       ${boolean("disabled", args.disabled)}
+      ${optionalAttribute("label-text", args.labelText)}
       lang="${args.lang}"
       layout="${args.layout}"
       min="${args.min}"
@@ -106,6 +111,7 @@ export const simple = (args: InputDatePickerStoryArgs): string => html`
       placement="${args.placement}"
       ${boolean("range", args.range)}
       ${boolean("read-only", args.readOnly)}
+      ${boolean("required", args.required)}
       validation-message="${args.validationMessage}"
       ${optionalAttribute("validation-icon", args.validationIcon)}
     ></calcite-input-date-picker>

--- a/packages/components/src/components/input-number/input-number.stories.ts
+++ b/packages/components/src/components/input-number/input-number.stories.ts
@@ -24,6 +24,7 @@ type InputNumberStoryArgs = Pick<
   | "icon"
   | "iconFlipRtl"
   | "integer"
+  | "labelText"
   | "readOnly"
   | "required"
   | "value"
@@ -53,6 +54,7 @@ export default {
     icon: "",
     iconFlipRtl: false,
     integer: false,
+    labelText: "Label text",
     readOnly: false,
     required: false,
     value: "",
@@ -117,6 +119,7 @@ export const simple = (args: InputNumberStoryArgs): string => html`
       ${optionalAttribute("icon", args.icon)}
       ${boolean("icon-flip-rtl", args.iconFlipRtl)}
       ${boolean("integer", args.integer)}
+      ${optionalAttribute("label-text", args.labelText)}
       ${boolean("read-only", args.readOnly)}
       ${boolean("required", args.required)}
       value="${args.value}"

--- a/packages/components/src/components/input-text/input-text.stories.ts
+++ b/packages/components/src/components/input-text/input-text.stories.ts
@@ -18,6 +18,7 @@ type InputTextStoryArgs = Pick<
   | "disabled"
   | "icon"
   | "iconFlipRtl"
+  | "labelText"
   | "maxLength"
   | "minLength"
   | "readOnly"
@@ -43,6 +44,7 @@ export default {
     disabled: false,
     icon: "",
     iconFlipRtl: false,
+    labelText: "Label text",
     maxLength: undefined,
     minLength: undefined,
     readOnly: false,
@@ -97,6 +99,7 @@ export const simple = (args: InputTextStoryArgs): string => html`
       ${boolean("disabled", args.disabled)}
       ${optionalAttribute("icon", args.icon)}
       ${boolean("icon-flip-rtl", args.iconFlipRtl)}
+      ${optionalAttribute("label-text", args.labelText)}
       ${optionalAttribute("max-length", args.maxLength)}
       ${optionalAttribute("min-length", args.minLength)}
       ${boolean("read-only", args.readOnly)}

--- a/packages/components/src/components/input-time-picker/input-time-picker.stories.ts
+++ b/packages/components/src/components/input-time-picker/input-time-picker.stories.ts
@@ -11,6 +11,7 @@ interface InputTimePickerStoryArgs extends Pick<
   | "clearable"
   | "disabled"
   | "hourFormat"
+  | "labelText"
   | "max"
   | "min"
   | "open"
@@ -35,6 +36,7 @@ export default {
     disabled: false,
     hidden: false,
     hourFormat: undefined,
+    labelText: "Label text",
     max: "",
     min: "",
     open: false,
@@ -78,6 +80,7 @@ export const simple = (args: InputTimePickerStoryArgs): string => html`
     ${boolean("disabled", args.disabled)}
     ${boolean("hidden", args.hidden)}
     hour-format="${args.hourFormat}"
+    ${optionalAttribute("label-text", args.labelText)}
     max="${args.max}"
     min="${args.min}"
     placeholder="${args.placeholder}"

--- a/packages/components/src/components/input-time-zone/input-time-zone.stories.ts
+++ b/packages/components/src/components/input-time-zone/input-time-zone.stories.ts
@@ -10,6 +10,7 @@ type InputTimeZoneStoryArgs = Pick<
   InputTimeZone,
   | "clearable"
   | "disabled"
+  | "labelText"
   | "mode"
   | "offsetStyle"
   | "open"
@@ -28,6 +29,7 @@ export default {
   args: {
     clearable: false,
     disabled: false,
+    labelText: "Label text",
     mode: mode.defaultValue,
     offsetStyle: "user",
     open: false,
@@ -75,6 +77,7 @@ export const simple = (args: InputTimeZoneStoryArgs): string => html`
   <calcite-input-time-zone
     ${boolean("clearable", args.clearable)}
     ${boolean("disabled", args.disabled)}
+    ${optionalAttribute("label-text", args.labelText)}
     mode="${args.mode}"
     offset-style="${args.offsetStyle}"
     ${boolean("open", args.open)}

--- a/packages/components/src/components/input/input.stories.ts
+++ b/packages/components/src/components/input/input.stories.ts
@@ -21,6 +21,7 @@ type InputStoryArgs = Pick<
   | "disabled"
   | "icon"
   | "iconFlipRtl"
+  | "labelText"
   | "value"
   | "readOnly"
   | "required"
@@ -49,6 +50,7 @@ export default {
     disabled: false,
     icon: "",
     iconFlipRtl: false,
+    labelText: "Label text",
     value: "",
     readOnly: false,
     required: false,
@@ -117,6 +119,7 @@ export const simple = (args: InputStoryArgs): string => html`
       ${boolean("disabled", args.disabled)}
       ${optionalAttribute("icon", args.icon)}
       ${boolean("icon-flip-rtl", args.iconFlipRtl)}
+      ${optionalAttribute("label-text", args.labelText)}
       value="${args.value}"
       ${boolean("read-only", args.readOnly)}
       ${boolean("required", args.required)}

--- a/packages/components/src/components/radio-button-group/radio-button-group.stories.ts
+++ b/packages/components/src/components/radio-button-group/radio-button-group.stories.ts
@@ -8,7 +8,7 @@ const { layout, scale, status } = ATTRIBUTES;
 
 interface RadioButtonGroupStoryArgs extends Pick<
   RadioButtonGroup,
-  "disabled" | "layout" | "scale" | "status" | "validationIcon" | "validationMessage"
+  "disabled" | "labelText" | "layout" | "required" | "scale" | "status" | "validationIcon" | "validationMessage"
 > {
   hidden: boolean;
 }
@@ -18,7 +18,9 @@ export default {
   args: {
     disabled: false,
     hidden: false,
+    labelText: "Label text",
     layout: layout.defaultValue,
+    required: false,
     scale: scale.defaultValue,
     status: status.defaultValue,
     validationIcon: "",
@@ -58,7 +60,9 @@ export const simple = (args: RadioButtonGroupStoryArgs): string => html`
     name="simple"
     ${boolean("disabled", args.disabled)}
     ${boolean("hidden", args.hidden)}
+    ${optionalAttribute("label-text", args.labelText)}
     layout="${args.layout}"
+    ${boolean("required", args.required)}
     scale="${args.scale}"
     status="${args.status}"
     ${optionalAttribute("validation-icon", args.validationIcon)}

--- a/packages/components/src/components/radio-button/radio-button.stories.ts
+++ b/packages/components/src/components/radio-button/radio-button.stories.ts
@@ -1,4 +1,4 @@
-import { boolean, modesDarkDefault } from "../../../.storybook/utils";
+import { boolean, modesDarkDefault, optionalAttribute } from "../../../.storybook/utils";
 import { html } from "../../../support/formatting";
 import { ATTRIBUTES } from "../../../.storybook/resources";
 import { RadioButton } from "./radio-button";
@@ -7,7 +7,7 @@ const { scale, status } = ATTRIBUTES;
 
 interface RadioButtonStoryArgs extends Pick<
   RadioButton,
-  "checked" | "disabled" | "focused" | "label" | "scale" | "status" | "validationMessage"
+  "checked" | "disabled" | "focused" | "label" | "labelText" | "required" | "scale" | "status" | "validationMessage"
 > {
   hidden: boolean;
 }
@@ -19,6 +19,8 @@ export default {
     disabled: false,
     hidden: false,
     focused: false,
+    labelText: "Label text",
+    required: false,
     scale: scale.defaultValue,
     label: "Radio Button",
     status: status.defaultValue,
@@ -37,20 +39,19 @@ export default {
 };
 
 export const simple = (args: RadioButtonStoryArgs): string => html`
-  <calcite-label layout="inline">
-    <calcite-radio-button
-      ${boolean("checked", args.checked)}
-      ${boolean("disabled", args.disabled)}
-      ${boolean("hidden", args.hidden)}
-      ${boolean("focused", args.focused)}
-      name="simple"
-      scale="${args.scale}"
-      status="${args.status}"
-      validation-message="${args.validationMessage}"
-      value="value"
-    ></calcite-radio-button>
-    ${args.label}
-  </calcite-label>
+  <calcite-radio-button
+    ${boolean("checked", args.checked)}
+    ${boolean("disabled", args.disabled)}
+    ${boolean("hidden", args.hidden)}
+    ${boolean("focused", args.focused)}
+    ${optionalAttribute("label-text", args.labelText)}
+    name="simple"
+    ${boolean("required", args.required)}
+    scale="${args.scale}"
+    status="${args.status}"
+    validation-message="${args.validationMessage}"
+    value="value"
+  ></calcite-radio-button>
 `;
 
 export const darkModeRTL = (): string => html`

--- a/packages/components/src/components/rating/rating.stories.ts
+++ b/packages/components/src/components/rating/rating.stories.ts
@@ -13,7 +13,9 @@ type RatingStoryArgs = Pick<
   | "showChip"
   | "average"
   | "count"
+  | "labelText"
   | "readOnly"
+  | "required"
   | "disabled"
   | "status"
   | "validationIcon"
@@ -28,7 +30,9 @@ export default {
     showChip: true,
     average: 4.4,
     count: 10,
+    labelText: "Label text",
     readOnly: false,
+    required: false,
     disabled: false,
     status: status.defaultValue,
     validationMessage: "",
@@ -57,7 +61,9 @@ export const simple = (args: RatingStoryArgs): string => html`
     ${boolean("show-chip", args.showChip)}
     average="${args.average}"
     count="${args.count}"
+    ${optionalAttribute("label-text", args.labelText)}
     ${boolean("read-only", args.readOnly)}
+    ${boolean("required", args.required)}
     ${boolean("disabled", args.disabled)}
     status="${args.status}"
     validation-message="${args.validationMessage}"

--- a/packages/components/src/components/segmented-control/segmented-control.stories.ts
+++ b/packages/components/src/components/segmented-control/segmented-control.stories.ts
@@ -8,7 +8,16 @@ const { layout, appearance, scale, width, status } = ATTRIBUTES;
 
 type SegmentedControlStoryArgs = Pick<
   SegmentedControl,
-  "layout" | "appearance" | "scale" | "width" | "disabled" | "status" | "validationIcon" | "validationMessage"
+  | "layout"
+  | "appearance"
+  | "scale"
+  | "width"
+  | "disabled"
+  | "labelText"
+  | "required"
+  | "status"
+  | "validationIcon"
+  | "validationMessage"
 >;
 
 export default {
@@ -19,6 +28,8 @@ export default {
     scale: scale.defaultValue,
     width: width.defaultValue,
     disabled: false,
+    labelText: "Label text",
+    required: false,
     status: status.defaultValue,
     validationIcon: "",
     validationMessage: "",
@@ -67,6 +78,8 @@ export const simple = (args: SegmentedControlStoryArgs): string => html`
     scale="${args.scale}"
     width="${args.width}"
     ${boolean("disabled", args.disabled)}
+    ${optionalAttribute("label-text", args.labelText)}
+    ${boolean("required", args.required)}
     status="${args.status}"
     ${optionalAttribute("validation-icon", args.validationIcon)}
     validation-message="${args.validationMessage}"

--- a/packages/components/src/components/select/select.stories.ts
+++ b/packages/components/src/components/select/select.stories.ts
@@ -9,7 +9,10 @@ const { status, width, scale } = ATTRIBUTES;
 
 interface SelectStoryArgs
   extends
-    Pick<Select, "disabled" | "status" | "width" | "scale" | "validationIcon" | "validationMessage">,
+    Pick<
+      Select,
+      "disabled" | "labelText" | "required" | "status" | "width" | "scale" | "validationIcon" | "validationMessage"
+    >,
     Pick<Option, "label" | "selected" | "value"> {
   optionDisabled: Option["disabled"];
 }
@@ -23,6 +26,8 @@ export default {
     scale: scale.defaultValue,
     validationMessage: "",
     validationIcon: "",
+    labelText: "Label text",
+    required: false,
     optionDisabled: false,
     label: "fancy label",
     selected: false,
@@ -55,6 +60,8 @@ export const simple = (args: SelectStoryArgs): string => html`
       status="${args.status}"
       width="${args.width}"
       scale="${args.scale}"
+      ${optionalAttribute("label-text", args.labelText)}
+      ${boolean("required", args.required)}
       validation-message="${args.validationMessage}"
       ${optionalAttribute("validation-icon", args.validationIcon)}
     >

--- a/packages/components/src/components/slider/slider.stories.ts
+++ b/packages/components/src/components/slider/slider.stories.ts
@@ -16,11 +16,13 @@ interface SliderStoryArgs extends Pick<
   | "fillPlacement"
   | "minLabel"
   | "disabled"
+  | "labelText"
   | "labelHandles"
   | "labelTicks"
   | "ticks"
   | "pageStep"
   | "precise"
+  | "required"
   | "mirrored"
   | "snap"
   | "scale"
@@ -42,11 +44,13 @@ export default {
     fillPlacement: "all",
     minLabel: "Temperature",
     disabled: false,
+    labelText: "Label text",
     labelHandles: false,
     labelTicks: false,
     ticks: 0,
     pageStep: 5,
     precise: false,
+    required: false,
     mirrored: false,
     snap: true,
     scale: scale.defaultValue,
@@ -91,11 +95,13 @@ export const simple = (args: SliderStoryArgs): string => html`
     fill-placement="${args.fillPlacement}"
     min-label="${args.minLabel}"
     ${boolean("disabled", args.disabled)}
+    ${optionalAttribute("label-text", args.labelText)}
     ${boolean("label-handles", args.labelHandles)}
     ${boolean("label-ticks", args.labelTicks)}
     ticks="${args.ticks}"
     page-step="${args.pageStep}"
     ${boolean("precise", args.precise)}
+    ${boolean("required", args.required)}
     ${boolean("mirrored", args.mirrored)}
     ${boolean("snap", args.snap)}
     scale="${args.scale}"

--- a/packages/components/src/components/text-area/text-area.stories.ts
+++ b/packages/components/src/components/text-area/text-area.stories.ts
@@ -16,6 +16,7 @@ type TextAreaStoryArgs = Pick<
   | "resize"
   | "rows"
   | "label"
+  | "labelText"
   | "limitText"
   | "loading"
   | "maxLength"
@@ -39,6 +40,7 @@ export default {
     resize: "both",
     rows: 2,
     label: "",
+    labelText: "Label text",
     limitText: false,
     loading: false,
     maxLength: undefined,
@@ -89,6 +91,7 @@ export const simple = (args: TextAreaStoryArgs): string => html`
     resize="${args.resize}"
     rows="${args.rows}"
     label="${args.label}"
+    ${optionalAttribute("label-text", args.labelText)}
     ${optionalAttribute("max-length", args.maxLength)}
     ${optionalAttribute("min-length", args.minLength)}
     limit-text="${args.limitText}"


### PR DESCRIPTION
**Related Issue:** #9539

## Summary
Follow up to PR #14614 to add additional visual properties that were missing: `required`, `label-text`,`disabled`, and Button's `alignment`.