### PR TITLE
fix(action-bar): hide leading group border for action-start slot when wrapping

### DIFF
--- a/packages/components/src/components/action-bar/action-bar.scss
+++ b/packages/components/src/components/action-bar/action-bar.scss
@@ -157,6 +157,16 @@
       var(--calcite-internal-action-bar-padding) + var(--calcite-internal-action-bar-gap)
     );
   }
+
+  // Groups slotted into actions-start render inside the start wrapper, which supplies the leading
+  // gutter and clipped leading divider. Clear the base trailing padding and divider to match
+  // the default-slot appearance in both layouts.
+  ::slotted(calcite-action-group[slot="actions-start"]) {
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+  }
 }
 
 :host([overflow-mode="wrap"][layout="horizontal"]) {
@@ -167,7 +177,7 @@
   // Draw the divider on each group's leading edge so a wrapped row never ends with a dangling
   // divider. Only matches when groups are slotted; the first-in-row divider is clipped by the
   // `has-action-groups` rule below.
-  ::slotted(calcite-action-group) {
+  ::slotted(calcite-action-group:not([slot="actions-start"])) {
     margin-inline-start: calc(-1 * var(--calcite-border-width-sm));
     padding-inline: var(--calcite-internal-action-bar-padding) 0;
     border-inline-start-width: var(--calcite-border-width-sm);
@@ -222,7 +232,7 @@
     column-gap: var(--calcite-internal-action-bar-line-gap);
   }
 
-  ::slotted(calcite-action-group) {
+  ::slotted(calcite-action-group:not([slot="actions-start"])) {
     margin-block-start: calc(-1 * var(--calcite-border-width-sm));
     padding-block: var(--calcite-internal-action-bar-padding) 0;
     border-block-start-width: var(--calcite-border-width-sm);

--- a/packages/components/src/components/action-bar/action-bar.scss
+++ b/packages/components/src/components/action-bar/action-bar.scss
@@ -158,9 +158,6 @@
     );
   }
 
-  // Groups slotted into actions-start render inside the start wrapper, which supplies the leading
-  // gutter and clipped leading divider. Clear the base trailing padding and divider to match
-  // the default-slot appearance in both layouts.
   ::slotted(calcite-action-group[slot="actions-start"]) {
     padding-inline-end: 0;
     padding-block-end: 0;

--- a/packages/components/src/components/action-bar/action-bar.stories.ts
+++ b/packages/components/src/components/action-bar/action-bar.stories.ts
@@ -457,6 +457,50 @@ export const verticalWrap = (): string =>
     </calcite-action-group>
   </calcite-action-bar>`;
 
+export const wrapWithActionsStartGroups = (): string =>
+  html`<div style="display: flex; gap: 1rem;">
+    <div style="width: 360px;">
+      <calcite-action-bar layout="horizontal" overflow-mode="wrap">
+        <calcite-action-group slot="actions-start">
+          <calcite-action text="Home" icon="home"></calcite-action>
+          <calcite-action text="Locate" icon="compass"></calcite-action>
+        </calcite-action-group>
+        <calcite-action-group>
+          <calcite-action text="Add" icon="plus"></calcite-action>
+          <calcite-action text="Save" icon="save"></calcite-action>
+          <calcite-action text="Layers" icon="layers"></calcite-action>
+        </calcite-action-group>
+        <calcite-action-group>
+          <calcite-action text="Basemaps" icon="layer-basemap"></calcite-action>
+          <calcite-action text="Measure" icon="measure"></calcite-action>
+          <calcite-action text="Share" icon="share"></calcite-action>
+        </calcite-action-group>
+        <calcite-action-group slot="actions-end">
+          <calcite-action text="Settings" icon="gear"></calcite-action>
+        </calcite-action-group>
+      </calcite-action-bar>
+    </div>
+    <calcite-action-bar layout="vertical" overflow-mode="wrap" style="height: 260px;">
+      <calcite-action-group slot="actions-start">
+        <calcite-action text="Home" icon="home"></calcite-action>
+        <calcite-action text="Locate" icon="compass"></calcite-action>
+      </calcite-action-group>
+      <calcite-action-group>
+        <calcite-action text="Add" icon="plus"></calcite-action>
+        <calcite-action text="Save" icon="save"></calcite-action>
+        <calcite-action text="Layers" icon="layers"></calcite-action>
+      </calcite-action-group>
+      <calcite-action-group>
+        <calcite-action text="Basemaps" icon="layer-basemap"></calcite-action>
+        <calcite-action text="Measure" icon="measure"></calcite-action>
+        <calcite-action text="Share" icon="share"></calcite-action>
+      </calcite-action-group>
+      <calcite-action-group slot="actions-end">
+        <calcite-action text="Settings" icon="gear"></calcite-action>
+      </calcite-action-group>
+    </calcite-action-bar>
+  </div>`;
+
 export const darkModeRTL = (): string => html`
   <calcite-action-bar position="start" dir="rtl" class="calcite-mode-dark">
     <calcite-action-group>


### PR DESCRIPTION
**Related Issue:** #11000 

## Summary

Follow up to PR #14799
- When `overflow-mode="wrap"`, hides leading border when groups are slotted in `actions-start`.
- Adds story.
