### PR TITLE
fix(icon): ensure icon names match documented names

### DIFF
--- a/packages/components/src/components/alert/alert.browser.e2e.tsx
+++ b/packages/components/src/components/alert/alert.browser.e2e.tsx
@@ -295,7 +295,7 @@ describe("dismiss progress color", () => {
         {override ? (
           <style>{`:root { --calcite-color-transparent-tint: ${override}; }`}</style>
         ) : null}
-        <calcite-alert autoClose autoCloseDuration="slow" icon="i2DExplore" kind="danger" open>
+        <calcite-alert autoClose autoCloseDuration="slow" icon="2d-explore" kind="danger" open>
           <div slot="message">Successfully duplicated a layer</div>
         </calcite-alert>
       </div>,

--- a/packages/components/src/components/icon/interfaces.ts
+++ b/packages/components/src/components/icon/interfaces.ts
@@ -1,7 +1,7 @@
-import type iconData from "@esri/calcite-ui-icons/docs/icons.json";
 import type { CamelCase } from "type-fest";
+type iconsDocData = typeof import("@esri/calcite-ui-icons/docs/icons.json");
 
-type KebabCaseIcons = keyof typeof iconData.icons;
+type KebabCaseIcons = keyof iconsDocData["icons"];
 type CamelCaseIcons = CamelCase<KebabCaseIcons>;
 
 export type IconName = KebabCaseIcons | CamelCaseIcons;

--- a/packages/components/src/components/icon/interfaces.ts
+++ b/packages/components/src/components/icon/interfaces.ts
@@ -1,15 +1,7 @@
-import * as icons from "@esri/calcite-ui-icons";
-import { KebabCase } from "type-fest";
+import type iconData from "@esri/calcite-ui-icons/docs/icons.json";
+import type { CamelCase } from "type-fest";
 
-type ExtractBaseIcon<T> = T extends `${infer Base}${"16" | "24" | "32"}F`
-  ? `${Base}F`
-  : T extends `${infer Base}F`
-    ? `${Base}F`
-    : T extends `${infer Base}${"16" | "24" | "32"}`
-      ? Base
-      : never;
-
-type CamelCaseIcons = ExtractBaseIcon<keyof typeof icons>;
-type KebabCaseIcons = KebabCase<CamelCaseIcons, { splitOnNumbers: true }>;
+type KebabCaseIcons = keyof typeof iconData.icons;
+type CamelCaseIcons = CamelCase<KebabCaseIcons>;
 
 export type IconName = KebabCaseIcons | CamelCaseIcons;

--- a/packages/components/src/components/icon/interfaces.ts
+++ b/packages/components/src/components/icon/interfaces.ts
@@ -1,7 +1,7 @@
+import iconData from "@esri/calcite-ui-icons/docs/icons.json";
 import type { CamelCase } from "type-fest";
-type iconsDocData = typeof import("@esri/calcite-ui-icons/docs/icons.json");
 
-type KebabCaseIcons = keyof iconsDocData["icons"];
+type KebabCaseIcons = keyof typeof iconData.icons;
 type CamelCaseIcons = CamelCase<KebabCaseIcons>;
 
 export type IconName = KebabCaseIcons | CamelCaseIcons;


### PR DESCRIPTION
**Related Issue:** #14777 

## Summary

Updates icon name type to generate names from the `calcite-ui-icons` docs output.