### PR TITLE
fix(input-time-picker): ensure time part input placement aligns with page direction

### DIFF
--- a/packages/components/src/components/input-time-picker/input-time-picker.scss
+++ b/packages/components/src/components/input-time-picker/input-time-picker.scss
@@ -95,7 +95,6 @@ calcite-time-picker {
 
 .content-container {
   display: grid;
-  flex-grow: 1;
   .input-container,
   .placeholder {
     grid-column: 1;
@@ -160,11 +159,10 @@ calcite-time-picker {
     var(--calcite-input-time-picker-input-action-icon-color, var(--calcite-color-text-3))
   );
   align-items: center;
-  block-size: 100%;
   cursor: pointer;
   display: flex;
   justify-content: center;
-  margin-inline-end: calc(var(--calcite-internal-input-time-picker-toggle-inline-end-offset) * -1);
+  margin-inline: auto calc(var(--calcite-internal-input-time-picker-toggle-inline-end-offset) * -1);
   padding-inline: var(--calcite-internal-input-time-picker-toggle-spacing);
   padding-inline-start: var(--calcite-space-none);
 

--- a/packages/components/src/components/input-time-picker/input-time-picker.scss
+++ b/packages/components/src/components/input-time-picker/input-time-picker.scss
@@ -95,6 +95,8 @@ calcite-time-picker {
 
 .content-container {
   display: grid;
+  flex-grow: 1;
+  justify-content: start;
   .input-container,
   .placeholder {
     grid-column: 1;
@@ -163,7 +165,7 @@ calcite-time-picker {
   cursor: pointer;
   display: flex;
   justify-content: center;
-  margin-inline: auto calc(var(--calcite-internal-input-time-picker-toggle-inline-end-offset) * -1);
+  margin-inline-end: calc(var(--calcite-internal-input-time-picker-toggle-inline-end-offset) * -1);
   padding-inline: var(--calcite-internal-input-time-picker-toggle-spacing);
   padding-inline-start: var(--calcite-space-none);
 

--- a/packages/components/src/components/input-time-picker/input-time-picker.scss
+++ b/packages/components/src/components/input-time-picker/input-time-picker.scss
@@ -159,6 +159,7 @@ calcite-time-picker {
     var(--calcite-input-time-picker-input-action-icon-color, var(--calcite-color-text-3))
   );
   align-items: center;
+  block-size: 100%;
   cursor: pointer;
   display: flex;
   justify-content: center;

--- a/packages/components/src/components/input-time-picker/input-time-picker.stories.ts
+++ b/packages/components/src/components/input-time-picker/input-time-picker.stories.ts
@@ -275,3 +275,14 @@ Focus.parameters = {
 export const clearable = (): string => html`
   <calcite-input-time-picker clearable value="10:37"></calcite-input-time-picker>
 `;
+
+export const timePartsAlignedInBothDirectionsWhenWide = (): string => html`
+  <style>
+    calcite-input-time-picker {
+      width: 300px;
+    }
+  </style>
+  <calcite-input-time-picker value="22:37"></calcite-input-time-picker>
+  <br />
+  <calcite-input-time-picker dir="rtl" lang="ar" numbering-system="arab" value="22:37"></calcite-input-time-picker>
+`;


### PR DESCRIPTION
**Related Issue:** #13135

## Summary

Updates layout to ensure time parts are placed according to `dir`.