### PR TITLE
refactor: remove obsolete `hidden-form-input` mixin

### DIFF
--- a/packages/components/src/components/autocomplete/autocomplete.scss
+++ b/packages/components/src/components/autocomplete/autocomplete.scss
@@ -123,5 +123,4 @@
 
 @include includes.form-internal-label();
 @include includes.form-validation-message();
-@include includes.hidden-form-input();
 @include includes.base-component();

--- a/packages/components/src/components/checkbox/checkbox.scss
+++ b/packages/components/src/components/checkbox/checkbox.scss
@@ -150,5 +150,4 @@
 
 @include includes.form-internal-label();
 @include includes.disabled();
-@include includes.hidden-form-input();
 @include includes.base-component();

--- a/packages/components/src/components/combobox/combobox.scss
+++ b/packages/components/src/components/combobox/combobox.scss
@@ -284,7 +284,6 @@ calcite-chip {
 @include includes.disabled();
 @include includes.clear-button();
 @include includes.form-validation-message();
-@include includes.hidden-form-input();
 @include includes.base-component();
 @include includes.text-highlight-item();
 @include includes.form-internal-label();

--- a/packages/components/src/components/input-date-picker/input-date-picker.scss
+++ b/packages/components/src/components/input-date-picker/input-date-picker.scss
@@ -460,7 +460,6 @@ calcite-date-picker {
 }
 
 @include includes.form-validation-message();
-@include includes.hidden-form-input();
 @include includes.form-internal-label();
 @include includes.base-component();
 @include includes.clear-button(

--- a/packages/components/src/components/input-number/input-number.scss
+++ b/packages/components/src/components/input-number/input-number.scss
@@ -640,7 +640,6 @@ input {
 
 @include includes.form-internal-label();
 @include includes.form-validation-message();
-@include includes.hidden-form-input();
 @include includes.base-component();
 @include includes.input-placeholder-text("--calcite-input-number-placeholder-text-color");
 @include includes.clear-button(

--- a/packages/components/src/components/input-text/input-text.scss
+++ b/packages/components/src/components/input-text/input-text.scss
@@ -490,7 +490,6 @@ input {
 
 @include includes.form-internal-label();
 @include includes.form-validation-message();
-@include includes.hidden-form-input();
 @include includes.base-component();
 @include includes.input-placeholder-text("--calcite-input-text-placeholder-text-color");
 @include includes.clear-button(

--- a/packages/components/src/components/input-time-picker/input-time-picker.scss
+++ b/packages/components/src/components/input-time-picker/input-time-picker.scss
@@ -47,7 +47,6 @@
 }
 
 @include includes.disabled();
-@include includes.hidden-form-input();
 
 @function get-trailing-text-input-padding($chevron-spacing) {
   @return calc(var(--calcite-toggle-spacing) + $chevron-spacing);

--- a/packages/components/src/components/input-time-zone/input-time-zone.scss
+++ b/packages/components/src/components/input-time-zone/input-time-zone.scss
@@ -19,4 +19,3 @@
 
 @include includes.base-component();
 @include includes.disabled();
-@include includes.hidden-form-input();

--- a/packages/components/src/components/input/input.scss
+++ b/packages/components/src/components/input/input.scss
@@ -720,7 +720,6 @@ input {
 
 @include includes.form-internal-label();
 @include includes.form-validation-message();
-@include includes.hidden-form-input();
 @include includes.base-component();
 @include includes.input-placeholder-text();
 @include includes.clear-button(

--- a/packages/components/src/components/radio-button/radio-button.scss
+++ b/packages/components/src/components/radio-button/radio-button.scss
@@ -150,5 +150,4 @@
 }
 
 @include includes.form-internal-label();
-@include includes.hidden-form-input();
 @include includes.base-component();

--- a/packages/components/src/components/rating/rating.scss
+++ b/packages/components/src/components/rating/rating.scss
@@ -121,5 +121,4 @@ calcite-chip {
 
 @include includes.form-internal-label();
 @include includes.form-validation-message();
-@include includes.hidden-form-input();
 @include includes.base-component();

--- a/packages/components/src/components/segmented-control/segmented-control.scss
+++ b/packages/components/src/components/segmented-control/segmented-control.scss
@@ -49,5 +49,4 @@
 
 @include includes.form-internal-label();
 @include includes.form-validation-message();
-@include includes.hidden-form-input();
 @include includes.base-component();

--- a/packages/components/src/components/select/select.scss
+++ b/packages/components/src/components/select/select.scss
@@ -144,5 +144,4 @@ select:disabled {
 
 @include includes.form-internal-label();
 @include includes.form-validation-message();
-@include includes.hidden-form-input();
 @include includes.base-component();

--- a/packages/components/src/components/slider/slider.scss
+++ b/packages/components/src/components/slider/slider.scss
@@ -404,5 +404,4 @@
 
 @include includes.form-internal-label();
 @include includes.form-validation-message();
-@include includes.hidden-form-input();
 @include includes.base-component();

--- a/packages/components/src/components/switch/switch.scss
+++ b/packages/components/src/components/switch/switch.scss
@@ -127,5 +127,4 @@
 }
 
 @include includes.form-internal-label();
-@include includes.hidden-form-input();
 @include includes.base-component();

--- a/packages/components/src/components/text-area/text-area.scss
+++ b/packages/components/src/components/text-area/text-area.scss
@@ -262,7 +262,6 @@
 
 @include includes.form-internal-label();
 @include includes.form-validation-message();
-@include includes.hidden-form-input();
 @include includes.disabled();
 @include includes.base-component();
 @include includes.input-placeholder-text("--calcite-text-area-placeholder-text-color");

--- a/packages/components/src/styles/includes/index.scss
+++ b/packages/components/src/styles/includes/index.scss
@@ -23,21 +23,6 @@
   word-break: break-word;
 }
 
-// mixin to hide inputs from form-associated components
-@mixin hidden-form-input() {
-  ::slotted(input[slot="hidden-form-input"]) {
-    margin: 0 !important;
-    opacity: 0 !important;
-    outline: none !important;
-    padding: 0 !important;
-    position: absolute !important;
-    inset: 0 !important;
-    transform: none !important;
-    -webkit-appearance: none !important;
-    z-index: -1 !important;
-  }
-}
-
 // mixin for the container of label displayed with form-associated components
 @mixin form-internal-label() {
   .internal-label-alignment--center {


### PR DESCRIPTION
**monday.com sync:** #12687481387

**Related Issue:** N/A

## Summary

This mixin is no longer necessary after https://github.com/Esri/calcite-design-system/issues/8126.