### PR TITLE
ci(actions): fix unblocked label removal Monday sync

### DIFF
--- a/.github/scripts/addUnblockedComment.js
+++ b/.github/scripts/addUnblockedComment.js
@@ -88,7 +88,7 @@ module.exports = async ({ github, context, core }) => {
           workflow_id: "issue-monday-sync.yml",
           ref: "dev",
           inputs: {
-            issue_number: issue_number,
+            issue_number: blockedIssueNumber.toString(),
             event_type: "SyncActionChanges",
             label_name: blocked,
             label_action: "removed",

--- a/.github/workflows/issue-monday-sync.yml
+++ b/.github/workflows/issue-monday-sync.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       issue_number:
-        type: number
+        type: string
         description: "The target issue number for syncing changes."
         required: true
       event_type:


### PR DESCRIPTION
**Related Issue:** n/a

## Summary

Noticed that the `blocked` label was not being removed in Monday.com when from unblocked issues. The workflow dispatch was [erroring due to invalid input for the `issue_number` input](https://github.com/Esri/calcite-design-system/actions/runs/30571747754/job/90969925648). The number needs to be a string, and in fixing found that it should be the `blockedIssueNumber` var instead of the `issue_number` of the closed issue.

Corrects the variable used, casts to a string, and fixes the `issue_number` input type in the Monday workflow to `string` to accurately represent the needed type.
