### PR TITLE
build: add `tabbable` dep explicitly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30125,6 +30125,7 @@
         "interactjs": "^1.10.27",
         "lit": "^3.3.0",
         "sortablejs": "^1.15.6",
+        "tabbable": "6.5.0",
         "timezone-groups": "^0.10.4",
         "type-fest": "^4.30.1"
       },

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -86,6 +86,7 @@
     "interactjs": "^1.10.27",
     "lit": "^3.3.0",
     "sortablejs": "^1.15.6",
+    "tabbable": "6.5.0",
     "timezone-groups": "^0.10.4",
     "type-fest": "^4.30.1"
   },


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Fixes `tabbable` being used as a ghost dep (see [example](https://github.com/Esri/calcite-design-system/blob/126a444463d24a66f10b78ffa9d0a8b831b42117/packages/components/src/utils/dom.ts#L1)). 👻