### PR TITLE
fix(action): avoid double screen reader label

### DIFF
--- a/packages/components/src/components/action/action.browser.e2e.tsx
+++ b/packages/components/src/components/action/action.browser.e2e.tsx
@@ -18,6 +18,10 @@ import { page } from "vitest/browser";
 
 describe("accessible", () => {
   accessible(() => mount(<calcite-action text="hello world" />));
+
+  describe("text-enabled", () => {
+    accessible(() => mount(<calcite-action text="hello world" text-enabled />));
+  });
 });
 
 describe("defaults", () => {
@@ -632,4 +636,10 @@ describe("themed", () => {
       },
     });
   });
+});
+
+it("sets single label when text is enabled", async () => {
+  await mount(<calcite-action text="hello world" text-enabled />);
+
+  await expect.element(page.getByRole("button")).toHaveAccessibleName("hello world");
 });

--- a/packages/components/src/components/action/action.tsx
+++ b/packages/components/src/components/action/action.tsx
@@ -253,7 +253,7 @@ export class Action extends LitElement {
     };
 
     return text ? (
-      <div class={textContainerClasses} key="text-container">
+      <div ariaHidden="true" class={textContainerClasses} key="text-container">
         {text}
       </div>
     ) : null;


### PR DESCRIPTION
**Related Issue:** #14825 

## Summary

Fixes regression from https://github.com/Esri/calcite-design-system/pull/14690 where the action text will be included twice in the component's accessible name.