### PR TITLE
test(action-bar): await slotted group trigger clicks in slot-change tests

### DIFF
--- a/packages/components/src/components/action-bar/action-bar.browser.e2e.tsx
+++ b/packages/components/src/components/action-bar/action-bar.browser.e2e.tsx
@@ -1320,12 +1320,8 @@ describe("slot-change action tracking", () => {
       </calcite-action-bar>,
     );
 
-    const defaultGroup = page
-      .getBySelector("calcite-action-group#default-group")
-      .element() as ActionGroup["el"];
-    const startGroup = page
-      .getBySelector("calcite-action-group#start-group[slot='actions-start']")
-      .element() as ActionGroup["el"];
+    const defaultGroup = page.getBySelector("calcite-action-group#default-group");
+    const startGroup = page.getBySelector("calcite-action-group#start-group[slot='actions-start']");
     const defaultTrigger = page.getBySelector(
       "calcite-action-group#default-group calcite-action[slot='trigger']",
     );
@@ -1337,11 +1333,11 @@ describe("slot-change action tracking", () => {
     await expect.element(startTrigger).toBeVisible();
 
     await defaultTrigger.click();
-    await expect.poll(() => defaultGroup.menuOpen).toBe(true);
+    await expect.element(defaultGroup).toHaveProperty("menuOpen", true);
 
     await startTrigger.click();
-    await expect.poll(() => startGroup.menuOpen).toBe(true);
-    await expect.poll(() => defaultGroup.menuOpen).toBe(false);
+    await expect.element(startGroup).toHaveProperty("menuOpen", true);
+    await expect.element(defaultGroup).toHaveProperty("menuOpen", false);
   });
 
   it("closes default-slot group menu when a slotted actions-end group menu opens", async () => {
@@ -1358,12 +1354,8 @@ describe("slot-change action tracking", () => {
       </calcite-action-bar>,
     );
 
-    const defaultGroup = page
-      .getBySelector("calcite-action-group#default-group")
-      .element() as ActionGroup["el"];
-    const endGroup = page
-      .getBySelector("calcite-action-group#end-group[slot='actions-end']")
-      .element() as ActionGroup["el"];
+    const defaultGroup = page.getBySelector("calcite-action-group#default-group");
+    const endGroup = page.getBySelector("calcite-action-group#end-group[slot='actions-end']");
     const defaultTrigger = page.getBySelector(
       "calcite-action-group#default-group calcite-action[slot='trigger']",
     );
@@ -1375,11 +1367,11 @@ describe("slot-change action tracking", () => {
     await expect.element(endTrigger).toBeVisible();
 
     await defaultTrigger.click();
-    await expect.poll(() => defaultGroup.menuOpen).toBe(true);
+    await expect.element(defaultGroup).toHaveProperty("menuOpen", true);
 
     await endTrigger.click();
-    await expect.poll(() => endGroup.menuOpen).toBe(true);
-    await expect.poll(() => defaultGroup.menuOpen).toBe(false);
+    await expect.element(endGroup).toHaveProperty("menuOpen", true);
+    await expect.element(defaultGroup).toHaveProperty("menuOpen", false);
   });
 
   it("closes other direct action-menus when one opens", async () => {

--- a/packages/components/src/components/action-bar/action-bar.browser.e2e.tsx
+++ b/packages/components/src/components/action-bar/action-bar.browser.e2e.tsx
@@ -1308,7 +1308,7 @@ describe("slot-change action tracking", () => {
 
   it("closes default-slot group menu when a slotted actions-start group menu opens", async () => {
     await mount<ActionBar>(
-      <calcite-action-bar>
+      <calcite-action-bar layout="horizontal" overflow-actions-disabled>
         <calcite-action-group id="default-group">
           <calcite-action icon="plus" text="Default" />
           <calcite-action icon="save" slot="menu-actions" text="Save" />
@@ -1326,24 +1326,27 @@ describe("slot-change action tracking", () => {
     const startGroup = page
       .getBySelector("calcite-action-group#start-group[slot='actions-start']")
       .element() as ActionGroup["el"];
-    const defaultTrigger = page
-      .getBySelector("calcite-action-group#default-group calcite-action[slot='trigger']")
-      .element() as Action["el"];
-    const startTrigger = page
-      .getBySelector("calcite-action-group#start-group calcite-action[slot='trigger']")
-      .element() as Action["el"];
+    const defaultTrigger = page.getBySelector(
+      "calcite-action-group#default-group calcite-action[slot='trigger']",
+    );
+    const startTrigger = page.getBySelector(
+      "calcite-action-group#start-group calcite-action[slot='trigger']",
+    );
 
-    await userEvent.click(defaultTrigger);
-    expect(defaultGroup.menuOpen).toBe(true);
+    await expect.element(defaultTrigger).toBeVisible();
+    await expect.element(startTrigger).toBeVisible();
 
-    await userEvent.click(startTrigger);
-    expect(startGroup.menuOpen).toBe(true);
-    expect(defaultGroup.menuOpen).toBe(false);
+    await defaultTrigger.click();
+    await expect.poll(() => defaultGroup.menuOpen).toBe(true);
+
+    await startTrigger.click();
+    await expect.poll(() => startGroup.menuOpen).toBe(true);
+    await expect.poll(() => defaultGroup.menuOpen).toBe(false);
   });
 
   it("closes default-slot group menu when a slotted actions-end group menu opens", async () => {
     await mount<ActionBar>(
-      <calcite-action-bar layout="horizontal">
+      <calcite-action-bar layout="horizontal" overflow-actions-disabled>
         <calcite-action-group id="default-group">
           <calcite-action icon="plus" text="Default" />
           <calcite-action icon="save" slot="menu-actions" text="Save" />
@@ -1361,19 +1364,22 @@ describe("slot-change action tracking", () => {
     const endGroup = page
       .getBySelector("calcite-action-group#end-group[slot='actions-end']")
       .element() as ActionGroup["el"];
-    const defaultTrigger = page
-      .getBySelector("calcite-action-group#default-group calcite-action[slot='trigger']")
-      .element() as Action["el"];
-    const endTrigger = page
-      .getBySelector("calcite-action-group#end-group calcite-action[slot='trigger']")
-      .element() as Action["el"];
+    const defaultTrigger = page.getBySelector(
+      "calcite-action-group#default-group calcite-action[slot='trigger']",
+    );
+    const endTrigger = page.getBySelector(
+      "calcite-action-group#end-group calcite-action[slot='trigger']",
+    );
 
-    await userEvent.click(defaultTrigger);
-    expect(defaultGroup.menuOpen).toBe(true);
+    await expect.element(defaultTrigger).toBeVisible();
+    await expect.element(endTrigger).toBeVisible();
 
-    await userEvent.click(endTrigger);
-    expect(endGroup.menuOpen).toBe(true);
-    expect(defaultGroup.menuOpen).toBe(false);
+    await defaultTrigger.click();
+    await expect.poll(() => defaultGroup.menuOpen).toBe(true);
+
+    await endTrigger.click();
+    await expect.poll(() => endGroup.menuOpen).toBe(true);
+    await expect.poll(() => defaultGroup.menuOpen).toBe(false);
   });
 
   it("closes other direct action-menus when one opens", async () => {

--- a/packages/components/src/components/action-bar/action-bar.browser.e2e.tsx
+++ b/packages/components/src/components/action-bar/action-bar.browser.e2e.tsx
@@ -1336,7 +1336,7 @@ describe("slot-change action tracking", () => {
     await userEvent.click(defaultTrigger);
     expect(defaultGroup.menuOpen).toBe(true);
 
-    startTrigger.click();
+    await userEvent.click(startTrigger);
     expect(startGroup.menuOpen).toBe(true);
     expect(defaultGroup.menuOpen).toBe(false);
   });
@@ -1371,7 +1371,7 @@ describe("slot-change action tracking", () => {
     await userEvent.click(defaultTrigger);
     expect(defaultGroup.menuOpen).toBe(true);
 
-    endTrigger.click();
+    await userEvent.click(endTrigger);
     expect(endGroup.menuOpen).toBe(true);
     expect(defaultGroup.menuOpen).toBe(false);
   });


### PR DESCRIPTION
**Related Issue:** N/A

## Summary
This PR hardens two flaky Action Bar browser tests under the slot-change action tracking suite:

- closes default-slot group menu when a slotted actions-start group menu opens
- closes default-slot group menu when a slotted actions-end group menu opens

The tests now:
- run with `layout="horizontal"` and `overflow-actions-disabled` to reduce layout/overflow-driven variability
- use locator-based trigger interactions instead of relying on cached element handles
- assert trigger visibility before clicking
- use `expect.poll(...)` for `menuOpen` state transitions after clicks

## Why
CI intermittently timed out on trigger click (`locator.click` timeout in Chromium).  
The previous approach could still be timing-sensitive when DOM state/interaction readiness diverged between local and CI environments. These updates make interaction and assertion timing more deterministic while preserving the original behavior under test.