### PR TITLE
docs: align properties with existing `@copyDoc` definitions

### DIFF
--- a/packages/components/api-extractor.config.ts
+++ b/packages/components/api-extractor.config.ts
@@ -85,7 +85,7 @@ export const config: ApiExtractorConfig = {
           const dragDescription = (component: string): string =>
             `When \`dragEnabled\` is \`true\` and multiple ${component} sorting is enabled with \`group\`, specifies the component's name for dragging between ${component}s.`;
 
-          const descriptionOverrides = {
+          const descriptionOverrides: Record<string, string> = {
             Avatar: `Specifies alternative text when \`thumbnail\` is defined, otherwise ${baseDescription.toLowerCase()}`,
             BlockGroup: `${baseDescription}\n\n${dragDescription("group")}`,
             List: `${baseDescription}\n\n${dragDescription("list")}`,

--- a/packages/components/api-extractor.config.ts
+++ b/packages/components/api-extractor.config.ts
@@ -109,7 +109,7 @@ export const config: ApiExtractorConfig = {
         },
         name: {
           description:
-            "Specifies the name of the component. Required to pass the component's `value` on form submission.",
+            "Specifies the name of the component.\n\nRequired to pass the component's `value` on form submission.",
         },
         overlayPositioning: {
           description:

--- a/packages/components/api-extractor.config.ts
+++ b/packages/components/api-extractor.config.ts
@@ -80,8 +80,22 @@ export const config: ApiExtractorConfig = {
         iconStart: {
           description: "Specifies an icon to display at the start of the component.",
         },
-        label: {
-          description: "Specifies an accessible label for the component.",
+        label(_apiProperty, apiClass) {
+          const baseDescription = "Specifies an accessible label for the component.";
+          const dragDescription = (component: string): string =>
+            `When \`dragEnabled\` is \`true\` and multiple ${component} sorting is enabled with \`group\`, specifies the component's name for dragging between ${component}s.`;
+
+          const descriptionOverrides = {
+            Avatar: `Specifies alternative text when \`thumbnail\` is defined, otherwise ${baseDescription.toLowerCase()}`,
+            BlockGroup: `${baseDescription}\n\n${dragDescription("group")}`,
+            List: `${baseDescription}\n\n${dragDescription("list")}`,
+            ListItem: `${baseDescription.slice(0, baseDescription.length - 1)}, displays above the \`description\`.`,
+            Navigation: "When `navigationAction` is `true`, specifies an accessible label for the `calcite-action`.",
+          };
+
+          return {
+            description: descriptionOverrides[apiClass.name] ?? baseDescription,
+          };
         },
         labelText: {
           description: "Specifies the component's label text.",

--- a/packages/components/src/components/action-menu/action-menu.tsx
+++ b/packages/components/src/components/action-menu/action-menu.tsx
@@ -161,8 +161,7 @@ export class ActionMenu extends LitElement {
   @property() flipPlacements?: FlipPlacement[];
 
   /**
-   * Specifies an accessible label for the component.
-   *
+   * @copyDoc
    * @required
    */
   @property() label!: string;

--- a/packages/components/src/components/alert/alert.tsx
+++ b/packages/components/src/components/alert/alert.tsx
@@ -135,8 +135,7 @@ export class Alert extends LitElement {
   > = "brand";
 
   /**
-   * Specifies an accessible label for the component.
-   *
+   * @copyDoc
    * @required
    */
   @property() label!: string;

--- a/packages/components/src/components/autocomplete/autocomplete.tsx
+++ b/packages/components/src/components/autocomplete/autocomplete.tsx
@@ -230,9 +230,7 @@ export class Autocomplete
   @property({ reflect: true }) minLength?: number;
 
   /**
-   * Specifies the name of the component.
-   *
-   * Required to pass the component's `value` on form submission.
+   * @copyDoc
    *
    * @see [MDN - name](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#name)
    */

--- a/packages/components/src/components/autocomplete/autocomplete.tsx
+++ b/packages/components/src/components/autocomplete/autocomplete.tsx
@@ -306,7 +306,6 @@ export class Autocomplete
   /**
    * @copyDoc
    *
-   * @readonly
    * @see [MDN - ValidityState](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState)
    */
   @property({ readOnly: true }) validity!: ValidityState;

--- a/packages/components/src/components/avatar/avatar.tsx
+++ b/packages/components/src/components/avatar/avatar.tsx
@@ -30,7 +30,7 @@ export class Avatar extends LitElement {
   /** Specifies the full name of the user. When `label` and `thumbnail` are not defined, specifies the accessible name for the component. */
   @property({ reflect: true }) fullName?: string;
 
-  /** Specifies alternative text when `thumbnail` is defined, otherwise specifies an accessible label for the component. */
+  /** @copyDoc */
   @property() label?: string;
 
   /** Specifies the size of the component. */

--- a/packages/components/src/components/block-group/block-group.tsx
+++ b/packages/components/src/components/block-group/block-group.tsx
@@ -105,10 +105,7 @@ export class BlockGroup extends LitElement {
   @property({ reflect: true }) group?: string;
 
   /**
-   * Specifies an accessible label for the component.
-   *
-   * When `dragEnabled` is `true` and multiple group sorting is enabled with `group`, specifies the component's name for dragging between groups.
-   *
+   * @copyDoc
    * @required
    */
   @property() label!: string;

--- a/packages/components/src/components/card-group/card-group.tsx
+++ b/packages/components/src/components/card-group/card-group.tsx
@@ -41,8 +41,7 @@ export class CardGroup extends LitElement {
   @property({ reflect: true }) disabled = false;
 
   /**
-   * Specifies an accessible label for the component.
-   *
+   * @copyDoc
    * @required
    */
   @property() label!: string;

--- a/packages/components/src/components/carousel-item/carousel-item.tsx
+++ b/packages/components/src/components/carousel-item/carousel-item.tsx
@@ -26,8 +26,7 @@ export class CarouselItem extends LitElement {
   // #region Public Properties
 
   /**
-   * Specifies an accessible label for the component.
-   *
+   * @copyDoc
    * @required
    */
   @property() label!: string;

--- a/packages/components/src/components/carousel/carousel.tsx
+++ b/packages/components/src/components/carousel/carousel.tsx
@@ -139,8 +139,7 @@ export class Carousel extends LitElement {
   @property({ reflect: true }) disabled = false;
 
   /**
-   * Specifies an accessible label for the component.
-   *
+   * @copyDoc
    * @required
    */
   @property() label!: string;

--- a/packages/components/src/components/checkbox/checkbox.tsx
+++ b/packages/components/src/components/checkbox/checkbox.tsx
@@ -122,7 +122,6 @@ export class Checkbox extends LitElement implements LabelableComponent {
   /**
    * @copyDoc
    *
-   * @readonly
    * @see [MDN - ValidityState](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState)
    */
   @property({ readOnly: true }) validity!: ValidityState;

--- a/packages/components/src/components/chip-group/chip-group.tsx
+++ b/packages/components/src/components/chip-group/chip-group.tsx
@@ -43,8 +43,7 @@ export class ChipGroup extends LitElement {
   @property({ reflect: true }) disabled = false;
 
   /**
-   * Specifies an accessible label for the component.
-   *
+   * @copyDoc
    * @required
    */
   @property() label!: string;

--- a/packages/components/src/components/chip/chip.tsx
+++ b/packages/components/src/components/chip/chip.tsx
@@ -97,8 +97,7 @@ export class Chip extends LitElement {
   @property({ reflect: true }) kind: Extract<"brand" | "inverse" | "neutral", Kind> = "neutral";
 
   /**
-   * Specifies an accessible label for the component.
-   *
+   * @copyDoc
    * @required
    */
   @property() label!: string;

--- a/packages/components/src/components/combobox-item-group/combobox-item-group.tsx
+++ b/packages/components/src/components/combobox-item-group/combobox-item-group.tsx
@@ -39,8 +39,7 @@ export class ComboboxItemGroup extends LitElement {
   @property() ancestors?: ComboboxChildElement[];
 
   /**
-   * Specifies an accessible label for the component.
-   *
+   * @copyDoc
    * @required
    */
   @property() label!: string;

--- a/packages/components/src/components/combobox/combobox.tsx
+++ b/packages/components/src/components/combobox/combobox.tsx
@@ -508,7 +508,6 @@ export class Combobox extends LitElement implements LabelableComponent, Floating
   /**
    * @copyDoc
    *
-   * @readonly
    * @see [MDN - ValidityState](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState)
    */
   @property({ readOnly: true }) validity!: ValidityState;

--- a/packages/components/src/components/combobox/combobox.tsx
+++ b/packages/components/src/components/combobox/combobox.tsx
@@ -388,8 +388,7 @@ export class Combobox extends LitElement implements LabelableComponent, Floating
   @property({ reflect: true }) form?: string;
 
   /**
-   * Specifies an accessible label for the component.
-   *
+   * @copyDoc
    * @required
    */
   @property() label!: string;

--- a/packages/components/src/components/dialog/dialog.tsx
+++ b/packages/components/src/components/dialog/dialog.tsx
@@ -160,7 +160,7 @@ export class Dialog extends LitElement implements OpenCloseComponentWithEl {
   /** When `true`, disables the component's close button. */
   @property({ reflect: true }) closeDisabled = false;
 
-  /** Specifies the component's description. */
+  /** @copyDoc */
   @property() description?: string;
 
   /** When `true`, the component is draggable. */

--- a/packages/components/src/components/handle/handle.tsx
+++ b/packages/components/src/components/handle/handle.tsx
@@ -59,7 +59,7 @@ export class Handle extends LitElement {
   @property({ reflect: true }) dragHandle?: string;
 
   /**
-   *
+   * @copyDoc
    * @private
    */
   @property() label?: string;

--- a/packages/components/src/components/input-date-picker/input-date-picker.tsx
+++ b/packages/components/src/components/input-date-picker/input-date-picker.tsx
@@ -320,7 +320,6 @@ export class InputDatePicker extends LitElement implements FloatingUIComponent, 
   /**
    * @copyDoc
    *
-   * @readonly
    * @see [MDN - ValidityState](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState)
    */
   @property({ readOnly: true }) validity!: ValidityState;

--- a/packages/components/src/components/input-number/input-number.tsx
+++ b/packages/components/src/components/input-number/input-number.tsx
@@ -244,7 +244,7 @@ export class InputNumber
   /** When `true`, restricts the component to integer numbers only and disables exponential notation. */
   @property() integer = false;
 
-  /** Specifies an accessible label for the component's button or hyperlink. */
+  /** @copyDoc */
   @property() label?: string;
 
   /** @copyDoc */

--- a/packages/components/src/components/input-number/input-number.tsx
+++ b/packages/components/src/components/input-number/input-number.tsx
@@ -360,7 +360,6 @@ export class InputNumber
   /**
    * @copyDoc
    *
-   * @readonly
    * @see [MDN - ValidityState](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState)
    */
   @property({ readOnly: true }) validity!: ValidityState;

--- a/packages/components/src/components/input-text/input-text.tsx
+++ b/packages/components/src/components/input-text/input-text.tsx
@@ -217,7 +217,7 @@ export class InputText extends LitElement implements LabelableComponent, Textual
   /** When `true` and the element direction is right-to-left (`"rtl"`), flips the component`s `icon`. */
   @property({ reflect: true }) iconFlipRtl = false;
 
-  /** Specifies an accessible label for the component's button or hyperlink. */
+  /** @copyDoc */
   @property() label?: string;
 
   /** @copyDoc */

--- a/packages/components/src/components/input-text/input-text.tsx
+++ b/packages/components/src/components/input-text/input-text.tsx
@@ -304,7 +304,6 @@ export class InputText extends LitElement implements LabelableComponent, Textual
   /**
    * @copyDoc
    *
-   * @readonly
    * @see [MDN - ValidityState](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState)
    */
   @property({ readOnly: true }) validity!: ValidityState;

--- a/packages/components/src/components/input-text/input-text.tsx
+++ b/packages/components/src/components/input-text/input-text.tsx
@@ -246,9 +246,7 @@ export class InputText extends LitElement implements LabelableComponent, Textual
   @property({ reflect: true }) minLength?: number;
 
   /**
-   * Specifies the name of the component.
-   *
-   * Required to pass the component's `value` on form submission.
+   * @copyDoc
    *
    * @see [MDN - name](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#name)
    */

--- a/packages/components/src/components/input-time-picker/input-time-picker.tsx
+++ b/packages/components/src/components/input-time-picker/input-time-picker.tsx
@@ -214,7 +214,6 @@ export class InputTimePicker extends LitElement implements LabelableComponent, T
   /**
    * @copyDoc
    *
-   * @readonly
    * @see [MDN - ValidityState](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState)
    */
   @property({ readOnly: true }) validity!: ValidityState;

--- a/packages/components/src/components/input-time-zone/input-time-zone.tsx
+++ b/packages/components/src/components/input-time-zone/input-time-zone.tsx
@@ -200,7 +200,6 @@ export class InputTimeZone extends LitElement implements LabelableComponent {
   /**
    * @copyDoc
    *
-   * @readonly
    * @see [MDN - ValidityState](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState)
    */
   @property({ readOnly: true }) validity!: ValidityState;

--- a/packages/components/src/components/input/input.tsx
+++ b/packages/components/src/components/input/input.tsx
@@ -319,9 +319,7 @@ export class Input
   @property() multiple = false;
 
   /**
-   * Specifies the name of the component.
-   *
-   * Required to pass the component's `value` on form submission.
+   * @copyDoc
    *
    * @see [MDN - name](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#name)
    */

--- a/packages/components/src/components/input/input.tsx
+++ b/packages/components/src/components/input/input.tsx
@@ -412,7 +412,6 @@ export class Input
   /**
    * @copyDoc
    *
-   * @readonly
    * @see [MDN - ValidityState](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState)
    */
   @property({ readOnly: true }) validity!: ValidityState;

--- a/packages/components/src/components/list-item/list-item.tsx
+++ b/packages/components/src/components/list-item/list-item.tsx
@@ -172,7 +172,7 @@ export class ListItem extends LitElement implements SortableComponentItem {
    */
   @property({ reflect: true }) interactionMode?: InteractionMode;
 
-  /** Specifies an accessible label for the component, displays above the `description`. */
+  /** @copyDoc */
   @property() label?: string;
 
   /** @copyDoc */

--- a/packages/components/src/components/list/list.tsx
+++ b/packages/components/src/components/list/list.tsx
@@ -253,10 +253,7 @@ export class List extends LitElement {
   @property({ reflect: true }) interactionMode: InteractionMode = "interactive";
 
   /**
-   * Specifies an accessible label for the component.
-   *
-   * When `dragEnabled` is `true` and multiple list sorting is enabled with `group`, specifies the component's name for dragging between lists.
-   *
+   * @copyDoc
    * @required
    */
   @property() label!: string;

--- a/packages/components/src/components/loader/loader.tsx
+++ b/packages/components/src/components/loader/loader.tsx
@@ -40,8 +40,7 @@ export class Loader extends LitElement {
   @property({ reflect: true }) inline = false;
 
   /**
-   * Specifies an accessible label for the component.
-   *
+   * @copyDoc
    * @required
    */
   @property() label!: string;

--- a/packages/components/src/components/menu-item/menu-item.tsx
+++ b/packages/components/src/components/menu-item/menu-item.tsx
@@ -89,8 +89,7 @@ export class MenuItem extends LitElement {
   @property() isTopLevelItem = false;
 
   /**
-   * Specifies an accessible label for the component.
-   *
+   * @copyDoc
    * @required
    */
   @property() label!: string;

--- a/packages/components/src/components/menu/menu.tsx
+++ b/packages/components/src/components/menu/menu.tsx
@@ -45,8 +45,7 @@ export class Menu extends LitElement {
   //#region Public Properties
 
   /**
-   * Specifies an accessible label for the component.
-   *
+   * @copyDoc
    * @required
    */
   @property() label!: string;

--- a/packages/components/src/components/meter/meter.tsx
+++ b/packages/components/src/components/meter/meter.tsx
@@ -106,8 +106,7 @@ export class Meter extends LitElement {
   @property({ reflect: true }) high?: number;
 
   /**
-   * Specifies an accessible label for the component.
-   *
+   * @copyDoc
    * @required
    */
   @property() label!: string;

--- a/packages/components/src/components/navigation/navigation.tsx
+++ b/packages/components/src/components/navigation/navigation.tsx
@@ -82,7 +82,7 @@ export class Navigation extends LitElement {
 
   // #region Public Properties
 
-  /** When `navigationAction` is `true`, specifies an accessible label for the `calcite-action`. */
+  /** @copyDoc */
   @property() label?: string;
 
   /** When `true`, displays a `calcite-action` and emits a `calciteNavActionSelect` event on selection change. */

--- a/packages/components/src/components/option-group/option-group.tsx
+++ b/packages/components/src/components/option-group/option-group.tsx
@@ -17,8 +17,7 @@ export class OptionGroup extends LitElement {
   disabled = false;
 
   /**
-   * Specifies an accessible label for the component.
-   *
+   * @copyDoc
    * @required
    */
   @property() label!: string;

--- a/packages/components/src/components/popover/popover.tsx
+++ b/packages/components/src/components/popover/popover.tsx
@@ -148,8 +148,7 @@ export class Popover extends LitElement implements FloatingUIComponent, Referenc
   @property({ type: Number, reflect: true }) headingLevel?: HeadingLevel;
 
   /**
-   * Specifies an accessible label for the component.
-   *
+   * @copyDoc
    * @required
    */
   @property() label!: string;

--- a/packages/components/src/components/radio-button/radio-button.tsx
+++ b/packages/components/src/components/radio-button/radio-button.tsx
@@ -113,7 +113,6 @@ export class RadioButton extends LitElement implements LabelableComponent {
    * @copyDoc
    *
    * @internal
-   * @readonly
    * @mdn [ValidityState](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState)
    */
   @property({ readOnly: true }) validity!: ValidityState;

--- a/packages/components/src/components/radio-button/radio-button.tsx
+++ b/packages/components/src/components/radio-button/radio-button.tsx
@@ -79,8 +79,7 @@ export class RadioButton extends LitElement implements LabelableComponent {
   @property({ reflect: true }) hovered = false;
 
   /**
-   * Accessible name for the component.
-   *
+   * @copyDoc
    * @private
    */
   @property() label?: string;

--- a/packages/components/src/components/rating/rating.tsx
+++ b/packages/components/src/components/rating/rating.tsx
@@ -146,7 +146,6 @@ export class Rating extends LitElement implements LabelableComponent {
   /**
    * @copyDoc
    *
-   * @readonly
    * @see [MDN - ValidityState](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState)
    */
   @property({ readOnly: true }) validity!: ValidityState;

--- a/packages/components/src/components/segmented-control/segmented-control.tsx
+++ b/packages/components/src/components/segmented-control/segmented-control.tsx
@@ -130,7 +130,6 @@ export class SegmentedControl extends LitElement implements LabelableComponent {
   /**
    * @copyDoc
    *
-   * @readonly
    * @see [MDN - ValidityState](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState)
    */
   @property({ readOnly: true }) validity!: ValidityState;

--- a/packages/components/src/components/select/select.tsx
+++ b/packages/components/src/components/select/select.tsx
@@ -137,7 +137,6 @@ export class Select extends LitElement implements LabelableComponent {
   /**
    * @copyDoc
    *
-   * @readonly
    * @see [MDN - ValidityState](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState)
    */
   @property({ readOnly: true }) validity!: ValidityState;

--- a/packages/components/src/components/select/select.tsx
+++ b/packages/components/src/components/select/select.tsx
@@ -96,8 +96,7 @@ export class Select extends LitElement implements LabelableComponent {
   @property({ reflect: true }) form?: string;
 
   /**
-   * Specifies an accessible label for the component.
-   *
+   * @copyDoc
    * @required
    */
   @property() label!: string;

--- a/packages/components/src/components/sheet/sheet.tsx
+++ b/packages/components/src/components/sheet/sheet.tsx
@@ -187,8 +187,7 @@ export class Sheet extends LitElement {
   @property({ reflect: true }) height?: Height;
 
   /**
-   * Specifies an accessible label for the component.
-   *
+   * @copyDoc
    * @required
    */
   @property() label!: string;

--- a/packages/components/src/components/slider/slider.tsx
+++ b/packages/components/src/components/slider/slider.tsx
@@ -284,9 +284,7 @@ export class Slider extends LitElement implements LabelableComponent {
   @property({ reflect: true }) mirrored = false;
 
   /**
-   * Specifies the name of the component.
-   *
-   * Required to pass the component's `value` on form submission
+   * @copyDoc
    */
   @property({ reflect: true }) name?: string;
 

--- a/packages/components/src/components/slider/slider.tsx
+++ b/packages/components/src/components/slider/slider.tsx
@@ -329,7 +329,6 @@ export class Slider extends LitElement implements LabelableComponent {
   /**
    * @copyDoc
    *
-   * @readonly
    * @see [MDN - ValidityState](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState)
    */
   @property({ readOnly: true }) validity!: ValidityState;

--- a/packages/components/src/components/swatch-group/swatch-group.tsx
+++ b/packages/components/src/components/swatch-group/swatch-group.tsx
@@ -40,8 +40,7 @@ export class SwatchGroup extends LitElement {
   @property({ reflect: true }) disabled = false;
 
   /**
-   * Specifies an accessible label for the component.
-   *
+   * @copyDoc
    * @required
    */
   @property() label!: string;

--- a/packages/components/src/components/swatch/swatch.tsx
+++ b/packages/components/src/components/swatch/swatch.tsx
@@ -75,8 +75,7 @@ export class Swatch extends LitElement {
   @property() interactive = false;
 
   /**
-   * Specifies an accessible label for the component.
-   *
+   * @copyDoc
    * @required
    */
   @property() label!: string;

--- a/packages/components/src/components/switch/switch.tsx
+++ b/packages/components/src/components/switch/switch.tsx
@@ -84,7 +84,6 @@ export class Switch extends LitElement implements LabelableComponent {
   /**
    * @copyDoc
    *
-   * @readonly
    * @see [MDN - ValidityState](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState)
    */
   @property({ readOnly: true }) validity!: ValidityState;

--- a/packages/components/src/components/text-area/text-area.tsx
+++ b/packages/components/src/components/text-area/text-area.tsx
@@ -259,7 +259,6 @@ export class TextArea
   /**
    * @copyDoc
    *
-   * @readonly
    * @see [MDN - ValidityState](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState)
    */
   @property({ readOnly: true }) validity!: ValidityState;

--- a/packages/components/src/components/text-area/text-area.tsx
+++ b/packages/components/src/components/text-area/text-area.tsx
@@ -201,7 +201,7 @@ export class TextArea
   @property({ reflect: true }) minLength?: number;
 
   /**
-   * Specifies the name of the component. Required to pass the component's value on form submission.
+   * @copyDoc
    *
    * @see [MDN - name](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-name)
    */

--- a/packages/components/src/components/tile-group/tile-group.tsx
+++ b/packages/components/src/components/tile-group/tile-group.tsx
@@ -44,8 +44,7 @@ export class TileGroup extends LitElement implements SelectableGroupComponent {
   @property({ reflect: true }) disabled = false;
 
   /**
-   * Specifies an accessible label for the component.
-   *
+   * @copyDoc
    * @required
    */
   @property() label!: string;

--- a/packages/components/src/components/tooltip/tooltip.tsx
+++ b/packages/components/src/components/tooltip/tooltip.tsx
@@ -81,8 +81,7 @@ export class Tooltip extends LitElement implements FloatingUIComponent, Referenc
   @property({ reflect: true }) closeOnClick = false;
 
   /**
-   * Specifies an accessible label for the component.
-   *
+   * @copyDoc
    * @deprecated in v1.5.0, removal target v6.0.0 - No longer necessary. Overrides the context of the component's text description, which could confuse assistive technology users.
    */
   @property() label?: string;


### PR DESCRIPTION
**Related Issue:** #14350

## Summary

During verification of #14293, multiple instances were found where existing `@copyDoc` definitions should be used. This PR updates those properties to use `@copyDoc`. 

Properties affected:
- `description`
- `label` - updating existing and added overrides
- `name`
- `validity` - removed the `@readonly` tag since it is not needed. The API extractor infers readonly from the `@property({ readOnly: true })` decorator. cc @jcfranco 
